### PR TITLE
Add missing default text on Revert setting dialog

### DIFF
--- a/server_release_template/dashboard/js/app/customSettings.js
+++ b/server_release_template/dashboard/js/app/customSettings.js
@@ -57,10 +57,10 @@ define([
                 alvrSettings.getHelpReset(
                     "controllerMode",
                     "_root_headset_controllers_content",
-                    0,
+                    6,
                     (postFix = ""),
                     "controllerMode",
-                    "Oculus Rift S"
+                    "Oculus Quest 2"
                 ),
             );
             controller.parent().addClass("special");
@@ -123,10 +123,10 @@ define([
                 alvrSettings.getHelpReset(
                     "headsetEmulationMode",
                     "_root_headset",
-                    0,
+                    2,
                     (postFix = ""),
                     "headsetEmulationMode",
-                    "Oculus Rift S"
+                    "Oculus Quest 2"
                 ),
             );
             headset.parent().addClass("special");

--- a/server_release_template/dashboard/js/app/customSettings.js
+++ b/server_release_template/dashboard/js/app/customSettings.js
@@ -58,6 +58,9 @@ define([
                     "controllerMode",
                     "_root_headset_controllers_content",
                     0,
+                    (postFix = ""),
+                    "controllerMode",
+                    "Oculus Rift S"
                 ),
             );
             controller.parent().addClass("special");
@@ -121,6 +124,9 @@ define([
                     "headsetEmulationMode",
                     "_root_headset",
                     0,
+                    (postFix = ""),
+                    "headsetEmulationMode",
+                    "Oculus Rift S"
                 ),
             );
             headset.parent().addClass("special");
@@ -346,7 +352,7 @@ define([
                             <input type="radio" name="displayRefreshRate" autocomplete="off" value="90">
                             90 Hz
                         </label>
-                                                  
+
                     </div> `;
 
             el.after(grp);


### PR DESCRIPTION
Add default text for Headset emulation mode and Controller emulation mode on Revert setting dialog to easy to understand.