### PR TITLE
Nvidia linux. Add encoder nvenc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,10 +43,9 @@ jobs:
           RUST_BACKTRACE: 1
         run: |
           sudo apt update
-          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev
+          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libgtk-3-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit
           cargo xtask build-ffmpeg-linux
           cd deps/linux/FFmpeg-n4.4 && sudo make install && cd ../../..
-          sudo apt install build-essential pkg-config cmake libasound2-dev libgtk-3-dev libvulkan-dev libunwind-dev
 
       - name: Build crates
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libgtk-3-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit
+          cp packaging/deb/cuda.pc /usr/share/pkgconfig
           cargo xtask build-ffmpeg-linux
           cd deps/linux/FFmpeg-n4.4 && sudo make install && cd ../../..
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,9 +944,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b2f5d0ee456f3928812dfc8c6d9a1d592b98678f6d56db9b0cd2b7bc6c8db5"
+checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
 dependencies = [
  "bytes",
  "memchr",
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c3fd473b3a903a62609e413ed7538f99e10b665ecb502b5e481a95283f8ab4"
+checksum = "5d04dafd11240188e146b6f6476a898004cace3be31d4ec5e08e216bf4947ac0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2297,6 +2297,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -2609,12 +2615,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -3047,9 +3053,9 @@ checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "naga"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4419062f8aa39fb25938169486341945758679e260ddbc1f94bfd1f33924dc2"
+checksum = "1dfa3912b150e6bfb38a7e94d3f53b950a456a905bb8858590af02006e2e78be"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -3524,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
  "alvr_filesystem",
  "fs_extra",
  "pico-args",
+ "pkg-config",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4198,15 +4198,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4e0a76dc12a116108933f6301b95e83634e0c47b0afbed6abbaa0601e99258"
+checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
@@ -4233,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00a731f4b606602a1683ae0a1289a59497c39075fb6dc56ce9ec9251ef48b89"
+checksum = "2c7433068977c56619bf2b7831da26eb986d0645fe56f2ad9357eda7ae4c435e"
 dependencies = [
  "ahash 0.7.6",
  "instant",
@@ -4248,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "rhai_codegen"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14fd9df9de7895cb7e79ba593a9d8eb00a769178476480c26703b97b500a726"
+checksum = "e02d33d76a7aa8ec72ac8298d5b52134fd2dff77445ada0c65f6f8c40d8f2931"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5629,9 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe9cb9c9d728c0f7ea0c309f1b3d5e9d5c7d379890d0a4e3df3103323ff7a84"
+checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
 dependencies = [
  "arrayvec 0.7.2",
  "bitflags",
@@ -5652,9 +5653,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742ec904d0577e1a88b82dba6cf0347c12197cd664b859b05f868bceb8cfff4d"
+checksum = "92e33cb9c380dd1166f316dfc511ad9646f72cf2deb47e90bd714db3617a6998"
 dependencies = [
  "arrayvec 0.7.2",
  "ash",

--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -249,7 +249,10 @@ void CEncoder::Run() {
         }
 
         encoded_data.clear();
-        while (encode_pipeline->GetEncoded(encoded_data)) {}
+        // Encoders can req more then once frame, need to accumulate more data before sending it to the client
+        if (!encode_pipeline->GetEncoded(encoded_data)) {
+          continue;
+        }
 
         m_listener->SendVideo(encoded_data.data(), encoded_data.size(), m_poseSubmitIndex + Settings::Instance().m_trackingFrameOffset);
 

--- a/alvr/server/cpp/platform/linux/EncodePipeline.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipeline.cpp
@@ -4,6 +4,7 @@
 #include "alvr_server/Settings.h"
 #include "EncodePipelineSW.h"
 #include "EncodePipelineVAAPI.h"
+#include "EncodePipelineNvEnc.h"
 #include "ffmpeg_helper.h"
 
 extern "C" {
@@ -74,6 +75,12 @@ std::unique_ptr<alvr::EncodePipeline> alvr::EncodePipeline::Create(std::vector<V
   } catch (...)
   {
     Info("failed to create VAAPI encoder");
+  }
+  try {
+    return std::make_unique<alvr::EncodePipelineNvEnc>(input_frames, vk_frame_ctx);
+  } catch (...)
+  {
+    Info("failed to create NvEnc encoder");
   }
   return std::make_unique<alvr::EncodePipelineSW>(input_frames, vk_frame_ctx);
 }

--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -25,6 +25,9 @@ const char *encoder(ALVR_CODEC codec) {
 } // namespace
 alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(std::vector<VkFrame> &input_frames,
                                                VkFrameCtx &vk_frame_ctx) {
+    auto input_frame_ctx = (AVHWFramesContext *)vk_frame_ctx.ctx->data;
+    assert(input_frame_ctx->sw_format == AV_PIX_FMT_BGRA);
+
     int err;
     for (auto &input_frame : input_frames) {
         vk_frames.push_back(input_frame.make_av_frame(vk_frame_ctx).release());

--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -1,0 +1,108 @@
+#include "EncodePipelineNvEnc.h"
+#include "ALVR-common/packet_types.h"
+#include "alvr_server/Settings.h"
+#include "ffmpeg_helper.h"
+#include <chrono>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavutil/opt.h>
+#include <libswscale/swscale.h>
+}
+
+namespace {
+
+const char *encoder(ALVR_CODEC codec) {
+    switch (codec) {
+    case ALVR_CODEC_H264:
+        return "h264_nvenc";
+    case ALVR_CODEC_H265:
+        return "hevc_nvenc";
+    }
+    throw std::runtime_error("invalid codec " + std::to_string(codec));
+}
+
+} // namespace
+alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(std::vector<VkFrame> &input_frames,
+                                               VkFrameCtx &vk_frame_ctx) {
+    int err;
+    for (auto &input_frame : input_frames) {
+        vk_frames.push_back(input_frame.make_av_frame(vk_frame_ctx).release());
+    }
+
+    const auto &settings = Settings::Instance();
+
+    auto codec_id = ALVR_CODEC(settings.m_codec);
+    const char *encoder_name = encoder(codec_id);
+    AVCodec *codec = AVCODEC.avcodec_find_encoder_by_name(encoder_name);
+    if (codec == nullptr) {
+        throw std::runtime_error(std::string("Failed to find encoder ") + encoder_name);
+    }
+
+    encoder_ctx = AVCODEC.avcodec_alloc_context3(codec);
+    if (not encoder_ctx) {
+        throw std::runtime_error("failed to allocate NVEnc encoder");
+    }
+
+    switch (codec_id) {
+    case ALVR_CODEC_H264:
+        AVUTIL.av_opt_set(encoder_ctx, "preset", "llhq", 0);
+        AVUTIL.av_opt_set(encoder_ctx, "zerolatency", "1", 0);
+        break;
+    case ALVR_CODEC_H265:
+        AVUTIL.av_opt_set(encoder_ctx, "preset", "llhq", 0);
+        AVUTIL.av_opt_set(encoder_ctx, "zerolatency", "1", 0);
+        break;
+    }
+
+    /**
+     * We will recieve a frame from HW as AV_PIX_FMT_VULKAN which will converted to AV_PIX_FMT_BGRA
+     * as SW format when we get it from HW.
+     * But NVEnc support only BGR0 format and we easy can just to force it
+     * Because:
+     * AV_PIX_FMT_BGRA - 28  ///< packed BGRA 8:8:8:8, 32bpp, BGRABGRA...
+     * AV_PIX_FMT_BGR0 - 123 ///< packed BGR 8:8:8,    32bpp, BGRXBGRX...   X=unused/undefined
+     *
+     * We just to ignore the alpha channel and it's done
+     */
+    encoder_ctx->pix_fmt = AV_PIX_FMT_BGR0;
+    encoder_ctx->width = settings.m_renderWidth;
+    encoder_ctx->height = settings.m_renderHeight;
+    encoder_ctx->time_base = {std::chrono::steady_clock::period::num,
+                              std::chrono::steady_clock::period::den};
+    encoder_ctx->framerate = AVRational{settings.m_refreshRate, 1};
+    encoder_ctx->sample_aspect_ratio = AVRational{1, 1};
+    encoder_ctx->max_b_frames = 0;
+    encoder_ctx->gop_size = 30;
+    encoder_ctx->bit_rate = settings.mEncodeBitrateMBs * 1000 * 1000;
+
+    err = AVCODEC.avcodec_open2(encoder_ctx, codec, NULL);
+    if (err < 0) {
+        throw alvr::AvException("Cannot open video encoder codec:", err);
+    }
+
+    hw_frame = AVUTIL.av_frame_alloc();
+}
+
+alvr::EncodePipelineNvEnc::~EncodePipelineNvEnc() {
+    for (auto &vk_frame : vk_frames)
+        AVUTIL.av_frame_free(&vk_frame);
+    AVUTIL.av_buffer_unref(&hw_ctx);
+    AVUTIL.av_frame_free(&hw_frame);
+}
+
+void alvr::EncodePipelineNvEnc::PushFrame(uint32_t frame_index, bool idr) {
+    assert(frame_index < vk_frames.size());
+
+    int err = AVUTIL.av_hwframe_transfer_data(hw_frame, vk_frames[frame_index], 0);
+    if (err) {
+        throw alvr::AvException("av_hwframe_transfer_data", err);
+    }
+
+    hw_frame->pict_type = idr ? AV_PICTURE_TYPE_I : AV_PICTURE_TYPE_NONE;
+    hw_frame->pts = std::chrono::steady_clock::now().time_since_epoch().count();
+
+    if ((err = AVCODEC.avcodec_send_frame(encoder_ctx, hw_frame)) < 0) {
+        throw alvr::AvException("avcodec_send_frame failed:", err);
+    }
+}

--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -44,7 +44,7 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(std::vector<VkFrame> &input_frame
 
     encoder_ctx = AVCODEC.avcodec_alloc_context3(codec);
     if (not encoder_ctx) {
-        throw std::runtime_error("failed to allocate NVEnc encoder");
+        throw std::runtime_error("failed to allocate NvEnc encoder");
     }
 
     switch (codec_id) {

--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.h
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "EncodePipeline.h"
+
+extern "C" struct AVBufferRef;
+extern "C" struct AVCodecContext;
+extern "C" struct AVFrame;
+
+namespace alvr
+{
+
+class EncodePipelineNvEnc: public EncodePipeline
+{
+public:
+  ~EncodePipelineNvEnc();
+  EncodePipelineNvEnc(std::vector<VkFrame> &input_frames, VkFrameCtx& vk_frame_ctx);
+
+  void PushFrame(uint32_t frame_index, bool idr) override;
+
+private:
+  AVBufferRef *hw_ctx = nullptr;
+  std::vector<AVFrame *> vk_frames;
+  AVFrame * hw_frame = nullptr;
+};
+}

--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.h
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include "EncodePipeline.h"
 
 extern "C" struct AVBufferRef;
@@ -19,7 +20,7 @@ public:
 
 private:
   AVBufferRef *hw_ctx = nullptr;
-  std::vector<AVFrame *> vk_frames;
+  std::vector<std::unique_ptr<AVFrame, std::function<void(AVFrame*)>>> vk_frames;
   AVFrame * hw_frame = nullptr;
 };
 }

--- a/alvr/xtask/Cargo.toml
+++ b/alvr/xtask/Cargo.toml
@@ -12,3 +12,4 @@ alvr_filesystem = { path = "../filesystem" }
 fs_extra = "1"
 pico-args = "0.4"
 walkdir = "2"
+pkg-config = "0.3.9"

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -96,7 +96,7 @@ pub fn build_ffmpeg_linux(nvenc_flag: bool) -> std::path::PathBuf {
             "--disable-network",
             "--enable-lto",
             format!(
-                "--disable-everything {} {} {} {} {} {}",
+                "--disable-everything {} {} {} {} {}",
                 /*
                    Describing Nvidia specific options --nvccflags: 
                    nvcc from CUDA toolkit version 11.0 or higher does not support compiling for 'compute_30' (default in ffmpeg)
@@ -106,11 +106,25 @@ pub fn build_ffmpeg_linux(nvenc_flag: bool) -> std::path::PathBuf {
                    Nvidia docs:
                    https://docs.nvidia.com/video-technologies/video-codec-sdk/ffmpeg-with-nvidia-gpu/#commonly-faced-issues-and-tips-to-resolve-them
                 */
-                (if nvenc_flag {"--enable-encoder=h264_nvenc --enable-encoder=hevc_nvenc --enable-nonfree --enable-cuda-nvcc --enable-libnpp --nvccflags=\"-gencode arch=compute_52,code=sm_52 -O2\" --extra-cflags=-I/usr/local/cuda/include/ --extra-ldflags=-L/usr/local/cuda/lib64/"} else {""}),
+                (if nvenc_flag {
+                    let cuda = pkg_config::Config::new().probe("cuda").unwrap();
+                    let include_flags = cuda.include_paths
+                        .iter()
+                        .map(|path| format!("-I{:?}", path))
+                        .reduce(|a, b| { format!("{}{}", a, b) })
+                        .expect("pkg-config cuda entry to have include-paths");
+                    let link_flags = cuda.link_paths
+                        .iter()
+                        .map(|path| format!("-L{:?}", path))
+                        .reduce(|a, b| { format!("{}{}", a, b) })
+                        .expect("pkg-config cuda entry to have link-paths");
+
+                    format!("--enable-encoder=h264_nvenc --enable-encoder=hevc_nvenc --enable-nonfree --enable-cuda-nvcc --enable-libnpp --nvccflags=\"-gencode arch=compute_52,code=sm_52 -O2\" --extra-cflags=\"{}\" --extra-ldflags=\"{}\" --enable-hwaccel=h264_nvenc --enable-hwaccel=hevc_nvenc",
+                            include_flags, link_flags)
+                } else {"".to_string()}),
                 "--enable-encoder=h264_vaapi --enable-encoder=hevc_vaapi",
                 "--enable-encoder=libx264 --enable-encoder=libx264rgb --enable-encoder=libx265",
                 "--enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi",
-                (if nvenc_flag {"--enable-hwaccel=h264_nvenc --enable-hwaccel=hevc_nvenc"} else {""}),
                 "--enable-filter=scale --enable-filter=scale_vaapi",
             ),
             "--enable-libx264 --enable-libx265 --enable-vulkan",

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -106,9 +106,11 @@ pub fn build_ffmpeg_linux(nvenc_flag: bool) -> std::path::PathBuf {
                    Nvidia docs:
                    https://docs.nvidia.com/video-technologies/video-codec-sdk/ffmpeg-with-nvidia-gpu/#commonly-faced-issues-and-tips-to-resolve-them
                 */
+                (if nvenc_flag {"--enable-encoder=h264_nvenc --enable-encoder=hevc_nvenc --enable-nonfree --enable-cuda-nvcc --enable-libnpp --nvccflags=\"-gencode arch=compute_52,code=sm_52 -O2\" --extra-cflags=-I/usr/local/cuda/include/ --extra-ldflags=-L/usr/local/cuda/lib64/"} else {""}),
                 "--enable-encoder=h264_vaapi --enable-encoder=hevc_vaapi",
                 "--enable-encoder=libx264 --enable-encoder=libx264rgb --enable-encoder=libx265",
-                "--enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --enable-hwaccel=h264_nvenc --enable-hwaccel=hevc_nvenc",
+                "--enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi",
+                (if nvenc_flag {"--enable-hwaccel=h264_nvenc --enable-hwaccel=hevc_nvenc"} else {""}),
                 "--enable-filter=scale --enable-filter=scale_vaapi",
             ),
             "--enable-libx264 --enable-libx265 --enable-vulkan",

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -94,10 +94,11 @@ pub fn build_ffmpeg_linux() -> std::path::PathBuf {
             "--disable-network",
             "--enable-lto",
             format!(
-                "--disable-everything {} {} {} {}",
+                "--disable-everything {} {} {} {} {}",
+                "--enable-encoder=h264_nvenc --enable-encoder=hevc_nvenc --enable-nonfree --enable-nvenc --enable-cuda --enable-cuda-nvcc --enable-libnpp --nvccflags=\"-gencode arch=compute_52,code=sm_52 -O2\" --extra-cflags=-I/usr/local/cuda/include/  --extra-ldflags=-L/usr/local/cuda/lib64/",
                 "--enable-encoder=h264_vaapi --enable-encoder=hevc_vaapi",
                 "--enable-encoder=libx264 --enable-encoder=libx264rgb --enable-encoder=libx265",
-                "--enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi",
+                "--enable-hwaccel=h264_vaapi --enable-hwaccel=hevc_vaapi --enable-hwaccel=h264_nvenc --enable-hwaccel=hevc_nvenc",
                 "--enable-filter=scale --enable-filter=scale_vaapi",
             ),
             "--enable-libx264 --enable-libx265 --enable-vulkan",

--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -38,7 +38,7 @@ FLAGS:
     --oculus-quest      Oculus Quest build. Used only for build-client subcommand
     --oculus-go         Oculus Go build. Used only for build-client subcommand
     --bundle-ffmpeg     Bundle ffmpeg libraries. Only used for build-server subcommand on Linux
-    --no-nvidia         Additional flag for build-ffmpeg-linux subcommand. Build don't reqired NVidia libs ffmpeg
+    --no-nvidia         Additional flag for `--bundle-ffmpeg` subcommand. Build don't require NVidia libs FFmpeg related
     --help              Print this text
 
 ARGS:

--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -20,7 +20,7 @@ SUBCOMMANDS:
     build-android-deps  Download and compile external dependencies for Android
     build-server        Build server driver, then copy binaries to build folder
     build-client        Build client, then copy binaries to build folder
-    build-ffmpeg-linux  Build FFmpeg with VAAPI and Vulkan support. Only for CI
+    build-ffmpeg-linux  Build FFmpeg with VAAPI, NVenc and Vulkan support. Only for CI
     publish-server      Build server in release mode, make portable version and installer
     publish-client      Build client for all headsets
     clean               Removes build folder

--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -20,7 +20,7 @@ SUBCOMMANDS:
     build-android-deps  Download and compile external dependencies for Android
     build-server        Build server driver, then copy binaries to build folder
     build-client        Build client, then copy binaries to build folder
-    build-ffmpeg-linux  Build FFmpeg with VAAPI, NVenc and Vulkan support. Only for CI
+    build-ffmpeg-linux  Build FFmpeg with VAAPI, NvEnc and Vulkan support. Only for CI
     publish-server      Build server in release mode, make portable version and installer
     publish-client      Build client for all headsets
     clean               Removes build folder
@@ -38,7 +38,7 @@ FLAGS:
     --oculus-quest      Oculus Quest build. Used only for build-client subcommand
     --oculus-go         Oculus Go build. Used only for build-client subcommand
     --bundle-ffmpeg     Bundle ffmpeg libraries. Only used for build-server subcommand on Linux
-    --no-nvidia         Additional flag for `--bundle-ffmpeg` subcommand. Build don't require NVidia libs FFmpeg related
+    --no-nvidia         Additional flag to use with `build-server`. Disables nVidia support.
     --help              Print this text
 
 ARGS:

--- a/alvr/xtask/src/packaging.rs
+++ b/alvr/xtask/src/packaging.rs
@@ -103,8 +103,9 @@ fn build_windows_installer(wix_path: &str) {
 }
 
 pub fn publish_server(is_nightly: bool, root: Option<String>, reproducible: bool) {
-    build_server(true, false, false, true, false, root, reproducible);
-
+    let bundle_ffmpeg = cfg!(target_os = "linux");
+    build_server(true, false, false, bundle_ffmpeg, false, root, reproducible);
+    
     // Add licenses
     let licenses_dir = afs::server_build_dir().join("licenses");
     fs::create_dir_all(&licenses_dir).unwrap();

--- a/alvr/xtask/src/packaging.rs
+++ b/alvr/xtask/src/packaging.rs
@@ -105,7 +105,7 @@ fn build_windows_installer(wix_path: &str) {
 pub fn publish_server(is_nightly: bool, root: Option<String>, reproducible: bool) {
     let bundle_ffmpeg = cfg!(target_os = "linux");
     build_server(true, false, false, bundle_ffmpeg, false, root, reproducible);
-    
+
     // Add licenses
     let licenses_dir = afs::server_build_dir().join("licenses");
     fs::create_dir_all(&licenses_dir).unwrap();

--- a/alvr/xtask/src/packaging.rs
+++ b/alvr/xtask/src/packaging.rs
@@ -103,7 +103,7 @@ fn build_windows_installer(wix_path: &str) {
 }
 
 pub fn publish_server(is_nightly: bool, root: Option<String>, reproducible: bool) {
-    build_server(true, false, false, false, root, reproducible);
+    build_server(true, false, false, true, false, root, reproducible);
 
     // Add licenses
     let licenses_dir = afs::server_build_dir().join("licenses");

--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -181,7 +181,6 @@ prep_fedora_server() {
     basePackages=(
         'dnf-utils'
         'git'
-        'cmake'
         "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${VERSION_ID}.noarch.rpm"
         "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${VERSION_ID}.noarch.rpm"
     )

--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -181,6 +181,7 @@ prep_fedora_server() {
     basePackages=(
         'dnf-utils'
         'git'
+        'cmake'
         "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${VERSION_ID}.noarch.rpm"
         "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${VERSION_ID}.noarch.rpm"
     )

--- a/packaging/deb/cuda.pc
+++ b/packaging/deb/cuda.pc
@@ -1,0 +1,9 @@
+prefix=/usr/lib/cuda
+includedir=${prefix}/include
+libdir=${prefix}/lib64
+
+Name: cuda
+Description: CUDA Driver Library
+Version: 0.0.0
+Libs: -L${libdir}/stubs -lcuda
+Cflags: -I${includedir}

--- a/packaging/rpm/alvr.spec
+++ b/packaging/rpm/alvr.spec
@@ -6,7 +6,7 @@ License: MIT
 Source: https://github.com/alvr-org/ALVR/archive/refs/tags/v17.0.0-dev.1.tar.gz
 URL: https://github.com/alvr-org/ALVR/
 ExclusiveArch: x86_64
-BuildRequires: alsa-lib-devel cairo-gobject-devel cargo clang-devel ffmpeg-devel gcc gcc-c++ ImageMagick libunwind-devel openssl-devel rpmdevtools rust rust-atk-sys-devel rust-cairo-sys-rs-devel rust-gdk-sys-devel rust-glib-sys-devel rust-pango-sys-devel selinux-policy-devel vulkan-headers vulkan-loader-devel
+BuildRequires: alsa-lib-devel cairo-gobject-devel cargo clang-devel ffmpeg-devel gcc gcc-c++ cmake ImageMagick libunwind-devel openssl-devel rpmdevtools rust rust-atk-sys-devel rust-cairo-sys-rs-devel rust-gdk-sys-devel rust-glib-sys-devel rust-pango-sys-devel selinux-policy-devel vulkan-headers vulkan-loader-devel
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Requires: ffmpeg steam
 Requires(post): policycoreutils

--- a/packaging/rpm/cuda.pc
+++ b/packaging/rpm/cuda.pc
@@ -1,0 +1,9 @@
+prefix=/usr/local/cuda
+includedir=${prefix}/include
+libdir=${prefix}/lib64
+
+Name: cuda
+Description: CUDA Driver Library
+Version: 0.0.0
+Libs: -L${libdir}/stubs -lcuda
+Cflags: -I${includedir}


### PR DESCRIPTION
Added NVenc encoder for Linux.

The current solution is to implement a loop to get the Vulkan frame and copy that through the CPU to the GPU again.
Current latency in my case is in the range of 5-10ms for encoding. But that is already playable quality and latency.

I introduce a new flag `--no-nvidia` to build in dev mode for people with Intel/AMD cards, which is not required to install Nvidia libs to their machines. The flag should pass together with `--bundle-ffmpeg` like example `cargo xtask build-server --bundle-ffmpeg --no-nvidia`. But if you will link to the existing FFmpeg on your machine it's don't need to provide at all, it's only like a modification flag for `--bundle-ffmpeg`.

For devs with Arch need to create a symbolic link from `/opt/cuda` to `/usr/local/cuda` because current scripts are prepared to be built in CI for the final release.

CEncdoder is a change from waiting for an answer to skipping to sending the current frame because nvenc is required more than one frame to encode. And PushFrame returns try_again error till the next frames what it created infinity loop of waiting.

AppImage with nvenc included
[ALVR-x86_64.zip](https://github.com/alvr-org/ALVR/files/7822105/ALVR-x86_64.zip)

![Screenshot from 2022-01-03 21-36-47](https://user-images.githubusercontent.com/2198153/147984606-036330ca-8340-44f2-9de2-8efdfd38549f.png)
