### PR TITLE
Removed timing checks, render a decoded frame asap

### DIFF
--- a/alvr/client/android/app/src/main/java/com/polygraphene/alvr/OvrActivity.java
+++ b/alvr/client/android/app/src/main/java/com/polygraphene/alvr/OvrActivity.java
@@ -314,8 +314,8 @@ public class OvrActivity extends Activity {
                     renderNative(renderedFrameIndex);
                 }
                 
-                mRenderingHandler.removeCallbacks(mRenderRunnable);
-                mRenderingHandler.post(mRenderRunnable);
+                mRenderingHandler.removeCallbacks(mRenderRunnable);                
+                mRenderingHandler.postDelayed(mRenderRunnable, 1);
             } else {
                 mLoadingTexture.drawMessage(mLoadingMessage);
 

--- a/alvr/client/android/app/src/main/java/com/polygraphene/alvr/OvrActivity.java
+++ b/alvr/client/android/app/src/main/java/com/polygraphene/alvr/OvrActivity.java
@@ -97,7 +97,6 @@ public class OvrActivity extends Activity {
     EGLContext mEGLContext;
     boolean mVrMode = false;
     float mRefreshRate = 60f;
-    long mPreviousRender = 0;
     String mDashboardURL = null;
     String mLoadingMessage = "";
 
@@ -309,22 +308,14 @@ public class OvrActivity extends Activity {
     private void render() {
         if (mResumed && mScreenSurface != null) {
             if (isConnectedNative()) {
-                long next = checkRenderTiming();
-                if (next > 0) {
-                    mRenderingHandler.postDelayed(mRenderRunnable, next);
-                    return;
-                }
                 long renderedFrameIndex = mDecoderThread.clearAvailable(mStreamSurfaceTexture);
 
                 if (renderedFrameIndex != -1) {
                     renderNative(renderedFrameIndex);
-                    mPreviousRender = System.nanoTime();
-
-                    mRenderingHandler.postDelayed(mRenderRunnable, 5);
-                } else {
-                    mRenderingHandler.removeCallbacks(mRenderRunnable);
-                    mRenderingHandler.postDelayed(mRenderRunnable, 50);
                 }
+                
+                mRenderingHandler.removeCallbacks(mRenderRunnable);
+                mRenderingHandler.post(mRenderRunnable);
             } else {
                 mLoadingTexture.drawMessage(mLoadingMessage);
 
@@ -333,12 +324,6 @@ public class OvrActivity extends Activity {
                 mRenderingHandler.postDelayed(mRenderRunnable, (long)(1f/ mRefreshRate));
             }
         }
-    }
-
-    private long checkRenderTiming() {
-        long current = System.nanoTime();
-        long threshold = (long)(1.0e9 / (double)mRefreshRate - 5.0e6);
-        return TimeUnit.NANOSECONDS.toMillis(threshold - (current - mPreviousRender));
     }
 
     public void onVrModeChanged(boolean enter) {


### PR DESCRIPTION
I'm not entirely sure why the removed code was there in the first place. Best I can understand it seems to schedule the frame render 5ms before the next vsync.

Removing it seems to clear up some extra time for the video encoder. Whereas I can usually push the encoder to 110% resolution at 90fps I can now go up to 125% without a noticeable artifacting (white lines) in game. And 120fps now goes up to 100% instead of 80%.

I have not noticed any downsides to this change yet and neither have a few people from the discord that tested my custom build.

I tested both a direct Handler.post() and a postDelayed of 1ms. There didn't seem to be much of a difference performance wise so I opted for the latter to waste less CPU cycles.