### PR TITLE
Explicitly enable extractNativeLibs

### DIFF
--- a/alvr/client/android/app/src/main/AndroidManifest.xml
+++ b/alvr/client/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:extractNativeLibs="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
 


### PR DESCRIPTION
Some relatively recent update to Gradle appears to have changed the default value for android:extractNativeLibs to 'false' (where not explicitly specified). This causes the client APK install to fail. This edit sets it to 'true' in the app manifest.