### PR TITLE
launcher: use steamlocate crate to verify steamvr exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "semver 0.11.0",
  "serde_json",
  "single-instance",
+ "steamlocate",
  "sysinfo",
  "ureq",
  "winreg 0.8.0",
@@ -260,9 +261,9 @@ checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
 
 [[package]]
 name = "android_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b49bdae48631d048e8f687320764bb0754a399ceba5a17c887b8fbfb668f4a3"
+checksum = "d9ed09b18365ed295d722d0b5ed59c01b79a826ff2d2a8f73d5ecca8e6fb2f66"
 dependencies = [
  "android_log-sys",
  "env_logger",
@@ -2009,9 +2010,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -2608,6 +2609,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
+
+[[package]]
+name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
@@ -2909,7 +2916,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -3256,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb7a2dc0e5307189b6933a61290ff06b65b35bdcaae2b2c50a0c3e355cb118e"
+checksum = "4e80a701a04edd9cab874a3d59323bebe24c9a92dd602088c78da83732066d1b"
 dependencies = [
  "chrono",
  "pem",
@@ -3274,9 +3281,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags",
 ]
@@ -3885,6 +3892,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "steamlocate"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c40e098716a3749812d81f24837dfd526af6b8594977c92f3c8055f475bfe6"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "lazy_static",
+ "regex",
+ "steamy-vdf",
+ "winreg 0.8.0",
+]
+
+[[package]]
+name = "steamy-vdf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533127ad49314bfe71c3d3fd36b3ebac3d24f40618092e70e1cfe8362c7fac79"
+dependencies = [
+ "nom 1.2.4",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3971,7 +4001,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
  "remove_dir_all",
  "winapi 0.3.9",
 ]

--- a/alvr/launcher/Cargo.toml
+++ b/alvr/launcher/Cargo.toml
@@ -11,9 +11,9 @@ druid = "0.7"
 semver = "0.11"
 serde_json = "1"
 single-instance = "0.3"
+steamlocate = "0.1"
 sysinfo = "0.17"
 ureq = "2"
-steamlocate = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.8"

--- a/alvr/launcher/Cargo.toml
+++ b/alvr/launcher/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1"
 single-instance = "0.3"
 sysinfo = "0.17"
 ureq = "2"
+steamlocate = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.8"

--- a/alvr/launcher/src/commands.rs
+++ b/alvr/launcher/src/commands.rs
@@ -11,6 +11,7 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
+use steamlocate::SteamDir;
 use sysinfo::{ProcessExt, RefreshKind, System, SystemExt};
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
@@ -88,7 +89,12 @@ pub fn kill_steamvr() {
 }
 
 pub fn check_steamvr_installation() -> bool {
-    commands::openvr_source_file_path().is_ok()
+    let steam = SteamDir::locate();
+
+    match steam {
+        Some(st) => st.app(&250820).is_some(),
+        None => false,
+    }
 }
 
 pub fn unblock_alvr_addon() -> StrResult {


### PR DESCRIPTION
Currently, SteamVR could not be found if it wasn't started before as the openvrpaths file will only
be made when SteamVR is started.