### PR TITLE
Ack the StreamStart package before attempting to connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client"
-version = "15.0.0"
+version = "15.1.0"
 dependencies = [
  "alvr_common",
  "android_logger",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_common"
-version = "15.0.0"
+version = "15.1.0"
 dependencies = [
  "alvr_xtask",
  "backtrace",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_launcher"
-version = "15.0.0"
+version = "15.1.0"
 dependencies = [
  "alvr_common",
  "druid",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server"
-version = "15.0.0"
+version = "15.1.0"
 dependencies = [
  "alcro",
  "alvr_common",

--- a/alvr/client/Cargo.toml
+++ b/alvr/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_client"
-version = "15.0.0"
+version = "15.1.0"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/alvr/client/android/app/build.gradle
+++ b/alvr/client/android/app/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 30
         versionCode 50
-        versionName "15.0.0"
+        versionName "15.1.0"
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++17 -fexceptions -frtti"

--- a/alvr/client/src/connection.rs
+++ b/alvr/client/src/connection.rs
@@ -1,7 +1,7 @@
 use crate::{audio, MAYBE_LEGACY_SENDER};
 use alvr_common::{
     data::*,
-    sockets::{ConnectionResult, AUDIO, LEGACY},
+    sockets::{ConnectionResult, StreamSocketBuilder, AUDIO, LEGACY},
     *,
 };
 use futures::future::BoxFuture;
@@ -12,7 +12,6 @@ use jni::{
 use nalgebra::{Point2, Point3, Quaternion, UnitQuaternion};
 use serde_json as json;
 use settings_schema::Switch;
-use sockets::StreamSocket;
 use std::{
     future, slice,
     sync::{
@@ -177,11 +176,16 @@ async fn connection_pipeline(
         session_desc.to_settings()
     };
 
+    let stream_socket_builder = StreamSocketBuilder::listen_for_server(
+        settings.connection.stream_port,
+        settings.connection.stream_protocol,
+    )
+    .await?;
+
     let mut stream_socket = tokio::select! {
-        res = StreamSocket::connect_to_server(
+        res = stream_socket_builder.accept_from_server(
             server_ip,
             settings.connection.stream_port,
-            settings.connection.stream_protocol,
         ) => res?,
         _ = time::sleep(Duration::from_secs(5)) => {
             return fmt_e!("Timeout while setting up streams");

--- a/alvr/client/src/connection.rs
+++ b/alvr/client/src/connection.rs
@@ -14,6 +14,7 @@ use serde_json as json;
 use settings_schema::Switch;
 use std::{
     future, slice,
+    str::FromStr,
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc as smpsc, Arc,
@@ -182,20 +183,26 @@ async fn connection_pipeline(
     )
     .await?;
 
-    if let Err(e) = control_sender
-        .lock()
-        .await
-        .send(&ClientControlPacket::StreamReady)
-        .await
+    let version = Version::from_str(&config_packet.reserved).ok();
+    if version
+        .map(|v| v >= Version::from((15, 1, 0)))
+        .unwrap_or(false)
     {
-        info!("Server disconnected. Cause: {}", e);
-        set_loading_message(
-            &*java_vm,
-            &*activity_ref,
-            hostname,
-            SERVER_DISCONNECTED_MESSAGE,
-        )?;
-        return Ok(());
+        if let Err(e) = control_sender
+            .lock()
+            .await
+            .send(&ClientControlPacket::StreamReady)
+            .await
+        {
+            info!("Server disconnected. Cause: {}", e);
+            set_loading_message(
+                &*java_vm,
+                &*activity_ref,
+                hostname,
+                SERVER_DISCONNECTED_MESSAGE,
+            )?;
+            return Ok(());
+        }
     }
 
     let mut stream_socket = tokio::select! {

--- a/alvr/client/src/connection.rs
+++ b/alvr/client/src/connection.rs
@@ -182,6 +182,22 @@ async fn connection_pipeline(
     )
     .await?;
 
+    if let Err(e) = control_sender
+        .lock()
+        .await
+        .send(&ClientControlPacket::StreamReady)
+        .await
+    {
+        info!("Server disconnected. Cause: {}", e);
+        set_loading_message(
+            &*java_vm,
+            &*activity_ref,
+            hostname,
+            SERVER_DISCONNECTED_MESSAGE,
+        )?;
+        return Ok(());
+    }
+
     let mut stream_socket = tokio::select! {
         res = stream_socket_builder.accept_from_server(
             server_ip,

--- a/alvr/client/src/lib.rs
+++ b/alvr/client/src/lib.rs
@@ -191,7 +191,7 @@ pub unsafe extern "system" fn Java_com_polygraphene_alvr_OvrActivity_onResumeNat
             recommended_eye_height: result.recommendedEyeHeight as _,
             available_refresh_rates,
             preferred_refresh_rate,
-            reserved: "".into(),
+            reserved: format!("{}", *ALVR_VERSION),
         };
 
         let private_identity = PrivateIdentity {

--- a/alvr/common/Cargo.toml
+++ b/alvr/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_common"
-version = "15.0.0"
+version = "15.1.0"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/alvr/common/src/data/packets.rs
+++ b/alvr/common/src/data/packets.rs
@@ -71,6 +71,7 @@ pub struct PlayspaceSyncPacket {
 
 #[derive(Serialize, Deserialize)]
 pub enum ClientControlPacket {
+    StreamReady,
     PlayspaceSync(PlayspaceSyncPacket),
     RequestIDR,
     KeepAlive,

--- a/alvr/common/src/data/version.rs
+++ b/alvr/common/src/data/version.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use semver::Version;
+pub use semver::Version;
 
 pub const ALVR_NAME: &str = "ALVR";
 

--- a/alvr/common/src/sockets/stream_socket/tcp.rs
+++ b/alvr/common/src/sockets/stream_socket/tcp.rs
@@ -17,19 +17,21 @@ use tokio_util::codec::Framed;
 pub type TcpStreamSendSocket = Arc<Mutex<SplitSink<Framed<TcpStream, LDC>, Bytes>>>;
 pub type TcpStreamReceiveSocket = SplitStream<Framed<TcpStream, LDC>>;
 
-pub async fn connect_to_server(
+pub async fn listen_for_server(port: u16) -> StrResult<TcpListener> {
+    trace_err!(TcpListener::bind((LOCAL_IP, port)).await)
+}
+
+pub async fn accept_from_server(
+    listener: TcpListener,
     server_ip: IpAddr,
-    port: u16,
 ) -> StrResult<(TcpStreamSendSocket, TcpStreamReceiveSocket)> {
-    let listener = trace_err!(TcpListener::bind((LOCAL_IP, port)).await)?;
     let (socket, server_address) = trace_err!(listener.accept().await)?;
 
     if server_address.ip() != server_ip {
         return fmt_e!(
-            "Connected to wrong client: {} != {}:{}",
+            "Connected to wrong client: {} != {}",
             server_address,
             server_ip,
-            port,
         );
     }
 

--- a/alvr/common/src/sockets/stream_socket/throttled_udp.rs
+++ b/alvr/common/src/sockets/stream_socket/throttled_udp.rs
@@ -125,7 +125,12 @@ pub async fn connect_to_client(
     ))
 }
 
-pub async fn connect_to_server(
+pub async fn listen_for_server(port: u16) -> StrResult<UdpSocket> {
+    trace_err!(UdpSocket::bind((LOCAL_IP, port)).await)
+}
+
+pub async fn accept_from_server(
+    socket: UdpSocket,
     server_ip: IpAddr,
     port: u16,
 ) -> StrResult<(
@@ -133,7 +138,6 @@ pub async fn connect_to_server(
     ThrottledUdpStreamReceiveSocket,
 )> {
     let server_addr: SocketAddr = (server_ip, port).into();
-    let socket = trace_err!(UdpSocket::bind((LOCAL_IP, port)).await)?;
     trace_err!(socket.connect(server_addr).await)?;
 
     let rx = Arc::new(socket);

--- a/alvr/common/src/sockets/stream_socket/udp.rs
+++ b/alvr/common/src/sockets/stream_socket/udp.rs
@@ -32,12 +32,16 @@ pub struct UdpStreamReceiveSocket {
     pub inner: SplitStream<UdpFramed<LDC>>,
 }
 
+pub async fn bind(port: u16) -> StrResult<UdpSocket> {
+    trace_err!(UdpSocket::bind((LOCAL_IP, port)).await)
+}
+
 pub async fn connect(
+    socket: UdpSocket,
     peer_ip: IpAddr,
     port: u16,
 ) -> StrResult<(UdpStreamSendSocket, UdpStreamReceiveSocket)> {
     let peer_addr = (peer_ip, port).into();
-    let socket = trace_err!(UdpSocket::bind((LOCAL_IP, port)).await)?;
     let socket = UdpFramed::new(socket, LDC::new());
     let (send_socket, receive_socket) = socket.split();
 

--- a/alvr/launcher/Cargo.toml
+++ b/alvr/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_launcher"
-version = "15.0.0"
+version = "15.1.0"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/alvr/server/Cargo.toml
+++ b/alvr/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_server"
-version = "15.0.0"
+version = "15.1.0"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -12,6 +12,7 @@ use std::{
     future,
     net::IpAddr,
     process::Command,
+    str::FromStr,
     sync::{mpsc as smpsc, Arc},
     thread,
     time::Duration,
@@ -62,6 +63,7 @@ async fn client_discovery() -> StrResult {
 
 struct ConnectionInfo {
     client_ip: IpAddr,
+    version: Option<Version>,
     control_sender: ControlSocketSender<ServerControlPacket>,
     control_receiver: ControlSocketReceiver<ClientControlPacket>,
 }
@@ -166,6 +168,8 @@ async fn client_handshake() -> StrResult<ConnectionInfo> {
         0
     };
 
+    let version = Version::from_str(&headset_info.reserved).ok();
+
     let client_config = ClientConfigPacket {
         session_desc: trace_err!(serde_json::to_string(SESSION_MANAGER.lock().get()))?,
         dashboard_url,
@@ -173,7 +177,7 @@ async fn client_handshake() -> StrResult<ConnectionInfo> {
         eye_resolution_height: video_eye_height,
         fps,
         game_audio_sample_rate,
-        reserved: "".into(),
+        reserved: format!("{}", *ALVR_VERSION),
     };
 
     let (mut control_sender, control_receiver) =
@@ -322,6 +326,7 @@ async fn client_handshake() -> StrResult<ConnectionInfo> {
 
     Ok(ConnectionInfo {
         client_ip,
+        version,
         control_sender,
         control_receiver,
     })
@@ -377,6 +382,7 @@ async fn connection_pipeline() -> StrResult {
 
     let ConnectionInfo {
         client_ip,
+        version,
         control_sender,
         mut control_receiver,
     } = connection_info;
@@ -388,13 +394,18 @@ async fn connection_pipeline() -> StrResult {
         .send(&ServerControlPacket::StartStream)
         .await?;
 
-    match control_receiver.recv().await {
-        Ok(ClientControlPacket::StreamReady) => {}
-        Ok(_) => {
-            return fmt_e!("Got unexpected packet waiting for stream ack");
-        }
-        Err(e) => {
-            return fmt_e!("Error while waiting for stream ack: {}", e);
+    if version
+        .map(|v| v >= Version::from((15, 1, 0)))
+        .unwrap_or(false)
+    {
+        match control_receiver.recv().await {
+            Ok(ClientControlPacket::StreamReady) => {}
+            Ok(_) => {
+                return fmt_e!("Got unexpected packet waiting for stream ack");
+            }
+            Err(e) => {
+                return fmt_e!("Error while waiting for stream ack: {}", e);
+            }
         }
     }
 

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -388,6 +388,16 @@ async fn connection_pipeline() -> StrResult {
         .send(&ServerControlPacket::StartStream)
         .await?;
 
+    match control_receiver.recv().await {
+        Ok(ClientControlPacket::StreamReady) => {}
+        Ok(_) => {
+            return fmt_e!("Got unexpected packet waiting for stream ack");
+        }
+        Err(e) => {
+            return fmt_e!("Error while waiting for stream ack: {}", e);
+        }
+    }
+
     let settings = SESSION_MANAGER.lock().get().to_settings();
 
     let mut stream_socket = tokio::select! {

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -391,7 +391,7 @@ async fn connection_pipeline() -> StrResult {
     let settings = SESSION_MANAGER.lock().get().to_settings();
 
     let mut stream_socket = tokio::select! {
-        res = StreamSocket::connect_to_client(
+        res = StreamSocketBuilder::connect_to_client(
             client_ip,
             settings.connection.stream_port,
             settings.connection.stream_protocol,


### PR DESCRIPTION
Fixes #517.

This PR should likely be reviewed on a commit-by-commit bases.

- 7daf5362cf6ccfc5743d998f508b102887bdb9c6: To send a package between listening on the stream_port and waiting for the server connection the  `StreamSocket::connect_to_server` function had to be split in two.
- c4ec024452939fbaed50162fa240bafb10a4e000: Introduces the `ClientControllPacket::StreamReady` packet.
- a01dab72f3f66a4f6dc63c62d7a556e82962b9b5: Adds version checks to send `StreamReady` only on versions 15.1.0 or higher. This commit should be easily revert-able for 16.0.0 and uses the `reserved` fields on the `ClientConfigPacket` and `HeadsetInfoPacket`. The server has this information already very early in the connection process, but passing it through would be very cumbersome. The client has no idea of the server version. This should likely be fixed in future versions of the protocol.
- 80828d9221f917abc269255921bc093b3259bb27: Bumb the version to 15.1.0. Can be ignored/dropped from the PR, if unwanted.

I did some tests with this branch today and wired connections via ADB are working just like networked ones now. Client and server connect reliably on startup, no matter the startup order. As soon as all parts are in place, the stream starts immediately.

Once this hits a stable release, I will add a wiki page explaining the setup process.
Until then for testing you need a quest with adb enabled (which is required for installing ALVR anyway) and follow these steps:

- Disable wifi (to prevent discovery) on your quest and check the ALVR app for your hostname, note it down.
- Add the quest manually to the ALVR server using `127.0.0.1` as the IP. (You will get an error here, if the quest was already discovered with a different IP, so check your wifi settings before.)
- Enable wifi again, ALVR cannot listen for connections otherwise, including adb-connections.
- Establish the port forwarding using:
  - `adb devices` <- check that your quest shows up and your pc is trusted
  - `adb forward tcp:9943 tcp:9943`
  - `adb forward tcp:9944 tcp:9944`
- (If you start port forwarding before the app on the quest runs, the server now prints warnings to the log, you can safely ignore these. Connections will succeed once the app on the quest runs and can send answers.)
- The stream should work at this point!

Should also work on the Oculus Go, but I have no device to test this.