### PR TITLE
Verfix 1

### DIFF
--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -26,13 +26,11 @@ controlFile='packaging/deb/control'
 # Android NDK version
 ndkVersion=30
 
-
 # Set a temporary working directory
 tmpDir="/tmp/alvr_$(date '+%Y%m%d-%H%M%S')"
 
 # Import OS info - provides ${ID}
 . /etc/os-release
-
 
 # Basic logger
 # Logs various types of output with details
@@ -72,6 +70,7 @@ Arguments:
         all                 Prepare and build ALVR client and server
         client              Prepare and build ALVR client
         server              Prepare and build ALVR server
+        clobber             Clobber (clean) the entire build environment and dependencies
     CARGO BUILD DEFAULTS
         Fedora              --release
         Debian-based        --release --bundle-ffmpeg
@@ -182,15 +181,21 @@ main() {
                 log critical "Failed to prepare ${PRETTY_NAME} (${ID}) for ALVR server build!" 3
             fi
         ;;
+        'clobber')
+            log info 'Clobbering build environment ...'
+            rm -rf "${repoDir}/"{'build','deps','target'}
+        ;;
         'all')
             ${0} server "${@:2}"
             ${0} client "${@:2}"
         ;;
         *)
+            log error "Invalid action: ${1}!" NOKILL
             help_docs
         ;;
     esac
 
+    # If there's a failure this will not run by design so we can debug
     rm -rf "${tmpDir}"
 }
 

