### PR TITLE
Support bundled ffmpeg libraries in Linux build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
         run: |
+          sudo apt update
           sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev
           cargo xtask build-ffmpeg-linux
           cd deps/ubuntu/FFmpeg-n4.4 && sudo make install && cd ../../..

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ version = "1.0.0"
 dependencies = [
  "fs_extra",
  "pico-args",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "nalgebra",
  "openvr-driver-sys",
  "parking_lot",
+ "pkg-config",
  "reqwest",
  "serde",
  "serde_json",

--- a/alvr/server/Cargo.toml
+++ b/alvr/server/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["settings-schema_legacy"]
 new_dashboard = ["settings-schema"]
+bundled_ffmpeg = []
 
 [dependencies]
 # Basic utilities
@@ -55,3 +56,5 @@ openvr-driver-sys = { path = "../openvr-driver-sys" }
 bindgen = "0.58"
 cc = { version = "1", features = ["parallel"] }
 walkdir = "2"
+[target.'cfg(unix)'.build-dependencies]
+pkg-config = "0.3.9"

--- a/alvr/server/build.rs
+++ b/alvr/server/build.rs
@@ -1,4 +1,55 @@
+#[cfg(target_os = "linux")]
+use pkg_config;
 use std::{env, path::PathBuf};
+
+// this code must be executed BEFORE the actual cpp build when using bundled ffmpeg,
+// as it adds definitions and include flags
+// but AFTER the build in other cases because linker flags must appear after.
+#[cfg(target_os = "linux")]
+fn do_ffmpeg_pkg_config(build: &mut cc::Build) {
+    let ffmpeg_path = env::var("CARGO_MANIFEST_DIR").unwrap() + "/../../deps/ubuntu/FFmpeg-n4.4/";
+
+    #[cfg(feature = "bundled_ffmpeg")]
+    {
+        for lib in vec!["libavutil", "libavfilter", "libavcodec", "libswscale"] {
+            let path = ffmpeg_path.clone() + lib;
+            env::set_var(
+                "PKG_CONFIG_PATH",
+                env::var("PKG_CONFIG_PATH").map_or(path.clone(), |old| format!("{}:{}", path, old)),
+            );
+        }
+    }
+
+    let pkg = pkg_config::Config::new()
+        .cargo_metadata(cfg!(not(feature = "bundled_ffmpeg")))
+        .to_owned();
+    let avutil = pkg.probe("libavutil").unwrap();
+    let avfilter = pkg.probe("libavfilter").unwrap();
+    let avcodec = pkg.probe("libavcodec").unwrap();
+    let swscale = pkg.probe("libswscale").unwrap();
+
+    if cfg!(feature = "bundled_ffmpeg") {
+        build
+            .define("AVCODEC_MAJOR", avcodec.version.split(".").next().unwrap())
+            .define("AVUTIL_MAJOR", avutil.version.split(".").next().unwrap())
+            .define(
+                "AVFILTER_MAJOR",
+                avfilter.version.split(".").next().unwrap(),
+            )
+            .define("SWSCALE_MAJOR", swscale.version.split(".").next().unwrap());
+
+        build.include(ffmpeg_path);
+
+        // activate dlopen for libav libraries
+        build
+            .define("LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN", None)
+            .define("LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN", None)
+            .define("LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN", None)
+            .define("LIBRARY_LOADER_SWSCALE_LOADER_H_DLOPEN", None);
+
+        println!("cargo:rustc-link-lib=dl");
+    }
+}
 
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
@@ -51,7 +102,13 @@ fn main() {
     // #[cfg(debug_assertions)]
     // build.define("ALVR_DEBUG_LOG", None);
 
+    #[cfg(all(target_os = "linux", feature = "bundled_ffmpeg"))]
+    do_ffmpeg_pkg_config(&mut build);
+
     build.compile("bindings");
+
+    #[cfg(all(target_os = "linux", not(feature = "bundled_ffmpeg")))]
+    do_ffmpeg_pkg_config(&mut build);
 
     bindgen::builder()
         .clang_arg("-xc++")
@@ -68,12 +125,9 @@ fn main() {
     );
     println!("cargo:rustc-link-lib=openvr_api");
 
-    if cfg!(target_os = "linux") {
-        println!("cargo:rustc-link-lib=vulkan");
-        println!("cargo:rustc-link-lib=avutil");
-        println!("cargo:rustc-link-lib=avcodec");
-        println!("cargo:rustc-link-lib=avfilter");
-        println!("cargo:rustc-link-lib=swscale");
+    #[cfg(target_os = "linux")]
+    {
+        pkg_config::Config::new().probe("vulkan").unwrap();
 
         // fail build if there are undefined symbols in final library
         println!("cargo:rustc-cdylib-link-arg=-Wl,--no-undefined");

--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -198,8 +198,8 @@ void CEncoder::Run() {
       fprintf(stderr, "\n\nWe are initalizing Vulkan in CEncoder thread\n\n\n");
 
 #ifdef DEBUG
-      av_log_set_level(AV_LOG_DEBUG);
-      av_log_set_callback(logfn);
+      AVUTIL.av_log_set_level(AV_LOG_DEBUG);
+      AVUTIL.av_log_set_callback(logfn);
 #endif
 
       AVDictionary *d = NULL; // "create" an empty dictionary

--- a/alvr/server/cpp/platform/linux/EncodePipeline.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipeline.cpp
@@ -76,19 +76,19 @@ std::unique_ptr<alvr::EncodePipeline> alvr::EncodePipeline::Create(std::vector<V
 
 alvr::EncodePipeline::~EncodePipeline()
 {
-  avcodec_free_context(&encoder_ctx);
+  AVCODEC.avcodec_free_context(&encoder_ctx);
 }
 
 bool alvr::EncodePipeline::GetEncoded(std::vector<uint8_t> &out)
 {
-  AVPacket * enc_pkt = av_packet_alloc();
-  int err = avcodec_receive_packet(encoder_ctx, enc_pkt);
+  AVPacket * enc_pkt = AVCODEC.av_packet_alloc();
+  int err = AVCODEC.avcodec_receive_packet(encoder_ctx, enc_pkt);
   if (err == AVERROR(EAGAIN)) {
     return false;
   } else if (err) {
     throw alvr::AvException("failed to encode", err);
   }
   filter_NAL(enc_pkt->data, enc_pkt->size, out);
-  av_packet_free(&enc_pkt);
+  AVCODEC.av_packet_free(&enc_pkt);
   return true;
 }

--- a/alvr/server/cpp/platform/linux/EncodePipelineSW.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineSW.cpp
@@ -41,13 +41,13 @@ alvr::EncodePipelineSW::EncodePipelineSW(std::vector<VkFrame>& input_frames, VkF
 
   auto codec_id = ALVR_CODEC(settings.m_codec);
   const char * encoder_name = encoder(codec_id);
-  AVCodec *codec = avcodec_find_encoder_by_name(encoder_name);
+  AVCodec *codec = AVCODEC.avcodec_find_encoder_by_name(encoder_name);
   if (codec == nullptr)
   {
     throw std::runtime_error(std::string("Failed to find encoder ") + encoder_name);
   }
 
-  encoder_ctx = avcodec_alloc_context3(codec);
+  encoder_ctx = AVCODEC.avcodec_alloc_context3(codec);
   if (not encoder_ctx)
   {
     throw std::runtime_error("failed to allocate " + std::string(encoder_name) + " encoder");
@@ -58,14 +58,14 @@ alvr::EncodePipelineSW::EncodePipelineSW(std::vector<VkFrame>& input_frames, VkF
   {
     case ALVR_CODEC_H264:
       encoder_ctx->profile = FF_PROFILE_H264_HIGH;
-      av_dict_set(&opt, "preset", "ultrafast", 0);
-      av_dict_set(&opt, "tune", "zerolatency", 0);
+      AVUTIL.av_dict_set(&opt, "preset", "ultrafast", 0);
+      AVUTIL.av_dict_set(&opt, "tune", "zerolatency", 0);
       encoder_ctx->gop_size = 72;
       break;
     case ALVR_CODEC_H265:
       encoder_ctx->profile = FF_PROFILE_HEVC_MAIN;
-      av_dict_set(&opt, "preset", "ultrafast", 0);
-      av_dict_set(&opt, "tune", "zerolatency", 0);
+      AVUTIL.av_dict_set(&opt, "preset", "ultrafast", 0);
+      AVUTIL.av_dict_set(&opt, "tune", "zerolatency", 0);
       encoder_ctx->gop_size = 72;
       break;
   }
@@ -80,19 +80,19 @@ alvr::EncodePipelineSW::EncodePipelineSW(std::vector<VkFrame>& input_frames, VkF
   encoder_ctx->max_b_frames = 0;
   encoder_ctx->bit_rate = settings.mEncodeBitrateMBs * 1024 * 1024;
 
-  int err = avcodec_open2(encoder_ctx, codec, &opt);
+  int err = AVCODEC.avcodec_open2(encoder_ctx, codec, &opt);
   if (err < 0) {
     throw alvr::AvException("Cannot open video encoder codec:", err);
   }
 
-  transferred_frame = av_frame_alloc();
-  encoder_frame = av_frame_alloc();
+  transferred_frame = AVUTIL.av_frame_alloc();
+  encoder_frame = AVUTIL.av_frame_alloc();
   encoder_frame->width = settings.m_renderWidth;
   encoder_frame->height = settings.m_renderHeight;
   encoder_frame->format = encoder_ctx->pix_fmt;
-  av_frame_get_buffer(encoder_frame, 0);
+  AVUTIL.av_frame_get_buffer(encoder_frame, 0);
 
-  scaler_ctx = sws_getContext(
+  scaler_ctx = SWSCALE.sws_getContext(
           vk_frames[0]->width, vk_frames[0]->height, ((AVHWFramesContext*)vk_frames[0]->hw_frames_ctx->data)->sw_format,
           encoder_ctx->width, encoder_ctx->height, encoder_ctx->pix_fmt,
           SWS_BILINEAR,
@@ -102,18 +102,18 @@ alvr::EncodePipelineSW::EncodePipelineSW(std::vector<VkFrame>& input_frames, VkF
 alvr::EncodePipelineSW::~EncodePipelineSW()
 {
   for (auto &vk_frame: vk_frames)
-    av_frame_free(&vk_frame);
-  av_frame_free(&transferred_frame);
-  av_frame_free(&encoder_frame);
+    AVUTIL.av_frame_free(&vk_frame);
+  AVUTIL.av_frame_free(&transferred_frame);
+  AVUTIL.av_frame_free(&encoder_frame);
 }
 
 void alvr::EncodePipelineSW::PushFrame(uint32_t frame_index, bool idr)
 {
-  int err = av_hwframe_transfer_data(transferred_frame, vk_frames[frame_index], 0);
+  int err = AVUTIL.av_hwframe_transfer_data(transferred_frame, vk_frames[frame_index], 0);
   if (err)
     throw alvr::AvException("av_hwframe_transfer_data", err);
 
-  err = sws_scale(scaler_ctx, transferred_frame->data, transferred_frame->linesize, 0, transferred_frame->height,
+  err = SWSCALE.sws_scale(scaler_ctx, transferred_frame->data, transferred_frame->linesize, 0, transferred_frame->height,
       encoder_frame->data, encoder_frame->linesize);
   if (err == 0)
     throw alvr::AvException("sws_scale failed:", err);
@@ -121,7 +121,7 @@ void alvr::EncodePipelineSW::PushFrame(uint32_t frame_index, bool idr)
   encoder_frame->pict_type = idr ? AV_PICTURE_TYPE_I : AV_PICTURE_TYPE_NONE;
   encoder_frame->pts = std::chrono::steady_clock::now().time_since_epoch().count();
 
-  if ((err = avcodec_send_frame(encoder_ctx, encoder_frame)) < 0) {
+  if ((err = AVCODEC.avcodec_send_frame(encoder_ctx, encoder_frame)) < 0) {
     throw alvr::AvException("avcodec_send_frame failed:", err);
   }
 }

--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
@@ -34,7 +34,7 @@ void set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx)
   AVHWFramesContext *frames_ctx = NULL;
   int err = 0;
 
-  if (!(hw_frames_ref = av_hwframe_ctx_alloc(hw_device_ctx))) {
+  if (!(hw_frames_ref = AVUTIL.av_hwframe_ctx_alloc(hw_device_ctx))) {
     throw std::runtime_error("Failed to create VAAPI frame context.");
   }
   frames_ctx = (AVHWFramesContext *)(hw_frames_ref->data);
@@ -43,15 +43,15 @@ void set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx)
   frames_ctx->width = ctx->width;
   frames_ctx->height = ctx->height;
   frames_ctx->initial_pool_size = 3;
-  if ((err = av_hwframe_ctx_init(hw_frames_ref)) < 0) {
-    av_buffer_unref(&hw_frames_ref);
+  if ((err = AVUTIL.av_hwframe_ctx_init(hw_frames_ref)) < 0) {
+    AVUTIL.av_buffer_unref(&hw_frames_ref);
     throw alvr::AvException("Failed to initialize VAAPI frame context:", err);
   }
-  ctx->hw_frames_ctx = av_buffer_ref(hw_frames_ref);
+  ctx->hw_frames_ctx = AVUTIL.av_buffer_ref(hw_frames_ref);
   if (!ctx->hw_frames_ctx)
     err = AVERROR(ENOMEM);
 
-  av_buffer_unref(&hw_frames_ref);
+  AVUTIL.av_buffer_unref(&hw_frames_ref);
 }
 
 // Map the vulkan frames to corresponding vaapi frames
@@ -62,7 +62,7 @@ std::vector<AVFrame*> map_frames(AVBufferRef *hw_device_ctx, std::vector<alvr::V
 
   auto input_frame_ctx = (AVHWFramesContext*)vk_frame_ctx.ctx->data;
 
-  if (!(hw_frames_ref = av_hwframe_ctx_alloc(hw_device_ctx))) {
+  if (!(hw_frames_ref = AVUTIL.av_hwframe_ctx_alloc(hw_device_ctx))) {
     throw std::runtime_error("Failed to create VAAPI frame context.");
   }
   auto frames_ctx = (AVHWFramesContext *)(hw_frames_ref->data);
@@ -71,22 +71,22 @@ std::vector<AVFrame*> map_frames(AVBufferRef *hw_device_ctx, std::vector<alvr::V
   frames_ctx->width = input_frame_ctx->width;
   frames_ctx->height = input_frame_ctx->height;
   frames_ctx->initial_pool_size = input_frames.size();
-  if ((err = av_hwframe_ctx_init(hw_frames_ref)) < 0) {
-    av_buffer_unref(&hw_frames_ref);
+  if ((err = AVUTIL.av_hwframe_ctx_init(hw_frames_ref)) < 0) {
+    AVUTIL.av_buffer_unref(&hw_frames_ref);
     throw alvr::AvException("Failed to initialize VAAPI frame context:", err);
   }
 
   std::vector<AVFrame*> result(0);
   for (auto& input_frame: input_frames)
   {
-    AVFrame * mapped_frame = av_frame_alloc();
-    av_hwframe_get_buffer(hw_frames_ref, mapped_frame, 0);
+    AVFrame * mapped_frame = AVUTIL.av_frame_alloc();
+    AVUTIL.av_hwframe_get_buffer(hw_frames_ref, mapped_frame, 0);
     auto vk_frame = input_frame.make_av_frame(vk_frame_ctx);
-    av_hwframe_map(mapped_frame, vk_frame.get(), AV_HWFRAME_MAP_READ);
+    AVUTIL.av_hwframe_map(mapped_frame, vk_frame.get(), AV_HWFRAME_MAP_READ);
     result.push_back(mapped_frame);
   }
 
-  av_buffer_unref(&hw_frames_ref);
+  AVUTIL.av_buffer_unref(&hw_frames_ref);
 
   return result;
 }
@@ -105,7 +105,7 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(std::vector<VkFrame>& input_frame
    * The pipeline is simply made of a scale_vaapi object, that does the conversion between formats
    * and the encoder that takes the converted frame and produces packets.
    */
-  int err = av_hwdevice_ctx_create(&hw_ctx, AV_HWDEVICE_TYPE_VAAPI, NULL, NULL, 0);
+  int err = AVUTIL.av_hwdevice_ctx_create(&hw_ctx, AV_HWDEVICE_TYPE_VAAPI, NULL, NULL, 0);
   if (err < 0) {
     throw alvr::AvException("Failed to create a VAAPI device:", err);
   }
@@ -114,13 +114,13 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(std::vector<VkFrame>& input_frame
 
   auto codec_id = ALVR_CODEC(settings.m_codec);
   const char * encoder_name = encoder(codec_id);
-  AVCodec *codec = avcodec_find_encoder_by_name(encoder_name);
+  AVCodec *codec = AVCODEC.avcodec_find_encoder_by_name(encoder_name);
   if (codec == nullptr)
   {
     throw std::runtime_error(std::string("Failed to find encoder ") + encoder_name);
   }
 
-  encoder_ctx = avcodec_alloc_context3(codec);
+  encoder_ctx = AVCODEC.avcodec_alloc_context3(codec);
   if (not encoder_ctx)
   {
     throw std::runtime_error("failed to allocate VAAPI encoder");
@@ -130,11 +130,11 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(std::vector<VkFrame>& input_frame
   {
     case ALVR_CODEC_H264:
       encoder_ctx->profile = FF_PROFILE_H264_MAIN;
-      av_opt_set(encoder_ctx, "rc_mode", "2", 0); //CBR
+      AVUTIL.av_opt_set(encoder_ctx, "rc_mode", "2", 0); //CBR
       break;
     case ALVR_CODEC_H265:
       encoder_ctx->profile = FF_PROFILE_HEVC_MAIN;
-      av_opt_set(encoder_ctx, "rc_mode", "2", 0);
+      AVUTIL.av_opt_set(encoder_ctx, "rc_mode", "2", 0);
       break;
   }
 
@@ -149,59 +149,59 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(std::vector<VkFrame>& input_frame
 
   set_hwframe_ctx(encoder_ctx, hw_ctx);
 
-  err = avcodec_open2(encoder_ctx, codec, NULL);
+  err = AVCODEC.avcodec_open2(encoder_ctx, codec, NULL);
   if (err < 0) {
     throw alvr::AvException("Cannot open video encoder codec:", err);
   }
 
   mapped_frames = map_frames(hw_ctx, input_frames, vk_frame_ctx);
 
-  filter_graph = avfilter_graph_alloc();
+  filter_graph = AVFILTER.avfilter_graph_alloc();
 
-  AVFilterInOut *outputs = avfilter_inout_alloc();
-  AVFilterInOut *inputs = avfilter_inout_alloc();
+  AVFilterInOut *outputs = AVFILTER.avfilter_inout_alloc();
+  AVFilterInOut *inputs = AVFILTER.avfilter_inout_alloc();
 
-  filter_in = avfilter_graph_alloc_filter(filter_graph, avfilter_get_by_name("buffer"), "in");
+  filter_in = AVFILTER.avfilter_graph_alloc_filter(filter_graph, AVFILTER.avfilter_get_by_name("buffer"), "in");
 
-  AVBufferSrcParameters *par = av_buffersrc_parameters_alloc();
+  AVBufferSrcParameters *par = AVFILTER.av_buffersrc_parameters_alloc();
   memset(par, 0, sizeof(*par));
   par->width = mapped_frames[0]->width;
   par->height = mapped_frames[0]->height;
   par->time_base = encoder_ctx->time_base;
   par->format = mapped_frames[0]->format;
-  par->hw_frames_ctx = av_buffer_ref(mapped_frames[0]->hw_frames_ctx);
-  av_buffersrc_parameters_set(filter_in, par);
-  av_free(par);
+  par->hw_frames_ctx = AVUTIL.av_buffer_ref(mapped_frames[0]->hw_frames_ctx);
+  AVFILTER.av_buffersrc_parameters_set(filter_in, par);
+  AVUTIL.av_free(par);
 
-  if ((err = avfilter_graph_create_filter(&filter_out, avfilter_get_by_name("buffersink"), "out", NULL, NULL, filter_graph)))
+  if ((err = AVFILTER.avfilter_graph_create_filter(&filter_out, AVFILTER.avfilter_get_by_name("buffersink"), "out", NULL, NULL, filter_graph)))
   {
     throw alvr::AvException("filter_out creation failed:", err);
   }
 
-  outputs->name = av_strdup("in");
+  outputs->name = AVUTIL.av_strdup("in");
   outputs->filter_ctx = filter_in;
   outputs->pad_idx = 0;
   outputs->next = NULL;
 
-  inputs->name = av_strdup("out");
+  inputs->name = AVUTIL.av_strdup("out");
   inputs->filter_ctx = filter_out;
   inputs->pad_idx = 0;
   inputs->next = NULL;
 
-  if ((err = avfilter_graph_parse_ptr(filter_graph, "scale_vaapi=format=nv12", &inputs, &outputs, NULL)) < 0)
+  if ((err = AVFILTER.avfilter_graph_parse_ptr(filter_graph, "scale_vaapi=format=nv12", &inputs, &outputs, NULL)) < 0)
   {
     throw alvr::AvException("avfilter_graph_parse_ptr failed:", err);
   }
 
-  avfilter_inout_free(&outputs);
-  avfilter_inout_free(&inputs);
+  AVFILTER.avfilter_inout_free(&outputs);
+  AVFILTER.avfilter_inout_free(&inputs);
 
   for (unsigned i = 0 ; i < filter_graph->nb_filters; ++i)
   {
-    filter_graph->filters[i]->hw_device_ctx = av_buffer_ref(hw_ctx);
+    filter_graph->filters[i]->hw_device_ctx = AVUTIL.av_buffer_ref(hw_ctx);
   }
 
-  if ((err = avfilter_graph_config(filter_graph, NULL)))
+  if ((err = AVFILTER.avfilter_graph_config(filter_graph, NULL)))
   {
     throw alvr::AvException("avfilter_graph_config failed:", err);
   }
@@ -209,24 +209,24 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(std::vector<VkFrame>& input_frame
 
 alvr::EncodePipelineVAAPI::~EncodePipelineVAAPI()
 {
-  avfilter_graph_free(&filter_graph);
+  AVFILTER.avfilter_graph_free(&filter_graph);
   for (auto frame: mapped_frames)
   {
-    av_frame_free(&frame);
+    AVUTIL.av_frame_free(&frame);
   }
-  av_buffer_unref(&hw_ctx);
+  AVUTIL.av_buffer_unref(&hw_ctx);
 }
 
 void alvr::EncodePipelineVAAPI::PushFrame(uint32_t frame_index, bool idr)
 {
   assert(frame_index < mapped_frames.size());
-  AVFrame *encoder_frame = av_frame_alloc();
-  int err = av_buffersrc_add_frame_flags(filter_in, mapped_frames[frame_index], AV_BUFFERSRC_FLAG_PUSH | AV_BUFFERSRC_FLAG_KEEP_REF);
+  AVFrame *encoder_frame = AVUTIL.av_frame_alloc();
+  int err = AVFILTER.av_buffersrc_add_frame_flags(filter_in, mapped_frames[frame_index], AV_BUFFERSRC_FLAG_PUSH | AV_BUFFERSRC_FLAG_KEEP_REF);
   if (err != 0)
   {
     throw alvr::AvException("av_buffersrc_add_frame failed", err);
   }
-  err = av_buffersink_get_frame(filter_out, encoder_frame);
+  err = AVFILTER.av_buffersink_get_frame(filter_out, encoder_frame);
   if (err != 0)
   {
     throw alvr::AvException("av_buffersink_get_frame failed", err);
@@ -235,8 +235,8 @@ void alvr::EncodePipelineVAAPI::PushFrame(uint32_t frame_index, bool idr)
   encoder_frame->pict_type = idr ? AV_PICTURE_TYPE_I : AV_PICTURE_TYPE_NONE;
   encoder_frame->pts = std::chrono::steady_clock::now().time_since_epoch().count();
 
-  if ((err = avcodec_send_frame(encoder_ctx, encoder_frame)) < 0) {
+  if ((err = AVCODEC.avcodec_send_frame(encoder_ctx, encoder_frame)) < 0) {
     throw alvr::AvException("avcodec_send_frame failed: ", err);
   }
-  av_frame_unref(encoder_frame);
+  AVUTIL.av_frame_unref(encoder_frame);
 }

--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.h
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.h
@@ -3,13 +3,30 @@
 #include <vulkan/vulkan.hpp>
 #include <memory>
 
-extern "C" struct AVBufferRef;
-extern "C" struct AVDictionary;
-extern "C" struct AVVkFrame;
-extern "C" struct AVFrame;
+#include "generated/avutil_loader.h"
+#include "generated/avcodec_loader.h"
+#include "generated/avfilter_loader.h"
+#include "generated/swscale_loader.h"
 
 namespace alvr
 {
+
+class libav
+{
+public:
+	static libav& instance();
+	avutil m_avutil;
+	avcodec m_avcodec;
+	swscale m_swscale;
+	avfilter m_avfilter;
+private:
+	libav();
+};
+
+#define AVUTIL ::alvr::libav::instance().m_avutil
+#define AVCODEC ::alvr::libav::instance().m_avcodec
+#define SWSCALE ::alvr::libav::instance().m_swscale
+#define AVFILTER ::alvr::libav::instance().m_avfilter
 
 // Utility class to build an exception from an ffmpeg return code.
 // Messages are rarely useful however.

--- a/alvr/server/cpp/platform/linux/generated/avcodec_loader.cpp
+++ b/alvr/server/cpp/platform/linux/generated/avcodec_loader.cpp
@@ -1,0 +1,148 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: alvr/server/generate_library_loader.py .
+
+#include "avcodec_loader.h"
+
+#include <dlfcn.h>
+
+avcodec::avcodec() : loaded_(false) {
+}
+
+avcodec::~avcodec() {
+  CleanUp(loaded_);
+}
+
+bool avcodec::Load(const std::string& library_name) {
+  if (loaded_)
+    return false;
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  library_ = dlopen(library_name.c_str(), RTLD_LAZY);
+  if (!library_)
+    return false;
+#else
+  (void)library_name;
+#endif
+
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  avcodec_alloc_context3 =
+      reinterpret_cast<decltype(this->avcodec_alloc_context3)>(
+          dlsym(library_, "avcodec_alloc_context3"));
+#else
+  avcodec_alloc_context3 = &::avcodec_alloc_context3;
+#endif
+  if (!avcodec_alloc_context3) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  avcodec_find_encoder_by_name =
+      reinterpret_cast<decltype(this->avcodec_find_encoder_by_name)>(
+          dlsym(library_, "avcodec_find_encoder_by_name"));
+#else
+  avcodec_find_encoder_by_name = &::avcodec_find_encoder_by_name;
+#endif
+  if (!avcodec_find_encoder_by_name) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  avcodec_free_context =
+      reinterpret_cast<decltype(this->avcodec_free_context)>(
+          dlsym(library_, "avcodec_free_context"));
+#else
+  avcodec_free_context = &::avcodec_free_context;
+#endif
+  if (!avcodec_free_context) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  avcodec_open2 =
+      reinterpret_cast<decltype(this->avcodec_open2)>(
+          dlsym(library_, "avcodec_open2"));
+#else
+  avcodec_open2 = &::avcodec_open2;
+#endif
+  if (!avcodec_open2) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  avcodec_receive_packet =
+      reinterpret_cast<decltype(this->avcodec_receive_packet)>(
+          dlsym(library_, "avcodec_receive_packet"));
+#else
+  avcodec_receive_packet = &::avcodec_receive_packet;
+#endif
+  if (!avcodec_receive_packet) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  avcodec_send_frame =
+      reinterpret_cast<decltype(this->avcodec_send_frame)>(
+          dlsym(library_, "avcodec_send_frame"));
+#else
+  avcodec_send_frame = &::avcodec_send_frame;
+#endif
+  if (!avcodec_send_frame) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  av_packet_alloc =
+      reinterpret_cast<decltype(this->av_packet_alloc)>(
+          dlsym(library_, "av_packet_alloc"));
+#else
+  av_packet_alloc = &::av_packet_alloc;
+#endif
+  if (!av_packet_alloc) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  av_packet_free =
+      reinterpret_cast<decltype(this->av_packet_free)>(
+          dlsym(library_, "av_packet_free"));
+#else
+  av_packet_free = &::av_packet_free;
+#endif
+  if (!av_packet_free) {
+    CleanUp(true);
+    return false;
+  }
+
+
+  loaded_ = true;
+  return true;
+}
+
+void avcodec::CleanUp(bool unload) {
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  if (unload) {
+    dlclose(library_);
+    library_ = NULL;
+  }
+#else
+  (void)unload;
+#endif
+  loaded_ = false;
+  avcodec_alloc_context3 = NULL;
+  avcodec_find_encoder_by_name = NULL;
+  avcodec_free_context = NULL;
+  avcodec_open2 = NULL;
+  avcodec_receive_packet = NULL;
+  avcodec_send_frame = NULL;
+  av_packet_alloc = NULL;
+  av_packet_free = NULL;
+
+}

--- a/alvr/server/cpp/platform/linux/generated/avcodec_loader.h
+++ b/alvr/server/cpp/platform/linux/generated/avcodec_loader.h
@@ -1,0 +1,49 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: alvr/server/generate_library_loader.py .
+
+#ifndef LIBRARY_LOADER_AVCODEC_LOADER_H
+#define LIBRARY_LOADER_AVCODEC_LOADER_H
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+
+}
+
+
+#include <string>
+
+class avcodec {
+ public:
+  avcodec();
+  ~avcodec();
+
+  bool Load(const std::string& library_name)
+      __attribute__((warn_unused_result));
+
+  bool loaded() const { return loaded_; }
+
+  decltype(&::avcodec_alloc_context3) avcodec_alloc_context3;
+  decltype(&::avcodec_find_encoder_by_name) avcodec_find_encoder_by_name;
+  decltype(&::avcodec_free_context) avcodec_free_context;
+  decltype(&::avcodec_open2) avcodec_open2;
+  decltype(&::avcodec_receive_packet) avcodec_receive_packet;
+  decltype(&::avcodec_send_frame) avcodec_send_frame;
+  decltype(&::av_packet_alloc) av_packet_alloc;
+  decltype(&::av_packet_free) av_packet_free;
+
+
+ private:
+  void CleanUp(bool unload);
+
+#if defined(LIBRARY_LOADER_AVCODEC_LOADER_H_DLOPEN)
+  void* library_;
+#endif
+
+  bool loaded_;
+
+  // Disallow copy constructor and assignment operator.
+  avcodec(const avcodec&);
+  void operator=(const avcodec&);
+};
+
+#endif  // LIBRARY_LOADER_AVCODEC_LOADER_H

--- a/alvr/server/cpp/platform/linux/generated/avfilter_loader.cpp
+++ b/alvr/server/cpp/platform/linux/generated/avfilter_loader.cpp
@@ -1,0 +1,213 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: alvr/server/generate_library_loader.py .
+
+#include "avfilter_loader.h"
+
+#include <dlfcn.h>
+
+avfilter::avfilter() : loaded_(false) {
+}
+
+avfilter::~avfilter() {
+  CleanUp(loaded_);
+}
+
+bool avfilter::Load(const std::string& library_name) {
+  if (loaded_)
+    return false;
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  library_ = dlopen(library_name.c_str(), RTLD_LAZY);
+  if (!library_)
+    return false;
+#else
+  (void)library_name;
+#endif
+
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  av_buffersink_get_frame =
+      reinterpret_cast<decltype(this->av_buffersink_get_frame)>(
+          dlsym(library_, "av_buffersink_get_frame"));
+#else
+  av_buffersink_get_frame = &::av_buffersink_get_frame;
+#endif
+  if (!av_buffersink_get_frame) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  av_buffersrc_add_frame_flags =
+      reinterpret_cast<decltype(this->av_buffersrc_add_frame_flags)>(
+          dlsym(library_, "av_buffersrc_add_frame_flags"));
+#else
+  av_buffersrc_add_frame_flags = &::av_buffersrc_add_frame_flags;
+#endif
+  if (!av_buffersrc_add_frame_flags) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  av_buffersrc_parameters_alloc =
+      reinterpret_cast<decltype(this->av_buffersrc_parameters_alloc)>(
+          dlsym(library_, "av_buffersrc_parameters_alloc"));
+#else
+  av_buffersrc_parameters_alloc = &::av_buffersrc_parameters_alloc;
+#endif
+  if (!av_buffersrc_parameters_alloc) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  av_buffersrc_parameters_set =
+      reinterpret_cast<decltype(this->av_buffersrc_parameters_set)>(
+          dlsym(library_, "av_buffersrc_parameters_set"));
+#else
+  av_buffersrc_parameters_set = &::av_buffersrc_parameters_set;
+#endif
+  if (!av_buffersrc_parameters_set) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  avfilter_get_by_name =
+      reinterpret_cast<decltype(this->avfilter_get_by_name)>(
+          dlsym(library_, "avfilter_get_by_name"));
+#else
+  avfilter_get_by_name = &::avfilter_get_by_name;
+#endif
+  if (!avfilter_get_by_name) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  avfilter_graph_alloc =
+      reinterpret_cast<decltype(this->avfilter_graph_alloc)>(
+          dlsym(library_, "avfilter_graph_alloc"));
+#else
+  avfilter_graph_alloc = &::avfilter_graph_alloc;
+#endif
+  if (!avfilter_graph_alloc) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  avfilter_graph_alloc_filter =
+      reinterpret_cast<decltype(this->avfilter_graph_alloc_filter)>(
+          dlsym(library_, "avfilter_graph_alloc_filter"));
+#else
+  avfilter_graph_alloc_filter = &::avfilter_graph_alloc_filter;
+#endif
+  if (!avfilter_graph_alloc_filter) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  avfilter_graph_config =
+      reinterpret_cast<decltype(this->avfilter_graph_config)>(
+          dlsym(library_, "avfilter_graph_config"));
+#else
+  avfilter_graph_config = &::avfilter_graph_config;
+#endif
+  if (!avfilter_graph_config) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  avfilter_graph_create_filter =
+      reinterpret_cast<decltype(this->avfilter_graph_create_filter)>(
+          dlsym(library_, "avfilter_graph_create_filter"));
+#else
+  avfilter_graph_create_filter = &::avfilter_graph_create_filter;
+#endif
+  if (!avfilter_graph_create_filter) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  avfilter_graph_free =
+      reinterpret_cast<decltype(this->avfilter_graph_free)>(
+          dlsym(library_, "avfilter_graph_free"));
+#else
+  avfilter_graph_free = &::avfilter_graph_free;
+#endif
+  if (!avfilter_graph_free) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  avfilter_graph_parse_ptr =
+      reinterpret_cast<decltype(this->avfilter_graph_parse_ptr)>(
+          dlsym(library_, "avfilter_graph_parse_ptr"));
+#else
+  avfilter_graph_parse_ptr = &::avfilter_graph_parse_ptr;
+#endif
+  if (!avfilter_graph_parse_ptr) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  avfilter_inout_alloc =
+      reinterpret_cast<decltype(this->avfilter_inout_alloc)>(
+          dlsym(library_, "avfilter_inout_alloc"));
+#else
+  avfilter_inout_alloc = &::avfilter_inout_alloc;
+#endif
+  if (!avfilter_inout_alloc) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  avfilter_inout_free =
+      reinterpret_cast<decltype(this->avfilter_inout_free)>(
+          dlsym(library_, "avfilter_inout_free"));
+#else
+  avfilter_inout_free = &::avfilter_inout_free;
+#endif
+  if (!avfilter_inout_free) {
+    CleanUp(true);
+    return false;
+  }
+
+
+  loaded_ = true;
+  return true;
+}
+
+void avfilter::CleanUp(bool unload) {
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  if (unload) {
+    dlclose(library_);
+    library_ = NULL;
+  }
+#else
+  (void)unload;
+#endif
+  loaded_ = false;
+  av_buffersink_get_frame = NULL;
+  av_buffersrc_add_frame_flags = NULL;
+  av_buffersrc_parameters_alloc = NULL;
+  av_buffersrc_parameters_set = NULL;
+  avfilter_get_by_name = NULL;
+  avfilter_graph_alloc = NULL;
+  avfilter_graph_alloc_filter = NULL;
+  avfilter_graph_config = NULL;
+  avfilter_graph_create_filter = NULL;
+  avfilter_graph_free = NULL;
+  avfilter_graph_parse_ptr = NULL;
+  avfilter_inout_alloc = NULL;
+  avfilter_inout_free = NULL;
+
+}

--- a/alvr/server/cpp/platform/linux/generated/avfilter_loader.h
+++ b/alvr/server/cpp/platform/linux/generated/avfilter_loader.h
@@ -1,0 +1,57 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: alvr/server/generate_library_loader.py .
+
+#ifndef LIBRARY_LOADER_AVFILTER_LOADER_H
+#define LIBRARY_LOADER_AVFILTER_LOADER_H
+
+extern "C" {
+#include <stdint.h>
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
+#include <libavfilter/avfilter.h>
+
+}
+
+
+#include <string>
+
+class avfilter {
+ public:
+  avfilter();
+  ~avfilter();
+
+  bool Load(const std::string& library_name)
+      __attribute__((warn_unused_result));
+
+  bool loaded() const { return loaded_; }
+
+  decltype(&::av_buffersink_get_frame) av_buffersink_get_frame;
+  decltype(&::av_buffersrc_add_frame_flags) av_buffersrc_add_frame_flags;
+  decltype(&::av_buffersrc_parameters_alloc) av_buffersrc_parameters_alloc;
+  decltype(&::av_buffersrc_parameters_set) av_buffersrc_parameters_set;
+  decltype(&::avfilter_get_by_name) avfilter_get_by_name;
+  decltype(&::avfilter_graph_alloc) avfilter_graph_alloc;
+  decltype(&::avfilter_graph_alloc_filter) avfilter_graph_alloc_filter;
+  decltype(&::avfilter_graph_config) avfilter_graph_config;
+  decltype(&::avfilter_graph_create_filter) avfilter_graph_create_filter;
+  decltype(&::avfilter_graph_free) avfilter_graph_free;
+  decltype(&::avfilter_graph_parse_ptr) avfilter_graph_parse_ptr;
+  decltype(&::avfilter_inout_alloc) avfilter_inout_alloc;
+  decltype(&::avfilter_inout_free) avfilter_inout_free;
+
+
+ private:
+  void CleanUp(bool unload);
+
+#if defined(LIBRARY_LOADER_AVFILTER_LOADER_H_DLOPEN)
+  void* library_;
+#endif
+
+  bool loaded_;
+
+  // Disallow copy constructor and assignment operator.
+  avfilter(const avfilter&);
+  void operator=(const avfilter&);
+};
+
+#endif  // LIBRARY_LOADER_AVFILTER_LOADER_H

--- a/alvr/server/cpp/platform/linux/generated/avutil_loader.cpp
+++ b/alvr/server/cpp/platform/linux/generated/avutil_loader.cpp
@@ -1,0 +1,330 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: alvr/server/generate_library_loader.py .
+
+#include "avutil_loader.h"
+
+#include <dlfcn.h>
+
+avutil::avutil() : loaded_(false) {
+}
+
+avutil::~avutil() {
+  CleanUp(loaded_);
+}
+
+bool avutil::Load(const std::string& library_name) {
+  if (loaded_)
+    return false;
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  library_ = dlopen(library_name.c_str(), RTLD_LAZY);
+  if (!library_)
+    return false;
+#else
+  (void)library_name;
+#endif
+
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_buffer_alloc =
+      reinterpret_cast<decltype(this->av_buffer_alloc)>(
+          dlsym(library_, "av_buffer_alloc"));
+#else
+  av_buffer_alloc = &::av_buffer_alloc;
+#endif
+  if (!av_buffer_alloc) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_buffer_ref =
+      reinterpret_cast<decltype(this->av_buffer_ref)>(
+          dlsym(library_, "av_buffer_ref"));
+#else
+  av_buffer_ref = &::av_buffer_ref;
+#endif
+  if (!av_buffer_ref) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_buffer_unref =
+      reinterpret_cast<decltype(this->av_buffer_unref)>(
+          dlsym(library_, "av_buffer_unref"));
+#else
+  av_buffer_unref = &::av_buffer_unref;
+#endif
+  if (!av_buffer_unref) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_dict_set =
+      reinterpret_cast<decltype(this->av_dict_set)>(
+          dlsym(library_, "av_dict_set"));
+#else
+  av_dict_set = &::av_dict_set;
+#endif
+  if (!av_dict_set) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_frame_alloc =
+      reinterpret_cast<decltype(this->av_frame_alloc)>(
+          dlsym(library_, "av_frame_alloc"));
+#else
+  av_frame_alloc = &::av_frame_alloc;
+#endif
+  if (!av_frame_alloc) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_frame_free =
+      reinterpret_cast<decltype(this->av_frame_free)>(
+          dlsym(library_, "av_frame_free"));
+#else
+  av_frame_free = &::av_frame_free;
+#endif
+  if (!av_frame_free) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_frame_get_buffer =
+      reinterpret_cast<decltype(this->av_frame_get_buffer)>(
+          dlsym(library_, "av_frame_get_buffer"));
+#else
+  av_frame_get_buffer = &::av_frame_get_buffer;
+#endif
+  if (!av_frame_get_buffer) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_frame_unref =
+      reinterpret_cast<decltype(this->av_frame_unref)>(
+          dlsym(library_, "av_frame_unref"));
+#else
+  av_frame_unref = &::av_frame_unref;
+#endif
+  if (!av_frame_unref) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_free =
+      reinterpret_cast<decltype(this->av_free)>(
+          dlsym(library_, "av_free"));
+#else
+  av_free = &::av_free;
+#endif
+  if (!av_free) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_hwdevice_ctx_create =
+      reinterpret_cast<decltype(this->av_hwdevice_ctx_create)>(
+          dlsym(library_, "av_hwdevice_ctx_create"));
+#else
+  av_hwdevice_ctx_create = &::av_hwdevice_ctx_create;
+#endif
+  if (!av_hwdevice_ctx_create) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_hwframe_ctx_alloc =
+      reinterpret_cast<decltype(this->av_hwframe_ctx_alloc)>(
+          dlsym(library_, "av_hwframe_ctx_alloc"));
+#else
+  av_hwframe_ctx_alloc = &::av_hwframe_ctx_alloc;
+#endif
+  if (!av_hwframe_ctx_alloc) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_hwframe_ctx_init =
+      reinterpret_cast<decltype(this->av_hwframe_ctx_init)>(
+          dlsym(library_, "av_hwframe_ctx_init"));
+#else
+  av_hwframe_ctx_init = &::av_hwframe_ctx_init;
+#endif
+  if (!av_hwframe_ctx_init) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_hwframe_get_buffer =
+      reinterpret_cast<decltype(this->av_hwframe_get_buffer)>(
+          dlsym(library_, "av_hwframe_get_buffer"));
+#else
+  av_hwframe_get_buffer = &::av_hwframe_get_buffer;
+#endif
+  if (!av_hwframe_get_buffer) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_hwframe_map =
+      reinterpret_cast<decltype(this->av_hwframe_map)>(
+          dlsym(library_, "av_hwframe_map"));
+#else
+  av_hwframe_map = &::av_hwframe_map;
+#endif
+  if (!av_hwframe_map) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_hwframe_transfer_data =
+      reinterpret_cast<decltype(this->av_hwframe_transfer_data)>(
+          dlsym(library_, "av_hwframe_transfer_data"));
+#else
+  av_hwframe_transfer_data = &::av_hwframe_transfer_data;
+#endif
+  if (!av_hwframe_transfer_data) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_log_set_callback =
+      reinterpret_cast<decltype(this->av_log_set_callback)>(
+          dlsym(library_, "av_log_set_callback"));
+#else
+  av_log_set_callback = &::av_log_set_callback;
+#endif
+  if (!av_log_set_callback) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_log_set_level =
+      reinterpret_cast<decltype(this->av_log_set_level)>(
+          dlsym(library_, "av_log_set_level"));
+#else
+  av_log_set_level = &::av_log_set_level;
+#endif
+  if (!av_log_set_level) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_opt_set =
+      reinterpret_cast<decltype(this->av_opt_set)>(
+          dlsym(library_, "av_opt_set"));
+#else
+  av_opt_set = &::av_opt_set;
+#endif
+  if (!av_opt_set) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_strdup =
+      reinterpret_cast<decltype(this->av_strdup)>(
+          dlsym(library_, "av_strdup"));
+#else
+  av_strdup = &::av_strdup;
+#endif
+  if (!av_strdup) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_strerror =
+      reinterpret_cast<decltype(this->av_strerror)>(
+          dlsym(library_, "av_strerror"));
+#else
+  av_strerror = &::av_strerror;
+#endif
+  if (!av_strerror) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_vkfmt_from_pixfmt =
+      reinterpret_cast<decltype(this->av_vkfmt_from_pixfmt)>(
+          dlsym(library_, "av_vkfmt_from_pixfmt"));
+#else
+  av_vkfmt_from_pixfmt = &::av_vkfmt_from_pixfmt;
+#endif
+  if (!av_vkfmt_from_pixfmt) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  av_vk_frame_alloc =
+      reinterpret_cast<decltype(this->av_vk_frame_alloc)>(
+          dlsym(library_, "av_vk_frame_alloc"));
+#else
+  av_vk_frame_alloc = &::av_vk_frame_alloc;
+#endif
+  if (!av_vk_frame_alloc) {
+    CleanUp(true);
+    return false;
+  }
+
+
+  loaded_ = true;
+  return true;
+}
+
+void avutil::CleanUp(bool unload) {
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  if (unload) {
+    dlclose(library_);
+    library_ = NULL;
+  }
+#else
+  (void)unload;
+#endif
+  loaded_ = false;
+  av_buffer_alloc = NULL;
+  av_buffer_ref = NULL;
+  av_buffer_unref = NULL;
+  av_dict_set = NULL;
+  av_frame_alloc = NULL;
+  av_frame_free = NULL;
+  av_frame_get_buffer = NULL;
+  av_frame_unref = NULL;
+  av_free = NULL;
+  av_hwdevice_ctx_create = NULL;
+  av_hwframe_ctx_alloc = NULL;
+  av_hwframe_ctx_init = NULL;
+  av_hwframe_get_buffer = NULL;
+  av_hwframe_map = NULL;
+  av_hwframe_transfer_data = NULL;
+  av_log_set_callback = NULL;
+  av_log_set_level = NULL;
+  av_opt_set = NULL;
+  av_strdup = NULL;
+  av_strerror = NULL;
+  av_vkfmt_from_pixfmt = NULL;
+  av_vk_frame_alloc = NULL;
+
+}

--- a/alvr/server/cpp/platform/linux/generated/avutil_loader.h
+++ b/alvr/server/cpp/platform/linux/generated/avutil_loader.h
@@ -1,0 +1,68 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: alvr/server/generate_library_loader.py .
+
+#ifndef LIBRARY_LOADER_AVUTIL_LOADER_H
+#define LIBRARY_LOADER_AVUTIL_LOADER_H
+
+extern "C" {
+#include <stdint.h>
+#include <libavutil/avutil.h>
+#include <libavutil/dict.h>
+#include <libavutil/opt.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_vulkan.h>
+
+}
+
+
+#include <string>
+
+class avutil {
+ public:
+  avutil();
+  ~avutil();
+
+  bool Load(const std::string& library_name)
+      __attribute__((warn_unused_result));
+
+  bool loaded() const { return loaded_; }
+
+  decltype(&::av_buffer_alloc) av_buffer_alloc;
+  decltype(&::av_buffer_ref) av_buffer_ref;
+  decltype(&::av_buffer_unref) av_buffer_unref;
+  decltype(&::av_dict_set) av_dict_set;
+  decltype(&::av_frame_alloc) av_frame_alloc;
+  decltype(&::av_frame_free) av_frame_free;
+  decltype(&::av_frame_get_buffer) av_frame_get_buffer;
+  decltype(&::av_frame_unref) av_frame_unref;
+  decltype(&::av_free) av_free;
+  decltype(&::av_hwdevice_ctx_create) av_hwdevice_ctx_create;
+  decltype(&::av_hwframe_ctx_alloc) av_hwframe_ctx_alloc;
+  decltype(&::av_hwframe_ctx_init) av_hwframe_ctx_init;
+  decltype(&::av_hwframe_get_buffer) av_hwframe_get_buffer;
+  decltype(&::av_hwframe_map) av_hwframe_map;
+  decltype(&::av_hwframe_transfer_data) av_hwframe_transfer_data;
+  decltype(&::av_log_set_callback) av_log_set_callback;
+  decltype(&::av_log_set_level) av_log_set_level;
+  decltype(&::av_opt_set) av_opt_set;
+  decltype(&::av_strdup) av_strdup;
+  decltype(&::av_strerror) av_strerror;
+  decltype(&::av_vkfmt_from_pixfmt) av_vkfmt_from_pixfmt;
+  decltype(&::av_vk_frame_alloc) av_vk_frame_alloc;
+
+
+ private:
+  void CleanUp(bool unload);
+
+#if defined(LIBRARY_LOADER_AVUTIL_LOADER_H_DLOPEN)
+  void* library_;
+#endif
+
+  bool loaded_;
+
+  // Disallow copy constructor and assignment operator.
+  avutil(const avutil&);
+  void operator=(const avutil&);
+};
+
+#endif  // LIBRARY_LOADER_AVUTIL_LOADER_H

--- a/alvr/server/cpp/platform/linux/generated/swscale_loader.cpp
+++ b/alvr/server/cpp/platform/linux/generated/swscale_loader.cpp
@@ -1,0 +1,70 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: alvr/server/generate_library_loader.py .
+
+#include "swscale_loader.h"
+
+#include <dlfcn.h>
+
+swscale::swscale() : loaded_(false) {
+}
+
+swscale::~swscale() {
+  CleanUp(loaded_);
+}
+
+bool swscale::Load(const std::string& library_name) {
+  if (loaded_)
+    return false;
+
+#if defined(LIBRARY_LOADER_SWSCALE_LOADER_H_DLOPEN)
+  library_ = dlopen(library_name.c_str(), RTLD_LAZY);
+  if (!library_)
+    return false;
+#else
+  (void)library_name;
+#endif
+
+
+#if defined(LIBRARY_LOADER_SWSCALE_LOADER_H_DLOPEN)
+  sws_getContext =
+      reinterpret_cast<decltype(this->sws_getContext)>(
+          dlsym(library_, "sws_getContext"));
+#else
+  sws_getContext = &::sws_getContext;
+#endif
+  if (!sws_getContext) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_SWSCALE_LOADER_H_DLOPEN)
+  sws_scale =
+      reinterpret_cast<decltype(this->sws_scale)>(
+          dlsym(library_, "sws_scale"));
+#else
+  sws_scale = &::sws_scale;
+#endif
+  if (!sws_scale) {
+    CleanUp(true);
+    return false;
+  }
+
+
+  loaded_ = true;
+  return true;
+}
+
+void swscale::CleanUp(bool unload) {
+#if defined(LIBRARY_LOADER_SWSCALE_LOADER_H_DLOPEN)
+  if (unload) {
+    dlclose(library_);
+    library_ = NULL;
+  }
+#else
+  (void)unload;
+#endif
+  loaded_ = false;
+  sws_getContext = NULL;
+  sws_scale = NULL;
+
+}

--- a/alvr/server/cpp/platform/linux/generated/swscale_loader.h
+++ b/alvr/server/cpp/platform/linux/generated/swscale_loader.h
@@ -1,0 +1,43 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: alvr/server/generate_library_loader.py .
+
+#ifndef LIBRARY_LOADER_SWSCALE_LOADER_H
+#define LIBRARY_LOADER_SWSCALE_LOADER_H
+
+extern "C" {
+#include <libswscale/swscale.h>
+
+}
+
+
+#include <string>
+
+class swscale {
+ public:
+  swscale();
+  ~swscale();
+
+  bool Load(const std::string& library_name)
+      __attribute__((warn_unused_result));
+
+  bool loaded() const { return loaded_; }
+
+  decltype(&::sws_getContext) sws_getContext;
+  decltype(&::sws_scale) sws_scale;
+
+
+ private:
+  void CleanUp(bool unload);
+
+#if defined(LIBRARY_LOADER_SWSCALE_LOADER_H_DLOPEN)
+  void* library_;
+#endif
+
+  bool loaded_;
+
+  // Disallow copy constructor and assignment operator.
+  swscale(const swscale&);
+  void operator=(const swscale&);
+};
+
+#endif  // LIBRARY_LOADER_SWSCALE_LOADER_H

--- a/alvr/server/gen_loader.sh
+++ b/alvr/server/gen_loader.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+mkdir -p cpp/platform/linux/generated
+
+./generate_library_loader.py \
+	--name avutil \
+	--output-cc cpp/platform/linux/generated/avutil_loader.cpp \
+	--output-h cpp/platform/linux/generated/avutil_loader.h \
+	--header '<stdint.h>
+#include <libavutil/avutil.h>
+#include <libavutil/dict.h>
+#include <libavutil/opt.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_vulkan.h>' \
+	--use-extern-c \
+	av_buffer_alloc av_buffer_ref av_buffer_unref av_dict_set av_frame_alloc av_frame_free av_frame_get_buffer av_frame_unref av_free av_hwdevice_ctx_create av_hwframe_ctx_alloc av_hwframe_ctx_init av_hwframe_get_buffer av_hwframe_map av_hwframe_transfer_data av_log_set_callback av_log_set_level av_opt_set av_strdup av_strerror av_vkfmt_from_pixfmt av_vk_frame_alloc
+
+./generate_library_loader.py \
+	--name avcodec \
+	--output-cc cpp/platform/linux/generated/avcodec_loader.cpp \
+	--output-h cpp/platform/linux/generated/avcodec_loader.h \
+	--header '<libavcodec/avcodec.h>' \
+	--use-extern-c \
+	avcodec_alloc_context3 avcodec_find_encoder_by_name avcodec_free_context avcodec_open2 avcodec_receive_packet avcodec_send_frame av_packet_alloc av_packet_free
+
+./generate_library_loader.py \
+	--name avfilter \
+	--output-cc cpp/platform/linux/generated/avfilter_loader.cpp \
+	--output-h cpp/platform/linux/generated/avfilter_loader.h \
+	--header '<stdint.h>
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
+#include <libavfilter/avfilter.h>' \
+	--use-extern-c \
+	av_buffersink_get_frame av_buffersrc_add_frame_flags av_buffersrc_parameters_alloc av_buffersrc_parameters_set avfilter_get_by_name avfilter_graph_alloc avfilter_graph_alloc_filter avfilter_graph_config avfilter_graph_create_filter avfilter_graph_free avfilter_graph_parse_ptr avfilter_inout_alloc avfilter_inout_free
+
+./generate_library_loader.py \
+	--name swscale \
+	--output-cc cpp/platform/linux/generated/swscale_loader.cpp \
+	--output-h cpp/platform/linux/generated/swscale_loader.h \
+	--header '<libswscale/swscale.h>' \
+	--use-extern-c \
+	sws_getContext sws_scale

--- a/alvr/server/generate_library_loader.py
+++ b/alvr/server/generate_library_loader.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+Creates a library loader (a header and implementation file),
+which is a wrapper for dlopen or direct linking with given library.
+
+The loader makes it possible to have the same client code for both cases,
+and also makes it easier to write code using dlopen (and also provides
+a standard way to do so, and limits the ugliness just to generated files).
+
+For more info refer to http://crbug.com/162733 .
+"""
+
+
+import optparse
+import os.path
+import re
+import sys
+
+
+HEADER_TEMPLATE = """// This is generated file. Do not modify directly.
+// Path to the code generator: %(generator_path)s .
+
+#ifndef %(unique_prefix)s
+#define %(unique_prefix)s
+
+%(wrapped_header_include)s
+
+#include <string>
+
+class %(class_name)s {
+ public:
+  %(class_name)s();
+  ~%(class_name)s();
+
+  bool Load(const std::string& library_name)
+      __attribute__((warn_unused_result));
+
+  bool loaded() const { return loaded_; }
+
+%(member_decls)s
+
+ private:
+  void CleanUp(bool unload);
+
+#if defined(%(unique_prefix)s_DLOPEN)
+  void* library_;
+#endif
+
+  bool loaded_;
+
+  // Disallow copy constructor and assignment operator.
+  %(class_name)s(const %(class_name)s&);
+  void operator=(const %(class_name)s&);
+};
+
+#endif  // %(unique_prefix)s
+"""
+
+
+HEADER_MEMBER_TEMPLATE = """  decltype(&::%(function_name)s) %(function_name)s;
+"""
+
+
+IMPL_TEMPLATE = """// This is generated file. Do not modify directly.
+// Path to the code generator: %(generator_path)s .
+
+#include "%(generated_header_name)s"
+
+#include <dlfcn.h>
+
+%(class_name)s::%(class_name)s() : loaded_(false) {
+}
+
+%(class_name)s::~%(class_name)s() {
+  CleanUp(loaded_);
+}
+
+bool %(class_name)s::Load(const std::string& library_name) {
+  if (loaded_)
+    return false;
+
+#if defined(%(unique_prefix)s_DLOPEN)
+  library_ = dlopen(library_name.c_str(), RTLD_LAZY);
+  if (!library_)
+    return false;
+#else
+  (void)library_name;
+#endif
+
+%(member_init)s
+
+  loaded_ = true;
+  return true;
+}
+
+void %(class_name)s::CleanUp(bool unload) {
+#if defined(%(unique_prefix)s_DLOPEN)
+  if (unload) {
+    dlclose(library_);
+    library_ = NULL;
+  }
+#else
+  (void)unload;
+#endif
+  loaded_ = false;
+%(member_cleanup)s
+}
+"""
+
+IMPL_MEMBER_INIT_TEMPLATE = """
+#if defined(%(unique_prefix)s_DLOPEN)
+  %(function_name)s =
+      reinterpret_cast<decltype(this->%(function_name)s)>(
+          dlsym(library_, "%(function_name)s"));
+#else
+  %(function_name)s = &::%(function_name)s;
+#endif
+  if (!%(function_name)s) {
+    CleanUp(true);
+    return false;
+  }
+"""
+
+IMPL_MEMBER_CLEANUP_TEMPLATE = """  %(function_name)s = NULL;
+"""
+
+def main():
+  parser = optparse.OptionParser()
+  parser.add_option('--name')
+  parser.add_option('--output-cc')
+  parser.add_option('--output-h')
+  parser.add_option('--header')
+
+  parser.add_option('--bundled-header')
+  parser.add_option('--use-extern-c', action='store_true', default=False)
+  parser.add_option('--link-directly', type=int, default=1)
+
+  options, args = parser.parse_args()
+
+  if not options.name:
+    parser.error('Missing --name parameter')
+  if not options.output_cc:
+    parser.error('Missing --output-cc parameter')
+  if not options.output_h:
+    parser.error('Missing --output-h parameter')
+  if not options.header:
+    parser.error('Missing --header paramater')
+  if not args:
+    parser.error('No function names specified')
+
+  if os.path.dirname(options.output_cc) != os.path.dirname(options.output_h):
+    parser.error('--output-cc and --output-h must be in same directory')
+
+  # Create a unique prefix, e.g. for header guards.
+  # Stick a known string at the beginning to ensure this doesn't begin
+  # with an underscore, which is reserved for the C++ implementation.
+  unique_prefix = (
+      'LIBRARY_LOADER_' +
+      re.sub(r'[\W]', '_', os.path.basename(options.output_h)).upper())
+
+  member_decls = []
+  member_init = []
+  member_cleanup = []
+  for fn in args:
+    member_decls.append(HEADER_MEMBER_TEMPLATE % {
+      'function_name': fn,
+      'unique_prefix': unique_prefix
+    })
+    member_init.append(IMPL_MEMBER_INIT_TEMPLATE % {
+      'function_name': fn,
+      'unique_prefix': unique_prefix
+    })
+    member_cleanup.append(IMPL_MEMBER_CLEANUP_TEMPLATE % {
+      'function_name': fn,
+      'unique_prefix': unique_prefix
+    })
+
+  header = options.header
+  if options.link_directly == 0 and options.bundled_header:
+    header = options.bundled_header
+  wrapped_header_include = '#include %s\n' % header
+
+  # Some libraries (e.g. libpci) have headers that cannot be included
+  # without extern "C", otherwise they cause the link to fail.
+  # TODO(phajdan.jr): This is a workaround for broken headers. Remove it.
+  if options.use_extern_c:
+    wrapped_header_include = 'extern "C" {\n%s\n}\n' % wrapped_header_include
+
+  # It seems cleaner just to have a single #define here and #ifdefs in bunch
+  # of places, rather than having a different set of templates, duplicating
+  # or complicating more code.
+  if options.link_directly == 0:
+    wrapped_header_include += '#define %s_DLOPEN\n' % unique_prefix
+  elif options.link_directly == 1:
+    pass
+  else:
+    parser.error('Invalid value for --link-directly. Should be 0 or 1.')
+
+  # Make it easier for people to find the code generator just in case.
+  # Doing it this way is more maintainable, because it's going to work
+  # even if file gets moved without updating the contents.
+  source_tree_root = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..'))
+  generator_path = os.path.relpath(__file__, source_tree_root)
+
+  header_contents = HEADER_TEMPLATE % {
+    'generator_path': generator_path,
+    'unique_prefix': unique_prefix,
+    'wrapped_header_include': wrapped_header_include,
+    'class_name': options.name,
+    'member_decls': ''.join(member_decls),
+  }
+
+  impl_contents = IMPL_TEMPLATE % {
+    'generator_path': generator_path,
+    'unique_prefix': unique_prefix,
+    'generated_header_name': os.path.basename(options.output_h),
+    'class_name': options.name,
+    'member_init': ''.join(member_init),
+    'member_cleanup': ''.join(member_cleanup),
+  }
+
+  header_file = open(options.output_h, 'w')
+  try:
+    header_file.write(header_contents)
+  finally:
+    header_file.close()
+
+  impl_file = open(options.output_cc, 'w')
+  try:
+    impl_file.write(impl_contents)
+  finally:
+    impl_file.close()
+
+  return 0
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/alvr/xtask/Cargo.toml
+++ b/alvr/xtask/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 [dependencies]
 fs_extra = "1"
 pico-args = "0.4"
+walkdir = "2"

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -78,15 +78,17 @@ fn build_rust_android_gradle() {
     fs::remove_dir_all(temp_build_dir).ok();
 }
 
-pub fn build_ffmpeg_linux() {
+pub fn build_ffmpeg_linux() -> std::path::PathBuf {
     // dependencies: build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev
 
     let download_path = deps_dir().join("ubuntu");
-    download_and_extract_zip(
-        "https://codeload.github.com/FFmpeg/FFmpeg/zip/n4.4",
-        &download_path,
-    );
     let ffmpeg_path = download_path.join("FFmpeg-n4.4");
+    if !ffmpeg_path.exists() {
+        download_and_extract_zip(
+            "https://codeload.github.com/FFmpeg/FFmpeg/zip/n4.4",
+            &download_path,
+        );
+    }
 
     bash_in(
         &ffmpeg_path,
@@ -112,6 +114,8 @@ pub fn build_ffmpeg_linux() {
     )
     .unwrap();
     bash_in(&ffmpeg_path, "make -j$(nproc)").unwrap();
+
+    ffmpeg_path
 }
 
 pub fn build_deps(target_os: &str) {


### PR DESCRIPTION
ALVR server requires some specific features in libavutil that are not
currently common in usual distributions, mainly vulkan support.

We add a new flag to the build-server xtask: bundle-ffmpeg, this will
download and compile ffmpeg with the required flags.

In server code, a generated wrapper is used to allow loading through
dlopen in case of bundled libraries or standard dynamic linking for the
general case. The link mode is selected at compile time using the
bundled-ffmpeg feature flag.