### PR TITLE
Use total latency for tracking prediction

### DIFF
--- a/alvr/client/android/app/src/main/cpp/latency_collector.cpp
+++ b/alvr/client/android/app/src/main/cpp/latency_collector.cpp
@@ -47,6 +47,8 @@ void LatencyCollector::submit(uint64_t frameIndex) {
     FrameTimestamp timestamp = getFrame(frameIndex);
     timestamp.submit = getTimestampUs();
 
+	m_LatencyTotal = timestamp.submit - timestamp.tracking;
+
     uint64_t latency[3];
     latency[0] = timestamp.submit - timestamp.tracking;
     latency[1] = timestamp.receivedLast - timestamp.estimatedSent;
@@ -165,6 +167,10 @@ uint64_t LatencyCollector::getFecFailureInSecond() {
 }
 uint32_t LatencyCollector::getFramesInSecond() {
     return m_framesPrevious;
+}
+
+uint64_t LatencyCollector::getLatencyTotal() {
+    return m_LatencyTotal;
 }
 
 LatencyCollector &LatencyCollector::Instance() {

--- a/alvr/client/android/app/src/main/cpp/latency_collector.h
+++ b/alvr/client/android/app/src/main/cpp/latency_collector.h
@@ -8,6 +8,7 @@ class LatencyCollector {
 public:
     static LatencyCollector &Instance();
 
+    uint64_t getLatencyTotal();
     uint64_t getLatency(uint32_t i, uint32_t j);
     uint64_t getPacketsLostTotal();
     uint64_t getPacketsLostInSecond();
@@ -64,6 +65,8 @@ private:
     uint64_t m_FecFailureTotal = 0;
     uint64_t m_FecFailureInSecond = 0;
     uint64_t m_FecFailurePrevious = 0;
+	
+    uint64_t m_LatencyTotal = 0;
 
     // Total/Transport/Decode latency
     // Total/Max/Min/Count

--- a/alvr/client/android/app/src/main/cpp/ovr_context.cpp
+++ b/alvr/client/android/app/src/main/cpp/ovr_context.cpp
@@ -527,7 +527,7 @@ void sendTrackingInfo(bool clientsidePrediction) {
     frame->frameIndex = g_ctx.FrameIndex;
     frame->fetchTime = getTimestampUs();
 
-    frame->displayTime = vrapi_GetPredictedDisplayTime(g_ctx.Ovr, g_ctx.FrameIndex);
+    frame->displayTime = vrapi_GetTimeInSeconds() + LatencyCollector::Instance().getLatencyTotal() * 1e-6;
     frame->tracking = vrapi_GetPredictedTracking2(g_ctx.Ovr, frame->displayTime);
 
     {


### PR DESCRIPTION
Cherry-picked from #695.
<hr>

Correct timing for tracking prediction of the headset and controllers. Seems to work best with ExtraLatencyMode off. Unstable if latency is too high.