### PR TITLE
Fixed a bug causing copy failures

### DIFF
--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -27,7 +27,7 @@ rawContentProvider='https://raw.githubusercontent.com'
 ndkVersion=30
 
 # Grab the repository directory
-repoDir="$(dirname "${0}")/../"
+repoDir="$(realpath $(dirname "${0}"))/.."
 if ! [ -d "${repoDir}/.git" ]; then
     # Get the absolute directory the script is running in, and add the repo name
     repoDir="$(dirname "$(realpath "${0}")")/$(basename "${repo}")"


### PR DESCRIPTION
This fixes a bug which occurs when the build script attempts to copy / rename the APKs:
```
> Task :app:compileOculusGoStableReleaseJavaWithJavac
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings
BUILD SUCCESSFUL in 25s
33 actionable tasks: 32 executed, 1 up-to-date

Done [2m 26s]

cp: cannot stat 'ALVR/packaging/..//build/alvr_client_oculus_go/*': No such file or directory
cp: cannot stat 'ALVR/packaging/..//build/alvr_client_oculus_quest/*': No such file or directory
2022-01-19 01:23:05 - Info: ALVR client built successfully.
```

This is resolved by making sure an absolute path is given for `${repoDir}`