### PR TITLE
Fix Deb Packaged Builds

### DIFF
--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -8,6 +8,7 @@
 # 5 - ALVR server tarball creation failed
 # 6 - Unable to download Deb control file
 # 7 - Unable to install / upgrade rustup
+# 8 - Unable to create deb
 # 99 - Script run as root
 #
 # Disable warnings about importing snapd
@@ -273,6 +274,9 @@ build_ubuntu_server() {
         'usr/libexec/alvr/'
     )
 
+    # Add debian Package config
+    export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${repoDir}/packaging/deb/cuda.pc"
+
     cd "${repoDir}" > /dev/null || return 4
     # There's no vulkan-enabled ffmpeg afaik
     log info 'Building ALVR server ...'
@@ -315,9 +319,12 @@ build_ubuntu_server() {
     done
 
     log info 'Generating package ...'
-    dpkg-deb --build --root-owner-group "${debTmpDir}"
-    # dpkg-deb puts the resulting file in the top level directory
-    cp "${tmpDir}/alvr_${debVer}.deb" "${HOME}"
+    if dpkg-deb --build --root-owner-group "${debTmpDir}"; then
+        # dpkg-deb puts the resulting file in the top level directory
+        cp "${tmpDir}/alvr_${debVer}.deb" "${HOME}"
+    else
+        log critical 'Unable to create package!' 8
+    fi
 }
 
 # Debian

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -2,9 +2,7 @@ Source: alvr
 Section: games
 Priority: optional
 Maintainer: Trae Santiago <trae32566@gmail.com>
-Depends:
- libx264-dev,
- libx265-dev
+Depends: libx264-dev, libx265-dev
 Build-Depends:
  build-essential,
  imagemagick,
@@ -25,6 +23,7 @@ Build-Depends:
  libxcb-shape0-dev,
  libxcb-xfixes0-dev,
  nasm,
+ nvidia-cuda-toolkit,
  pkg-config,
  unzip,
  yasm


### PR DESCRIPTION
This adds `nvidia-cuda-toolkit` as a build dependency, adds the package config path, and fixes the control file dependency list.