### PR TITLE
alvr_server/Logger: fix regression in #798

### DIFF
--- a/alvr/server/cpp/alvr_server/Logger.cpp
+++ b/alvr/server/cpp/alvr_server/Logger.cpp
@@ -9,8 +9,8 @@ void _log(const char *format, va_list args, void (*logFn)(const char *))
 {
 	char buf[1024];
 	int count = vsnprintf(buf, sizeof(buf), format, args);
-	if (count > sizeof(buf))
-		count = sizeof(buf);
+	if (count > (int)sizeof(buf))
+		count = (int)sizeof(buf);
 	if (count > 0 && buf[count - 1] == '\n')
 		buf[count - 1] = '\0';
 


### PR DESCRIPTION
```
warning: cpp/alvr_server/Logger.cpp: In function ‘void _log(const char*, __va_list_tag*, void (*)(const char*))’:
warning: cpp/alvr_server/Logger.cpp:12:12: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
warning:    12 |  if (count > sizeof(buf))
warning:       |      ~~~~~~^~~~~~~~~~~~~
```