--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -102,7 +102,7 @@ maybe_clone() {
     # If the repo doesn't exist, or we need a specific version, we should clone
     if ! [ -d "${repoDir}" ] || [ "${kwArgs['--branch']}" != '' ]; then
         log info "Cloning ${repo} into ${repoDir//$(basename "${repo}")} ..."
-        ! git -C "${repoDir//$(basename "${repo}")}" clone -b "${kwArgs['--branch']:-master}" "https://github.com/${repo}.git" && exit 1
+        git -C "${repoDir//$(basename "${repo}")}" clone -b "${kwArgs['--branch']:-master}" "https://github.com/${repo}.git" || exit 1
 
         # If we can, import the version-specific helpers after for compatibility
         for helper in "${repoDir}/packaging/alvr_build_linux_targets/"*'.sh'; do
@@ -122,7 +122,7 @@ main() {
     done
 
     # Create temporary directory if it doesn't exist
-    ! [ -d "${tmpDir}" ] && mkdir "${tmpDir}"
+    [ -d "${tmpDir}" ] || mkdir "${tmpDir}"
 
     # Grab the repository directory
     repoDir="$(realpath "$(dirname "${0}")")/.."
@@ -136,7 +136,7 @@ main() {
     buildDir="${repoDir}/build/alvr_server_linux/"
 
     # We need to clone either way for distro-specific bash functions and deb control file
-    ! maybe_clone && log critical 'Unable to clone repository!' 9
+    maybe_clone || log critical 'Unable to clone repository!' 9
 
     case "${1,,}" in
         'client')

--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -138,7 +138,7 @@ main() {
     buildDir="${repoDir}/build/alvr_server_linux/"
 
     # We need to clone either way for distro-specific bash functions and deb control file
-    ! maybe_clone && log critical 'Unable to clone repository!'
+    ! maybe_clone && log critical 'Unable to clone repository!' 9
 
     case "${1,,}" in
         'client')

--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -82,10 +82,10 @@ Arguments:
         Client              --release
     FLAGS
         --build-only        Only build ALVR package(s)
+        --prep-only         Only prepare system for ALVR package build
         --branch=           Branch to clone
         --client-args=      List of ALL cargo xtask client build arguments
         --server-args=      List of ALL cargo xtask server build arguments
-        --prep-only         Only prepare system for ALVR package build
         --rustup-src=       Source to install rustup from if not found:
             WARNING: This does NOT affect Fedora server builds
             rustup.rs       rustup.rs script        [RUNNING UNREVIEWED ONLINE SCRIPTS IS UNRECOMMENDED]
@@ -111,14 +111,6 @@ maybe_clone() {
             . "${helper}"
         done
     fi
-
-
-    # Get the short hash for this commit AFTER all git stuff
-    shortHash=$(git -C "${repoDir}" rev-parse --short HEAD)
-
-    # If the branch is 'v###' exactly, it's probably a release
-    ! [[ "$(git -C "${repoDir}" branch --show-current)" =~ ^v\d+$ ]] && buildVer="+$(date +%s)+${shortHash}"
-
 }
 
 main() {

--- a/packaging/alvr_build_linux.sh
+++ b/packaging/alvr_build_linux.sh
@@ -105,9 +105,11 @@ maybe_clone() {
         git -C "${repoDir//$(basename "${repo}")}" clone -b "${kwArgs['--branch']:-master}" "https://github.com/${repo}.git" || exit 1
 
         # If we can, import the version-specific helpers after for compatibility
-        for helper in "${repoDir}/packaging/alvr_build_linux_targets/"*'.sh'; do
-            . "${helper}"
-        done
+        if [ -d "${repoDir}/packaging/alvr_build_linux_targets/" ]; then
+            for helper in "${repoDir}/packaging/alvr_build_linux_targets/"*'.sh'; do
+                . "${helper}"
+            done
+        fi
     fi
 }
 

--- a/packaging/alvr_build_linux_targets/debian.sh
+++ b/packaging/alvr_build_linux_targets/debian.sh
@@ -48,7 +48,6 @@ build_debian_server() {
 
     # Create debian-specific version
     debVer="$(grep '^Version' "${tmpDir}/control" | awk '{ print $2 }')"
-    [ "${buildVer}" != '' ] && debVer+="${buildVer}"
 
     debTmpDir="${tmpDir}/alvr_${debVer}"
     newBins=(

--- a/packaging/alvr_build_linux_targets/debian.sh
+++ b/packaging/alvr_build_linux_targets/debian.sh
@@ -71,8 +71,9 @@ build_debian_server() {
     export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${repoDir}/packaging/deb/cuda.pc"
 
     cd "${repoDir}" > /dev/null || return 4
-    # There's no vulkan-enabled ffmpeg in the ubuntu repos afaik
     log info 'Building ALVR server ...'
+    # Cargo does NOT like quotes
+    # shellcheck disable=SC2086
     if cargo xtask build-server ${kwArgs['--server-args']:---release --bundle-ffmpeg}; then
         cd - > /dev/null || return 4
     else

--- a/packaging/alvr_build_linux_targets/debian.sh
+++ b/packaging/alvr_build_linux_targets/debian.sh
@@ -46,7 +46,7 @@ build_debian_server() {
     # Configure the control file if it doesn't exist
     ! [ -f "${tmpDir}/control" ] && transform_control
 
-    # Create debian-specific version
+    # Get version from control so we can use it in the name
     debVer="$(grep '^Version' "${tmpDir}/control" | awk '{ print $2 }')"
 
     debTmpDir="${tmpDir}/alvr_${debVer}"
@@ -98,8 +98,6 @@ build_debian_server() {
     cp "${repoDir}/LICENSE" "${debTmpDir}/usr/share/licenses/alvr/"
     # Copy control and changelog files
     cp "${repoDir}/packaging/deb/changelog" "${tmpDir}/control" "${debTmpDir}/DEBIAN/"
-    # Mangle version to version+<short-hash> AFTER it's copied
-    sed -i "s/^Ver.*/Version: ${debVer}/" "${debTmpDir}/DEBIAN/control"
     cp "${repoDir}/packaging/freedesktop/alvr.desktop" "${debTmpDir}/usr/share/applications/"
     cp "${repoDir}/packaging/firewall/alvr-firewalld.xml" "${debTmpDir}/usr/share/alvr/"
     cp "${repoDir}/packaging/firewall/alvr_fw_config.sh" "${debTmpDir}/usr/libexec/alvr/"

--- a/packaging/alvr_build_linux_targets/debian.sh
+++ b/packaging/alvr_build_linux_targets/debian.sh
@@ -113,6 +113,7 @@ build_debian_server() {
     if dpkg-deb --build --root-owner-group "${debTmpDir}"; then
         # dpkg-deb puts the resulting file in the top level directory
         mv "${tmpDir}/alvr_${debVer}.deb" "${repoDir}/build"
+        rm -rf "${repoDir}/build/alvr_server_linux"
     else
         log critical 'Unable to create package!' 8
     fi

--- a/packaging/alvr_build_linux_targets/debian.sh
+++ b/packaging/alvr_build_linux_targets/debian.sh
@@ -44,7 +44,7 @@ build_debian_client() { build_generic_client "${@}"; }
 # This needs srs error checking
 build_debian_server() {
     # Configure the control file if it doesn't exist
-    ! [ -f "${tmpDir}/control" ] && transform_control
+    [ -f "${tmpDir}/control" ] || transform_control
 
     # Get version from control so we can use it in the name
     debVer="$(grep '^Version' "${tmpDir}/control" | awk '{ print $2 }')"

--- a/packaging/alvr_build_linux_targets/fedora.sh
+++ b/packaging/alvr_build_linux_targets/fedora.sh
@@ -54,6 +54,8 @@ build_fedora_server() {
     else
         log critical 'Failed to build tarball!' 5
     fi
+
+    # Copy and cleanup crap needs to go here
 }
 
 transform_spec() {

--- a/packaging/alvr_build_linux_targets/fedora.sh
+++ b/packaging/alvr_build_linux_targets/fedora.sh
@@ -43,20 +43,13 @@ build_fedora_server() {
     # Don't care if this fails
     mkdir -p "${HOME}/rpmbuild/SOURCES" > /dev/null 2>&1
 
-    # Configure the specfile if it doesn't exist
+    # Configure the specfile if it doesn't exist (ex: if --build-only is used)
     ! [ -f "${tmpDir}/tmp.spec" ] && transform_spec
 
     log info 'Building tarball ...'
     # The relative path at the end here is a rlly bad idea, but where does it live?!
     if tar -czf "${HOME}/rpmbuild/SOURCES/$(spectool "${tmpDir}/tmp.spec" | grep -oP 'v\d+\.\d+\..*\.tar\.gz')" -C "${repoDir}" .; then
-        log info 'Mangling spec file version and building RPMS ...'
-        [ "${buildVer}" != '' ] && sed -i "s/Release:.*/\0${buildVer}/" "${tmpDir}/tmp.spec"
-
-        # Replace build arguments in specfile if needed
-        if [ "${kwArgs['--server-args']}" != '' ]; then
-            sed -i "s/cargo xtask build-server --release/cargo xtask build-server ${kwArgs['--server-args']}/" "${tmpDir}/tmp.spec"
-        fi
-
+        log info 'Building RPMs ...'
         rpmbuild -ba "${tmpDir}/tmp.spec"
     else
         log critical 'Failed to build tarball!' 5
@@ -67,6 +60,11 @@ transform_spec() {
     log info 'Copying spec file ...'
     cp "${repoDir}/${specFile}" "${tmpDir}/tmp.spec"
 
+    # Replace build arguments in specfile if needed
+    log info 'Mangling spec file version ...'
+    if [ "${kwArgs['--server-args']}" != '' ]; then
+        sed -i "s/cargo xtask build-server --release/cargo xtask build-server ${kwArgs['--server-args']}/" "${tmpDir}/tmp.spec"
+    fi
 # Nvidia + CUDA build deps need to be added to the spec, then stripped here if --no-nvidia is use
 #    if [ "${kwArgs['--no-nvidia']}" != '' ]; then
 #        log info 'Removing unused nvidia build dependency ...'

--- a/packaging/alvr_build_linux_targets/fedora.sh
+++ b/packaging/alvr_build_linux_targets/fedora.sh
@@ -41,7 +41,7 @@ build_fedora_client() { build_generic_client "${@}"; }
 
 build_fedora_server() {
     # Don't care if this fails
-    mkdir -p "${HOME}/rpmbuild/SOURCES" > /dev/null 2>&1
+    mkdir -p "${HOME}/rpmbuild/SOURCES" "${repoDir}/build" > /dev/null 2>&1
 
     # Configure the specfile if it doesn't exist (ex: if --build-only is used)
     [ -f "${tmpDir}/tmp.spec" ] || transform_spec

--- a/packaging/alvr_build_linux_targets/fedora.sh
+++ b/packaging/alvr_build_linux_targets/fedora.sh
@@ -47,7 +47,7 @@ build_fedora_server() {
     [ -f "${tmpDir}/tmp.spec" ] || transform_spec
 
     # Get the version and release as array index 0 and 1
-    fedVer=($(grep -P 'Version|Release' "${tmpDir}/tmp.spec" | sed 's/Version: //; s/Release: //'))
+    mapfile -t fedVer < <(grep -P 'Version|Release' "${tmpDir}/tmp.spec" | sed 's/Version: //; s/Release: //'))
 
     # Get the tarball name
     tgzName="$(spectool "${tmpDir}/tmp.spec" | grep -oP 'v\d+\.\d+\..*\.tar\.gz')"

--- a/packaging/alvr_build_linux_targets/fedora.sh
+++ b/packaging/alvr_build_linux_targets/fedora.sh
@@ -57,8 +57,8 @@ build_fedora_server() {
     if tar -czf "${HOME}/rpmbuild/SOURCES/${tgzName}" -C "${repoDir}" .; then
         log info 'Building RPMs ...'
         if rpmbuild -ba "${tmpDir}/tmp.spec"; then
-            mv "${HOME}/rpmbuild/RPMS/x86_64/alvr-${fedVer[0]}-${fedVer[1]}.x86_64.rpm" "${repoDir}/build"
-            mv "${HOME}/rpmbuild/SRPMS/alvr-${fedVer[0]}-${fedVer[1]}.src.rpm" "${repoDir}/build"
+            mv "${HOME}/rpmbuild/RPMS/x86_64/alvr-${fedVer[0]}-${fedVer[1]}.x86_64.rpm" "${repoDir}/build/"
+            mv "${HOME}/rpmbuild/SRPMS/alvr-${fedVer[0]}-${fedVer[1]}.src.rpm" "${repoDir}/build/"
             rm -rf "${HOME}/rpmbuild/SOURCES/${tgzName}" "${HOME}/rpmbuild/BUILD"
         else
             return 4

--- a/packaging/alvr_build_linux_targets/fedora.sh
+++ b/packaging/alvr_build_linux_targets/fedora.sh
@@ -44,7 +44,7 @@ build_fedora_server() {
     mkdir -p "${HOME}/rpmbuild/SOURCES" > /dev/null 2>&1
 
     # Configure the specfile if it doesn't exist (ex: if --build-only is used)
-    ! [ -f "${tmpDir}/tmp.spec" ] && transform_spec
+    [ -f "${tmpDir}/tmp.spec" ] || transform_spec
 
     log info 'Building tarball ...'
     # The relative path at the end here is a rlly bad idea, but where does it live?!

--- a/packaging/alvr_build_linux_targets/generic.sh
+++ b/packaging/alvr_build_linux_targets/generic.sh
@@ -53,7 +53,7 @@ build_generic_client() {
     fi
 
     # Get the version
-    apkVer="-$(grep -P '^version' "${repoDir}/alvr/common/Cargo.toml" | sed -E 's/^version = "(.*)"$/\1/')${buildVer}"
+    apkVer="-$(grep -P '^version' "${repoDir}/alvr/common/Cargo.toml" | sed -E 's/^version = "(.*)"$/\1/')"
 
     log info 'Starting client build ...'
     # no subshell expansion warnings

--- a/packaging/alvr_build_linux_targets/generic.sh
+++ b/packaging/alvr_build_linux_targets/generic.sh
@@ -14,7 +14,7 @@ prep_rustup() {
                 curl -sSf https://sh.rustup.rs | sh
             ;;
             # If the keyword is the value, there was no keyword specified
-            'snap' | '--rustup-src') ! sudo snap install rustup --classic && exit 7 ;;
+            'snap' | '--rustup-src') sudo snap install rustup --classic || return 7 ;;
             *)
                 log critical "Neither Rustup installation nor Rustup source type found; bad source was: ${kwArgs['--rustup-src']}" 7
             ;;
@@ -22,9 +22,8 @@ prep_rustup() {
     fi
 
     log info 'Installing rust nightly ...'
-    if ! rustup install nightly; then
-        return 7
-    fi
+    rustup install nightly || return 7
+    
     # This doesn't necessarily need to succeed, but ideally it will
     rustup default nightly
 }

--- a/packaging/alvr_build_linux_targets/generic.sh
+++ b/packaging/alvr_build_linux_targets/generic.sh
@@ -58,6 +58,8 @@ build_generic_client() {
     log info 'Starting client build ...'
     # no subshell expansion warnings
     cd "${repoDir}" > /dev/null || return 2
+    # Cargo does NOT like quotes
+    # shellcheck disable=SC2086
     if cargo xtask build-android-deps && cargo xtask build-client ${kwArgs['--client-args']:---release}; then
         # Move and rename the files at the top of the build directory
         mv "${repoDir}/build/alvr_client_oculus_go/"* "${repoDir}/build/alvr_client_oculus_go${apkVer}.apk"

--- a/packaging/alvr_build_linux_targets/generic.sh
+++ b/packaging/alvr_build_linux_targets/generic.sh
@@ -23,7 +23,7 @@ prep_rustup() {
 
     log info 'Installing rust nightly ...'
     rustup install nightly || return 7
-    
+
     # This doesn't necessarily need to succeed, but ideally it will
     rustup default nightly
 }
@@ -52,7 +52,7 @@ build_generic_client() {
     fi
 
     # Get the version
-    apkVer="-$(grep -P '^version' "${repoDir}/alvr/common/Cargo.toml" | sed -E 's/^version = "(.*)"$/\1/')"
+    apkVer="_$(grep -P '^version' "${repoDir}/alvr/common/Cargo.toml" | sed -E 's/^version = "(.*)"$/\1/')"
 
     log info 'Starting client build ...'
     # no subshell expansion warnings

--- a/packaging/rpm/alvr.spec
+++ b/packaging/rpm/alvr.spec
@@ -1,14 +1,14 @@
 Name: alvr
 Version: 18.0.0
-Release: 0.0.1dev00
+Release: 0.0.2dev00
 Summary: Stream VR games from your PC to your headset via Wi-Fi
 License: MIT
 Source: https://github.com/alvr-org/ALVR/archive/refs/tags/v18.0.0-dev00.tar.gz
 URL: https://github.com/alvr-org/ALVR/
 ExclusiveArch: x86_64
-BuildRequires: alsa-lib-devel cairo-gobject-devel cargo clang-devel ffmpeg-devel gcc gcc-c++ cmake ImageMagick jack-audio-connection-kit-devel libunwind-devel openssl-devel rpmdevtools rust rust-atk-sys-devel rust-cairo-sys-rs-devel rust-gdk-sys-devel rust-glib-sys-devel rust-pango-sys-devel selinux-policy-devel vulkan-headers vulkan-loader-devel
+BuildRequires: alsa-lib-devel cairo-gobject-devel cargo clang-devel ffmpeg-devel gcc gcc-c++ cmake ImageMagick (jack-audio-connection-kit-devel or pipewire-jack-audio-connection-kit-devel) libunwind-devel openssl-devel rpmdevtools rust rust-atk-sys-devel rust-cairo-sys-rs-devel rust-gdk-sys-devel rust-glib-sys-devel rust-pango-sys-devel selinux-policy-devel vulkan-headers vulkan-loader-devel
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-Requires: ffmpeg jack-audio-connection-kit steam
+Requires: ffmpeg (jack-audio-connection-kit or pipewire-jack-audio-connection-kit) steam
 Requires(post): policycoreutils
 Requires(postun): policycoreutils
 %define alvrBuildDir build/%{name}_server_linux


### PR DESCRIPTION
This PR:
- Adds build clobbering functionality
- Fixes dynamic imports of scripts
- Simplifies error handling and logging logic
- Removes hash and epoch from package names
- Adds automatic distro-specific build build cleanup
- Moves where Fedora builds are produced to /build
- Fixes Fedora build requirements (+release bump)