### PR TITLE
Controller tracking fix

### DIFF
--- a/alvr/client/android/app/src/main/cpp/latency_collector.cpp
+++ b/alvr/client/android/app/src/main/cpp/latency_collector.cpp
@@ -19,7 +19,7 @@ LatencyCollector::FrameTimestamp &LatencyCollector::getFrame(uint64_t frameIndex
 }
 
 void LatencyCollector::setTotalLatency(uint32_t latency) {
-    if (latency < 5e5)
+    if (latency < 2e5)
         m_ServerTotalLatency = latency * 0.05 + m_ServerTotalLatency * 0.95;
 }
 void LatencyCollector::tracking(uint64_t frameIndex) {

--- a/alvr/client/android/app/src/main/cpp/ovr_context.cpp
+++ b/alvr/client/android/app/src/main/cpp/ovr_context.cpp
@@ -34,7 +34,7 @@ using namespace gl_render_utils;
 
 const chrono::duration<float> MENU_BUTTON_LONG_PRESS_DURATION = 5s;
 const uint32_t ovrButton_Unknown1 = 0x01000000;
-const int MAXIMUM_TRACKING_FRAMES = 180;
+const int MAXIMUM_TRACKING_FRAMES = 360;
 
 struct TrackingFrame {
     ovrTracking2 tracking;


### PR DESCRIPTION
In some cases high latency causes controller tracking to stop
I don't know if lowering the latency prediction limit is necessary, increasing the tracking frames might be enough