### PR TITLE
session: create `$XDG_CONFIG_HOME/alvr` on linux

### DIFF
--- a/alvr/common/src/commands.rs
+++ b/alvr/common/src/commands.rs
@@ -208,6 +208,15 @@ pub fn get_session_path(base: &Path) -> StrResult<PathBuf> {
     }
 }
 
+#[cfg(target_os = "linux")]
+pub fn maybe_create_alvr_config_directory() -> StrResult {
+    let alvr_dir = trace_none!(dirs::config_dir())?.join("alvr");
+    if !alvr_dir.exists() {
+        trace_err!(fs::create_dir(alvr_dir))?;
+    }
+    Ok(())
+}
+
 /////////////////// firewall //////////////////////
 
 fn netsh_add_rule_command_string(rule_name: &str, program_path: &Path) -> String {

--- a/alvr/common/src/data/legacy_session.rs
+++ b/alvr/common/src/data/legacy_session.rs
@@ -581,6 +581,9 @@ mod manager {
 
     impl SessionManager {
         pub fn new(dir: &Path) -> Self {
+            #[cfg(target_os = "linux")]
+            commands::maybe_create_alvr_config_directory().unwrap();
+
             let session_path = commands::get_session_path(&dir).unwrap();
             let session_desc = match fs::read_to_string(&session_path) {
                 Ok(session_string) => {

--- a/alvr/common/src/data/session.rs
+++ b/alvr/common/src/data/session.rs
@@ -636,6 +636,9 @@ mod manager {
 
     impl SessionManager {
         pub fn new(dir: &Path) -> Self {
+            #[cfg(target_os = "linux")]
+            commands::maybe_create_alvr_config_directory().unwrap();
+
             let session_path = commands::get_session_path(&dir).unwrap();
             let session_desc = match fs::read_to_string(&session_path) {
                 Ok(session_string) => {


### PR DESCRIPTION
Previously, this folder had to be created by the user. This commit fixes
that by automatically creating the folder in the rusty SessionManager.

This will break if the `Settings.cpp` parser is used first but it seems
to work fine for the time being.