### PR TITLE
rework compositor wrapper mechanism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ members = [
     "alvr/server",
     "alvr/dashboard",
     "alvr/launcher",
+    "alvr/vrcompositor-wrapper",
     "alvr/vulkan-layer",
 ]

--- a/alvr/launcher/res/vrcompositor_launcher_wrapper.sh
+++ b/alvr/launcher/res/vrcompositor_launcher_wrapper.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-
-export VK_LAYER_PATH=$(cat $XDG_RUNTIME_DIR/alvr_dir.txt)/share/vulkan/explicit_layer.d
-export VK_INSTANCE_LAYERS=VK_LAYER_ALVR_capture
-export DISABLE_VK_LAYER_VALVE_steam_fossilize_1=1
-
-exec "$0".real "$@"

--- a/alvr/vrcompositor-wrapper/Cargo.toml
+++ b/alvr/vrcompositor-wrapper/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "vrcompositor-wrapper"
+version = "15.2.1"
+authors = ["alvr-org", "Patrick Nicolas <patricknicolas@laposte.net>"]
+license = "MIT"
+edition = "2018"
+
+[dependencies]
+exec = "0.3.1"

--- a/alvr/vrcompositor-wrapper/src/main.rs
+++ b/alvr/vrcompositor-wrapper/src/main.rs
@@ -1,0 +1,18 @@
+fn main() {
+    let argv0 = std::env::args().next().unwrap();
+    // location of the ALVR vulkan layer manifest
+    let layer_path = match std::fs::read_link(&argv0) {
+        Ok(path) => path
+            .parent()
+            .unwrap()
+            .join("../../share/vulkan/explicit_layer.d"),
+        Err(err) => panic!("Failed to read vrcompositor symlink: {}", err),
+    };
+    std::env::set_var("VK_LAYER_PATH", layer_path);
+    std::env::set_var("VK_INSTANCE_LAYERS", "VK_LAYER_ALVR_capture");
+    // fossilize breaks the ALVR vulkan layer
+    std::env::set_var("DISABLE_VK_LAYER_VALVE_steam_fossilize_1", "1");
+
+    let err = exec::execvp(argv0 + ".real", std::env::args());
+    println!("Failed to run vrcompositor {}", err);
+}

--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -177,6 +177,24 @@ pub fn build_server(
         }
     }
 
+    #[cfg(target_os = "linux")]
+    {
+        command::run_in(
+            &workspace_dir().join("alvr/vrcompositor-wrapper"),
+            &format!("cargo build {}", build_flag),
+        )
+        .unwrap();
+        fs::create_dir_all(server_build_dir().join("libexec").join("alvr")).unwrap();
+        fs::copy(
+            artifacts_dir.join("vrcompositor-wrapper"),
+            server_build_dir()
+                .join("libexec")
+                .join("alvr")
+                .join("vrcompositor-wrapper"),
+        )
+        .unwrap();
+    }
+
     command::run_in(
         &workspace_dir().join("alvr/server"),
         &format!(


### PR DESCRIPTION
A wrapper is required to inject the ALVR vulkan layer.
For minimal interference, we want the layer to only be present in
vrcompositor process.
We have 2 possible targets: vrcompositor-launcher and vrcompositor, the
first one must have cap_sys_nice=eip, and the second one must retain the
`vrcompositor` name (argv[0]).
Using a shell script is not possible because it can't have the
capability or retain the name when using exec, an ELF is required. It is
better to replace vrcompositor, so there won't be a prompt to fix
capabilities on each run and we can simply rewrite the wrapper on each
execution.