### PR TITLE
Fix linux build error in alvr server

### DIFF
--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -220,14 +220,6 @@ pub fn build_server(is_release: bool, is_nightly: bool, fetch_crates: bool, new_
         driver_dst_dir.join(DRIVER_FNAME),
     )
     .unwrap();
-    if cfg!(target_os = "linux") {
-        // patch for executing the webserver without steamvr
-        fs::copy(
-            artifacts_dir.join(exec_fname("alvr_server")),
-            driver_dst_dir.join(exec_fname("alvr_server")),
-        )
-        .unwrap();
-    }
 
     if cfg!(windows) {
         let dir_content = dirx::get_dir_content("alvr/server/cpp/bin/windows").unwrap();


### PR DESCRIPTION
@zarik5 I believe the 'alvr_server' executable was removed in ea3ab930e868683153338a85c4cf710a6ab8196f . However, the code that copies this executable into the driver destination directory had not been removed