### PR TITLE
Fix for ISSUE-917: Allow Linux Build Script to Run Inside Repository Tree 

### DIFF
--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -26,11 +26,17 @@ rawContentProvider='https://raw.githubusercontent.com'
 # Android NDK version
 ndkVersion=30
 
-# Grab the directory git creates
-repoDir="$(dirname "$(realpath "${0}")")/$(basename "${repo}")"
+# Grab the repository directory
+repoDir="$(dirname "${0}")/../"
+if ! [ -d "${repoDir}/.git" ]; then
+    # Get the absolute directory the script is running in, and add the repo name
+    repoDir="$(dirname "$(realpath "${0}")")/$(basename "${repo}")"
+fi
+
 # Set a temporary working directory
 tmpDir="/tmp/alvr_$(date '+%Y%m%d-%H%M%S')"
 buildDir="${repoDir}/build/alvr_server_linux/"
+
 # Import OS info - provides ${ID}
 . /etc/os-release
 


### PR DESCRIPTION
This adds auto-detection of the script location when it is inside of a repository tree, which fixes issue #917 .