### PR TITLE
Fix #768: Add alvr::VkContext::dispatch::getVkHeaderVersion()

### DIFF
--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.h
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.h
@@ -46,6 +46,7 @@ public:
   struct dispatch
   {
     PFN_vkImportSemaphoreFdKHR vkImportSemaphoreFdKHR;
+    int getVkHeaderVersion() const { return VK_HEADER_VERSION; }
   };
 
   VkContext(const char* device, AVDictionary* opt = nullptr);


### PR DESCRIPTION
No need to downgrade vulkan-headers on Arch. Everything compiles fine now. 

Newer vulkan-headers added a runtime version check, but ALVR hadn't implemented a version getter method, so the check couldn't be compiled. This PR adds the method that was missing.

Let me know if this code should be moved. Not sure if it's OK to add the implementation in the header file even though it's so simple.

