### PR TITLE
Build android apps with optimizations enabled for release configurations

### DIFF
--- a/alvr/client/android/app/build.gradle
+++ b/alvr/client/android/app/build.gradle
@@ -23,6 +23,9 @@ android {
             ndk {
                 abiFilters "arm64-v8a"
             }
+            cargo {
+                profile = "release"
+            }
         }
         debug {
             jniDebuggable = true


### PR DESCRIPTION
I was a little surprised, when I spotted `[unoptimized + debuginfo]` in my test client build, when compiling with `cargo xtask build-client --release`.

Maybe I am missing something here, but it seems to me, that the alvr-client was never build with optimizations enabled.
We are probably leaving some performance on the table here.

A quick smoke test showed no obvious differences in the experience (I did not compare the numbers).
There should be no harm in enabling the flag. This was probably not left out on purpose anyway.