### PR TITLE
v16 protocol updates

### DIFF
--- a/alvr/common/src/data/packets.rs
+++ b/alvr/common/src/data/packets.rs
@@ -49,6 +49,7 @@ pub struct ClientConfigPacket {
     pub fps: f32,
     pub game_audio_sample_rate: u32,
     pub reserved: String,
+    pub server_version: Option<Version>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -74,6 +75,7 @@ pub enum ClientControlPacket {
     PlayspaceSync(PlayspaceSyncPacket),
     RequestIdr,
     KeepAlive,
+    StreamReady,
     Reserved(String),
     ReservedBuffer(Vec<u8>),
 }


### PR DESCRIPTION
Closes #513.

This change removes some of the cruft introduced in the minor releases
since the initial v15 release.