### PR TITLE
Add throttled UDP socket option for stream socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,10 +123,12 @@ dependencies = [
  "gfx-backend-dx11",
  "gfx-backend-vulkan",
  "gfx-hal",
+ "governor",
  "lazy_static",
  "log",
  "msgbox",
  "nalgebra",
+ "nonzero_ext",
  "parking_lot",
  "rand 0.8.3",
  "rcgen",
@@ -1483,6 +1491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,14 +1592,14 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.6.23"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
 dependencies = [
  "cc",
  "libc",
  "log",
- "rustc_version",
+ "rustversion",
  "winapi 0.3.9",
 ]
 
@@ -1796,6 +1810,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c5d2f987ee8f6dff3fa1a352058dc59b990e447e4c7846aa7d804971314f7b"
+dependencies = [
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "quanta",
+ "rand 0.8.3",
+ "smallvec",
+]
+
+[[package]]
 name = "gtk"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +1890,16 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "ahash",
+ "autocfg",
 ]
 
 [[package]]
@@ -2016,7 +2057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -2629,6 +2670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "hashbrown 0.8.2",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2697,12 @@ dependencies = [
  "memchr",
  "version_check",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a1290799eababa63ea60af0cbc3f03363e328e58f32fb0294798ed3e85f444"
 
 [[package]]
 name = "ntapi"
@@ -3180,6 +3236,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98dc777a7a39b76b1a26ae9d3f691f4c1bc0455090aa0b64dfa8cb7fc34c135"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3581,6 +3647,12 @@ dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
 name = "ryu"

--- a/alvr/common/Cargo.toml
+++ b/alvr/common/Cargo.toml
@@ -31,6 +31,8 @@ gfx-hal = "=0.6.0"
 winit = "0.24" # needed to get the screen size
 cpal = "0.13"
 rodio = "0.13"
+governor = "0.3.2"
+nonzero_ext = "0.2.0"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 dirs = "3"

--- a/alvr/common/src/data/settings.rs
+++ b/alvr/common/src/data/settings.rs
@@ -470,7 +470,7 @@ pub fn session_settings_default() -> SettingsDefault {
             web_server_port: 8082,
             stream_protocol: SocketProtocolDefault {
                 variant: SocketProtocolDefaultVariant::Udp,
-                ThrottledUdp: 2.0,
+                ThrottledUdp: 1.5,
             },
             stream_port: 9944,
             aggressive_keyframe_resend: false,

--- a/alvr/common/src/data/settings.rs
+++ b/alvr/common/src/data/settings.rs
@@ -270,6 +270,8 @@ pub struct HeadsetDesc {
 pub enum SocketProtocol {
     Udp,
     Tcp,
+    #[schema(advanced, min = 1.0, step = 0.1, gui = "UpDown")]
+    ThrottledUdp(f32),
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize)]
@@ -468,6 +470,7 @@ pub fn session_settings_default() -> SettingsDefault {
             web_server_port: 8082,
             stream_protocol: SocketProtocolDefault {
                 variant: SocketProtocolDefaultVariant::Udp,
+                ThrottledUdp: 2.0,
             },
             stream_port: 9944,
             aggressive_keyframe_resend: false,

--- a/alvr/common/src/data/settings.rs
+++ b/alvr/common/src/data/settings.rs
@@ -120,6 +120,13 @@ pub struct VideoDesc {
     pub color_correction: Switch<ColorCorrectionDesc>,
 }
 
+#[derive(SettingsSchema, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThrottlingConfig {
+    #[schema(min = 1.0, step = 0.1, gui = "UpDown")]
+    pub byterate_multiplier: f32,
+}
+
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase", tag = "type", content = "content")]
 pub enum AudioDeviceId {
@@ -270,8 +277,8 @@ pub struct HeadsetDesc {
 pub enum SocketProtocol {
     Udp,
     Tcp,
-    #[schema(advanced, min = 1.0, step = 0.1, gui = "UpDown")]
-    ThrottledUdp(f32),
+    #[schema(advanced)]
+    ThrottledUdp(ThrottlingConfig),
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize)]
@@ -470,7 +477,9 @@ pub fn session_settings_default() -> SettingsDefault {
             web_server_port: 8082,
             stream_protocol: SocketProtocolDefault {
                 variant: SocketProtocolDefaultVariant::Udp,
-                ThrottledUdp: 1.5,
+                ThrottledUdp: ThrottlingConfigDefault {
+                    byterate_multiplier: 1.5,
+                },
             },
             stream_port: 9944,
             aggressive_keyframe_resend: false,

--- a/alvr/common/src/sockets/stream_socket/mod.rs
+++ b/alvr/common/src/sockets/stream_socket/mod.rs
@@ -5,6 +5,7 @@
 // bytes while still handling the additional byte buffer with zero copies and extra allocations.
 
 mod tcp;
+mod throttled_udp;
 mod udp;
 
 use crate::{data::*, *};
@@ -19,6 +20,7 @@ use std::{
     sync::Arc,
 };
 use tcp::{TcpStreamReceiveSocket, TcpStreamSendSocket};
+use throttled_udp::{ThrottledUdpStreamReceiveSocket, ThrottledUdpStreamSendSocket};
 use tokio::sync::{mpsc, Mutex};
 use udp::{UdpStreamReceiveSocket, UdpStreamSendSocket};
 
@@ -32,11 +34,13 @@ pub const RESERVED: StreamId = 2;
 #[derive(Clone)]
 enum StreamSendSocket {
     Udp(UdpStreamSendSocket),
+    ThrottledUdp(ThrottledUdpStreamSendSocket),
     Tcp(TcpStreamSendSocket),
 }
 
 enum StreamReceiveSocket {
     Udp(UdpStreamReceiveSocket),
+    ThrottledUdp(ThrottledUdpStreamReceiveSocket),
     Tcp(TcpStreamReceiveSocket),
 }
 
@@ -110,6 +114,9 @@ impl<T> StreamSender<T> {
             ),
             StreamSendSocket::Tcp(socket) => {
                 trace_err!(socket.lock().await.send(buffer.inner.freeze()).await)
+            }
+            StreamSendSocket::ThrottledUdp(socket) => {
+                trace_err!(socket.send(buffer.inner.freeze()).await)
             }
         }
     }
@@ -241,6 +248,14 @@ impl StreamSocket {
                     StreamReceiveSocket::Tcp(receive_socket),
                 )
             }
+            SocketProtocol::ThrottledUdp(_) => {
+                let (send_socket, receive_socket) =
+                    throttled_udp::connect(server_ip, port, None).await?;
+                (
+                    StreamSendSocket::ThrottledUdp(send_socket),
+                    StreamReceiveSocket::ThrottledUdp(receive_socket),
+                )
+            }
         };
 
         Ok(Self {
@@ -254,6 +269,7 @@ impl StreamSocket {
         client_ip: IpAddr,
         port: u16,
         protocol: SocketProtocol,
+        byterate: u32,
     ) -> StrResult<Self> {
         let (send_socket, receive_socket) = match protocol {
             SocketProtocol::Udp => {
@@ -270,6 +286,21 @@ impl StreamSocket {
                     StreamReceiveSocket::Tcp(receive_socket),
                 )
             }
+            SocketProtocol::ThrottledUdp(multiplier) => {
+                let (send_socket, receive_socket) = throttled_udp::connect(
+                    client_ip,
+                    port,
+                    Some(throttled_udp::ThrottlingSettings {
+                        byterate,
+                        multiplier,
+                    }),
+                )
+                .await?;
+                (
+                    StreamSendSocket::ThrottledUdp(send_socket),
+                    StreamReceiveSocket::ThrottledUdp(receive_socket),
+                )
+            }
         };
 
         Ok(Self {
@@ -283,6 +314,9 @@ impl StreamSocket {
         match self.receive_socket {
             StreamReceiveSocket::Udp(socket) => udp::receive_loop(socket, self.packet_queues).await,
             StreamReceiveSocket::Tcp(socket) => tcp::receive_loop(socket, self.packet_queues).await,
+            StreamReceiveSocket::ThrottledUdp(socket) => {
+                throttled_udp::receive_loop(socket, self.packet_queues).await
+            }
         }
     }
 }

--- a/alvr/common/src/sockets/stream_socket/mod.rs
+++ b/alvr/common/src/sockets/stream_socket/mod.rs
@@ -250,7 +250,7 @@ impl StreamSocket {
             }
             SocketProtocol::ThrottledUdp(_) => {
                 let (send_socket, receive_socket) =
-                    throttled_udp::connect(server_ip, port, None).await?;
+                    throttled_udp::connect_to_server(server_ip, port).await?;
                 (
                     StreamSendSocket::ThrottledUdp(send_socket),
                     StreamReceiveSocket::ThrottledUdp(receive_socket),
@@ -269,7 +269,7 @@ impl StreamSocket {
         client_ip: IpAddr,
         port: u16,
         protocol: SocketProtocol,
-        byterate: u32,
+        video_byterate: u32,
     ) -> StrResult<Self> {
         let (send_socket, receive_socket) = match protocol {
             SocketProtocol::Udp => {
@@ -286,14 +286,14 @@ impl StreamSocket {
                     StreamReceiveSocket::Tcp(receive_socket),
                 )
             }
-            SocketProtocol::ThrottledUdp(multiplier) => {
-                let (send_socket, receive_socket) = throttled_udp::connect(
+            SocketProtocol::ThrottledUdp(config) => {
+                let (send_socket, receive_socket) = throttled_udp::connect_to_client(
                     client_ip,
                     port,
-                    Some(throttled_udp::ThrottlingSettings {
-                        byterate,
-                        multiplier,
-                    }),
+                    throttled_udp::ThrottlingSettings {
+                        video_byterate,
+                        multiplier: config.byterate_multiplier,
+                    },
                 )
                 .await?;
                 (

--- a/alvr/common/src/sockets/stream_socket/throttled_udp.rs
+++ b/alvr/common/src/sockets/stream_socket/throttled_udp.rs
@@ -64,6 +64,7 @@ pub struct ThrottledUdpStreamReceiveSocket {
     buffer: BytesMut,
 }
 
+// Code taken from https://github.com/tokio-rs/tokio/blob/master/tokio-util/src/udp/frame.rs
 impl Stream for ThrottledUdpStreamReceiveSocket {
     type Item = io::Result<(BytesMut, SocketAddr)>;
 

--- a/alvr/common/src/sockets/stream_socket/throttled_udp.rs
+++ b/alvr/common/src/sockets/stream_socket/throttled_udp.rs
@@ -1,0 +1,144 @@
+use crate::{
+    sockets::{StreamId, LOCAL_IP},
+    *,
+};
+use bytes::{BufMut, Bytes, BytesMut};
+
+use futures::{Stream, StreamExt};
+use governor::{
+    clock,
+    state::{InMemoryState, NotKeyed},
+    Quota, RateLimiter,
+};
+use nonzero_ext::NonZero;
+use std::{
+    collections::HashMap,
+    io,
+    mem::MaybeUninit,
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::{
+    io::ReadBuf,
+    net::UdpSocket,
+    sync::{mpsc, Mutex},
+};
+
+const INITIAL_RD_CAPACITY: usize = 64 * 1024;
+const MINIMUM_BYTERATE: u32 = 1000;
+
+pub struct ThrottlingSettings {
+    pub byterate: u32,
+    pub multiplier: f32,
+}
+
+#[allow(clippy::type_complexity)]
+#[derive(Clone)]
+pub struct ThrottledUdpStreamSendSocket {
+    inner: Arc<UdpSocket>,
+    limiter: Arc<Option<RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock>>>,
+}
+
+impl ThrottledUdpStreamSendSocket {
+    pub async fn send(&self, data: Bytes) -> io::Result<()> {
+        if let Some(ref limiter) = *self.limiter {
+            if let Some(len) = NonZero::new(data.len() as u32) {
+                limiter.until_n_ready(len).await.ok();
+            }
+        }
+        match self.inner.send(&data).await {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+// peer_addr is needed to check that the packet comes from the desired device. Connecting directly
+// to the peer is not supported by UdpFramed.
+pub struct ThrottledUdpStreamReceiveSocket {
+    pub inner: Arc<UdpSocket>,
+    buffer: BytesMut,
+}
+
+impl Stream for ThrottledUdpStreamReceiveSocket {
+    type Item = io::Result<(BytesMut, SocketAddr)>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let pin = self.get_mut();
+
+        pin.buffer.reserve(INITIAL_RD_CAPACITY);
+
+        let addr = unsafe {
+            let buf = &mut *(pin.buffer.chunk_mut() as *mut _ as *mut [MaybeUninit<u8>]);
+            let mut read = ReadBuf::uninit(buf);
+            let ptr = read.filled().as_ptr();
+            let res = match Pin::new(&mut pin.inner).poll_recv_from(cx, &mut read) {
+                Poll::Ready(res) => res,
+                Poll::Pending => return Poll::Pending,
+            };
+
+            assert_eq!(ptr, read.filled().as_ptr());
+            let addr = res?;
+            pin.buffer.advance_mut(read.filled().len());
+            addr
+        };
+        Poll::Ready(Some(Ok((pin.buffer.split_to(pin.buffer.len()), addr))))
+    }
+}
+
+pub async fn connect(
+    peer_ip: IpAddr,
+    port: u16,
+    throttling_settings: Option<ThrottlingSettings>,
+) -> StrResult<(
+    ThrottledUdpStreamSendSocket,
+    ThrottledUdpStreamReceiveSocket,
+)> {
+    let peer_addr: SocketAddr = (peer_ip, port).into();
+    let socket = trace_err!(UdpSocket::bind((LOCAL_IP, port)).await)?;
+    trace_err!(socket.connect(peer_addr).await)?;
+
+    let rx = Arc::new(socket);
+    let tx = rx.clone();
+
+    let limiter = match throttling_settings {
+        Some(settings) => {
+            let byterate = (settings.byterate as f32 * settings.multiplier) as u32;
+            let byterate = std::cmp::max(MINIMUM_BYTERATE, byterate);
+            let burst = byterate / 1000;
+            let quota = Quota::per_second(NonZero::new(byterate).unwrap())
+                .allow_burst(NonZero::new(burst).unwrap());
+            Some(RateLimiter::direct(quota))
+        }
+        None => None,
+    };
+
+    Ok((
+        ThrottledUdpStreamSendSocket {
+            inner: tx,
+            limiter: Arc::new(limiter),
+        },
+        ThrottledUdpStreamReceiveSocket {
+            inner: rx,
+            buffer: BytesMut::new(),
+        },
+    ))
+}
+
+pub async fn receive_loop(
+    mut socket: ThrottledUdpStreamReceiveSocket,
+    packet_enqueuers: Arc<Mutex<HashMap<StreamId, mpsc::UnboundedSender<BytesMut>>>>,
+) -> StrResult {
+    while let Some(maybe_packet) = socket.next().await {
+        let (packet_bytes, _) = trace_err!(maybe_packet)?;
+
+        let stream_id = packet_bytes[0];
+        if let Some(enqueuer) = packet_enqueuers.lock().await.get_mut(&stream_id) {
+            trace_err!(enqueuer.send(packet_bytes))?;
+        }
+    }
+
+    Ok(())
+}

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -28,6 +28,10 @@ fn align32(value: f32) -> u32 {
     ((value / 32.).floor() * 32.) as u32
 }
 
+fn mbits_to_bytes(value: u64) -> u32 {
+    (value * 1024 * 1024 / 8) as u32
+}
+
 async fn client_discovery() -> StrResult {
     let res = search_client_loop(|client_ip, handshake_packet| async move {
         crate::update_client_list(
@@ -389,6 +393,7 @@ async fn connection_pipeline() -> StrResult {
             client_ip,
             settings.connection.stream_port,
             settings.connection.stream_protocol,
+            mbits_to_bytes(settings.video.encode_bitrate_mbs)
         ) => res?,
         _ = time::sleep(Duration::from_secs(2)) => {
             return fmt_e!("Timeout while setting up streams");


### PR DESCRIPTION
A throttled transfer is needed to avoid bursts in the (mainly) video stream on networks with lower bandwidth.
In my case, I use a 5Ghz router which only supports up to 100Mbit Ethernet, so these bursts result in dropped packets and overall an unusable stream.

This PR uses the governor Rust library to implement throttling over a naked UDP socket. The receiving code is a modified version of the UdpFramed Stream implementation.