### PR TITLE
Add running scripts on connect/disconnect

### DIFF
--- a/alvr/client/src/connection.rs
+++ b/alvr/client/src/connection.rs
@@ -321,7 +321,9 @@ async fn try_connect(
                 control_sender
                     .lock()
                     .await
-                    .send(&ClientControlPacket::Reserved("{ \"keepalive\": true }".into()))
+                    .send(&ClientControlPacket::Reserved(
+                        "{ \"keepalive\": true }".into(),
+                    ))
                     .await
                     .ok();
                 time::sleep(NETWORK_KEEPALIVE_INTERVAL).await;

--- a/alvr/client/src/connection.rs
+++ b/alvr/client/src/connection.rs
@@ -318,7 +318,12 @@ async fn try_connect(
         let control_sender = control_sender.clone();
         async move {
             loop {
-                control_sender.lock().await.send(&ClientControlPacket::NetworkKeepAlive).await.ok();
+                control_sender
+                    .lock()
+                    .await
+                    .send(&ClientControlPacket::NetworkKeepAlive)
+                    .await
+                    .ok();
                 time::sleep(NETWORK_KEEPALIVE_INTERVAL).await;
             }
         }

--- a/alvr/client/src/connection.rs
+++ b/alvr/client/src/connection.rs
@@ -33,6 +33,7 @@ const SERVER_RESTART_MESSAGE: &str = "The server is restarting\nPlease wait...";
 const SERVER_DISCONNECTED_MESSAGE: &str = "The server has disconnected.";
 const RETRY_CONNECT_INTERVAL: Duration = Duration::from_millis(500);
 const PLAYSPACE_SYNC_INTERVAL: Duration = Duration::from_millis(500);
+const NETWORK_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
 // close stream on Drop (manual disconnection or execution canceling)
 struct StreamCloseGuard {
@@ -313,6 +314,16 @@ async fn try_connect(
         }
     };
 
+    let keepalive_sender_loop = {
+        let control_sender = control_sender.clone();
+        async move {
+            loop {
+                control_sender.lock().await.send(&ClientControlPacket::NetworkKeepAlive).await.ok();
+                time::sleep(NETWORK_KEEPALIVE_INTERVAL).await;
+            }
+        }
+    };
+
     let control_loop = async move {
         loop {
             tokio::select! {
@@ -332,7 +343,8 @@ async fn try_connect(
                             .await?;
                             break Ok(());
                         }
-                        Ok(ServerControlPacket::Reserved(_))
+                        Ok(ServerControlPacket::NetworkKeepAlive)
+                        | Ok(ServerControlPacket::Reserved(_))
                         | Ok(ServerControlPacket::ReservedBuffer(_)) => (),
                         Err(e) => {
                             info!("Server disconnected. Cause: {}", e);
@@ -355,6 +367,7 @@ async fn try_connect(
         res = tracking_loop => res,
         res = playspace_sync_loop => res,
         res = control_loop => res,
+        res = keepalive_sender_loop => res,
     }
 }
 

--- a/alvr/client/src/connection.rs
+++ b/alvr/client/src/connection.rs
@@ -321,7 +321,7 @@ async fn try_connect(
                 control_sender
                     .lock()
                     .await
-                    .send(&ClientControlPacket::NetworkKeepAlive)
+                    .send(&ClientControlPacket::Reserved("{ \"keepalive\": true }".into()))
                     .await
                     .ok();
                 time::sleep(NETWORK_KEEPALIVE_INTERVAL).await;
@@ -348,8 +348,7 @@ async fn try_connect(
                             .await?;
                             break Ok(());
                         }
-                        Ok(ServerControlPacket::NetworkKeepAlive)
-                        | Ok(ServerControlPacket::Reserved(_))
+                        Ok(ServerControlPacket::Reserved(_))
                         | Ok(ServerControlPacket::ReservedBuffer(_)) => (),
                         Err(e) => {
                             info!("Server disconnected. Cause: {}", e);

--- a/alvr/common/src/data/packets.rs
+++ b/alvr/common/src/data/packets.rs
@@ -65,6 +65,7 @@ pub enum ServerControlPacket {
     Restarting,
     Reserved(String),
     ReservedBuffer(Vec<u8>),
+    NetworkKeepAlive,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -82,4 +83,5 @@ pub enum ClientControlPacket {
     RequestIDR,
     Reserved(String),
     ReservedBuffer(Vec<u8>),
+    NetworkKeepAlive,
 }

--- a/alvr/common/src/data/packets.rs
+++ b/alvr/common/src/data/packets.rs
@@ -65,7 +65,6 @@ pub enum ServerControlPacket {
     Restarting,
     Reserved(String),
     ReservedBuffer(Vec<u8>),
-    NetworkKeepAlive,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -83,5 +82,4 @@ pub enum ClientControlPacket {
     RequestIDR,
     Reserved(String),
     ReservedBuffer(Vec<u8>),
-    NetworkKeepAlive,
 }

--- a/alvr/common/src/data/session.rs
+++ b/alvr/common/src/data/session.rs
@@ -59,6 +59,8 @@ pub struct OpenvrConfig {
     pub client_buffer_size: u64,
     pub force_3dof: bool,
     pub aggressive_keyframe_resend: bool,
+    pub on_connect_script: String,
+    pub on_disconnect_script: String,
     pub adapter_index: u32,
     pub codec: u32,
     pub refresh_rate: u32,

--- a/alvr/common/src/data/settings.rs
+++ b/alvr/common/src/data/settings.rs
@@ -319,6 +319,12 @@ pub struct ConnectionDesc {
     pub aggressive_keyframe_resend: bool,
 
     #[schema(advanced)]
+    pub on_connect_script: String,
+
+    #[schema(advanced)]
+    pub on_disconnect_script: String,
+
+    #[schema(advanced)]
     pub enable_fec: bool,
 }
 
@@ -478,6 +484,8 @@ pub fn session_settings_default() -> SettingsDefault {
             throttling_bitrate_bits: 30_000_000 * 3 / 2 + 2_000_000,
             client_recv_buffer_size: 60_000,
             aggressive_keyframe_resend: false,
+            on_connect_script: "".into(),
+            on_disconnect_script: "".into(),
             enable_fec: true,
         },
         extra: ExtraDescDefault {

--- a/alvr/common/src/sockets/control_socket.rs
+++ b/alvr/common/src/sockets/control_socket.rs
@@ -158,6 +158,8 @@ pub async fn connect_to_server<S: Serialize, R: DeserializeOwned>(
         pair = try_connect_loop => pair,
     };
 
+    trace_err!(socket.set_nodelay(true))?;
+
     let socket = Framed::new(socket, LDC::new());
     let (mut sender, mut receiver) = socket.split();
 
@@ -205,6 +207,9 @@ pub async fn begin_connecting_to_client(
             }
         }
     };
+
+    trace_err!(socket.set_nodelay(true))?;
+
     let client_ip = trace_err!(socket.peer_addr())?.ip();
     let socket = Framed::new(socket, LDC::new());
     let (sender, mut receiver) = socket.split();

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -3,10 +3,7 @@ use alvr_common::{data::*, logging::*, sockets::*, *};
 use nalgebra::Translation3;
 use settings_schema::Switch;
 use std::{collections::HashMap, net::IpAddr, process::Command, sync::Arc, time::Duration};
-use tokio::{
-    sync::Mutex,
-    time,
-};
+use tokio::{sync::Mutex, time};
 
 const NETWORK_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -348,7 +345,10 @@ pub async fn connection_lifecycle_loop() -> StrResult {
         log_id(LogId::ClientConnected);
         if !on_connect_script.is_empty() {
             info!("Running on connect script (connect): {}", on_connect_script);
-            if let Err(e) = Command::new(&on_connect_script).env("ACTION", "connect").spawn() {
+            if let Err(e) = Command::new(&on_connect_script)
+                .env("ACTION", "connect")
+                .spawn()
+            {
                 warn!("Failed to run connect script: {}", e);
             }
         }
@@ -362,7 +362,12 @@ pub async fn connection_lifecycle_loop() -> StrResult {
             let control_sender = control_sender.clone();
             async move {
                 loop {
-                    control_sender.lock().await.send(&ServerControlPacket::NetworkKeepAlive).await.ok();
+                    control_sender
+                        .lock()
+                        .await
+                        .send(&ServerControlPacket::NetworkKeepAlive)
+                        .await
+                        .ok();
                     time::sleep(NETWORK_KEEPALIVE_INTERVAL).await;
                 }
             }
@@ -409,8 +414,14 @@ pub async fn connection_lifecycle_loop() -> StrResult {
                             .on_disconnect_script
                             .clone();
                         if !on_disconnect_script.is_empty() {
-                            info!("Running on disconnect script (disconnect): {}", on_disconnect_script);
-                            if let Err(e) = Command::new(&on_disconnect_script).env("ACTION", "disconnect").spawn() {
+                            info!(
+                                "Running on disconnect script (disconnect): {}",
+                                on_disconnect_script
+                            );
+                            if let Err(e) = Command::new(&on_disconnect_script)
+                                .env("ACTION", "disconnect")
+                                .spawn()
+                            {
                                 warn!("Failed to run disconnect script: {}", e);
                             }
                         }

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -365,7 +365,9 @@ pub async fn connection_lifecycle_loop() -> StrResult {
                     control_sender
                         .lock()
                         .await
-                        .send(&ServerControlPacket::Reserved("{ \"keepalive\": true }".into()))
+                        .send(&ServerControlPacket::Reserved(
+                            "{ \"keepalive\": true }".into(),
+                        ))
                         .await
                         .ok();
                     time::sleep(NETWORK_KEEPALIVE_INTERVAL).await;

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -347,8 +347,8 @@ pub async fn connection_lifecycle_loop() -> StrResult {
 
         log_id(LogId::ClientConnected);
         if !on_connect_script.is_empty() {
-            info!("Running on connect script: {}", on_connect_script);
-            if let Err(e) = Command::new(&on_connect_script).spawn() {
+            info!("Running on connect script (connect): {}", on_connect_script);
+            if let Err(e) = Command::new(&on_connect_script).env("ACTION", "connect").spawn() {
                 warn!("Failed to run connect script: {}", e);
             }
         }
@@ -409,8 +409,8 @@ pub async fn connection_lifecycle_loop() -> StrResult {
                             .on_disconnect_script
                             .clone();
                         if !on_disconnect_script.is_empty() {
-                            info!("Running on disconnect script: {}", on_disconnect_script);
-                            if let Err(e) = Command::new(&on_disconnect_script).spawn() {
+                            info!("Running on disconnect script (disconnect): {}", on_disconnect_script);
+                            if let Err(e) = Command::new(&on_disconnect_script).env("ACTION", "disconnect").spawn() {
                                 warn!("Failed to run disconnect script: {}", e);
                             }
                         }

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -365,7 +365,7 @@ pub async fn connection_lifecycle_loop() -> StrResult {
                     control_sender
                         .lock()
                         .await
-                        .send(&ServerControlPacket::NetworkKeepAlive)
+                        .send(&ServerControlPacket::Reserved("{ \"keepalive\": true }".into()))
                         .await
                         .ok();
                     time::sleep(NETWORK_KEEPALIVE_INTERVAL).await;
@@ -400,8 +400,7 @@ pub async fn connection_lifecycle_loop() -> StrResult {
                         };
                     }
                     Ok(ClientControlPacket::RequestIDR) => unsafe { crate::RequestIDR() },
-                    Ok(ClientControlPacket::NetworkKeepAlive)
-                    | Ok(ClientControlPacket::Reserved(_))
+                    Ok(ClientControlPacket::Reserved(_))
                     | Ok(ClientControlPacket::ReservedBuffer(_)) => (),
                     Err(e) => {
                         log_id(LogId::ClientDisconnected);

--- a/alvr/server/src/lib.rs
+++ b/alvr/server/src/lib.rs
@@ -53,8 +53,14 @@ pub fn shutdown_runtime() {
         .on_disconnect_script
         .clone();
     if !on_disconnect_script.is_empty() {
-        info!("Running on disconnect script (shutdown): {}", on_disconnect_script);
-        if let Err(e) = Command::new(&on_disconnect_script).env("ACTION", "shutdown").spawn() {
+        info!(
+            "Running on disconnect script (shutdown): {}",
+            on_disconnect_script
+        );
+        if let Err(e) = Command::new(&on_disconnect_script)
+            .env("ACTION", "shutdown")
+            .spawn()
+        {
             warn!("Failed to run disconnect script: {}", e);
         }
     }

--- a/alvr/server/src/lib.rs
+++ b/alvr/server/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
     net::IpAddr,
     os::raw::c_char,
     path::PathBuf,
+    process::Command,
     sync::{atomic::AtomicUsize, atomic::Ordering, Arc, Once},
     thread,
     time::Duration,
@@ -43,6 +44,20 @@ pub fn shutdown_runtime() {
     }
 
     SHUTDOWN_NOTIFIER.notify_waiters();
+
+    let on_disconnect_script = SESSION_MANAGER
+        .lock()
+        .get()
+        .to_settings()
+        .connection
+        .on_disconnect_script
+        .clone();
+    if !on_disconnect_script.is_empty() {
+        info!("Running on disconnect script (shutdown): {}", on_disconnect_script);
+        if let Err(e) = Command::new(&on_disconnect_script).env("ACTION", "shutdown").spawn() {
+            warn!("Failed to run disconnect script: {}", e);
+        }
+    }
 
     if let Some(runtime) = MAYBE_RUNTIME.lock().take() {
         runtime.shutdown_background();

--- a/server_release_template/web_gui/js/app/nls/settings.js
+++ b/server_release_template/web_gui/js/app/nls/settings.js
@@ -154,10 +154,10 @@ define({
         "_root_connection_clientRecvBufferSize.description": "Buffer size on client side. \nDepends on the bitrate. \nCalculated size is recommended. If you experience packet loss, enlarge buffer.", // adv
         "_root_connection_aggressiveKeyframeResend.name": "Aggressive keyframe resend",
         "_root_connection_aggressiveKeyframeResend.description": "Decrease minimum interval between keyframes from 100 ms to 5 ms. \nUsed only when packet loss is detected. \nImproves experience on networks with packet loss.",
-        "_root_connection_onConnectScript.name": "On connect script/executable",
-        "_root_connection_onConnectScript.description": "This script/executable will be run asynchronously when headset connects",
-        "_root_connection_onDisconnectScript.name": "On disconnect script/executable",
-        "_root_connection_onDisconnectScript.description": "This script/executable will be run asynchronously when headset disconnects",
+        "_root_connection_onConnectScript.name": "On connect script",
+        "_root_connection_onConnectScript.description": "This script/executable will be run asynchronously when headset connects.\nEnvironment variable ACTION will be set to &#34;connect&#34; (without quotes).",
+        "_root_connection_onDisconnectScript.name": "On disconnect script",
+        "_root_connection_onDisconnectScript.description": "This script/executable will be run asynchronously when headset disconnects and on SteamVR shutdown.\nEnvironment variable ACTION will be set to &#34;disconnect&#34; or &#34;shutdown&#34; (both without quotes).",
         // Extra tab
         "_root_extra_tab.name": "Extra",
         "_root_extra_theme-choice-.name": "Theme",

--- a/server_release_template/web_gui/js/app/nls/settings.js
+++ b/server_release_template/web_gui/js/app/nls/settings.js
@@ -154,6 +154,10 @@ define({
         "_root_connection_clientRecvBufferSize.description": "Buffer size on client side. \nDepends on the bitrate. \nCalculated size is recommended. If you experience packet loss, enlarge buffer.", // adv
         "_root_connection_aggressiveKeyframeResend.name": "Aggressive keyframe resend",
         "_root_connection_aggressiveKeyframeResend.description": "Decrease minimum interval between keyframes from 100 ms to 5 ms. \nUsed only when packet loss is detected. \nImproves experience on networks with packet loss.",
+        "_root_connection_onConnectScript.name": "On connect script/executable",
+        "_root_connection_onConnectScript.description": "This script/executable will be run asynchronously when headset connects",
+        "_root_connection_onDisconnectScript.name": "On disconnect script/executable",
+        "_root_connection_onDisconnectScript.description": "This script/executable will be run asynchronously when headset disconnects",
         // Extra tab
         "_root_extra_tab.name": "Extra",
         "_root_extra_theme-choice-.name": "Theme",


### PR DESCRIPTION
Added settings for running scripts on connect and disconnect (including SteamVR shutdown).

Previously non-graceful closing of TCP control connection was not detected (as no packets were sent/received), an application level sending of keep-alive messages has been implemented (as it uses new _ServerControlPacket_ and _ClientControlPacket_ values it is not compatible with previous client versions). 
Previously `tokio::net::TcpStream` supported enabling OS level TCP keep-alive, but this functionality was removed in https://github.com/tokio-rs/tokio/pull/1767.