### PR TITLE
Skip BT Gampads in updateHapticsState

### DIFF
--- a/alvr/client/android/app/src/main/cpp/ovr_context.cpp
+++ b/alvr/client/android/app/src/main/cpp/ovr_context.cpp
@@ -712,6 +712,7 @@ void updateHapticsState() {
 
     for (uint32_t deviceIndex = 0;
          vrapi_EnumerateInputDevices(g_ctx.Ovr, deviceIndex, &curCaps) >= 0; deviceIndex++) {
+        if (curCaps.Type == ovrControllerType_Gamepad) continue;
         ovrInputTrackedRemoteCapabilities remoteCapabilities;
 
         remoteCapabilities.Header = curCaps;


### PR DESCRIPTION
Client was crashing on server connection whenever I had a Bluetooth gamepad connected.

Found I could prevent this crash by skipping gamepads in the updateHapticsState enumeration.