### PR TITLE
Linux portable build fix

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -91,7 +91,7 @@ jobs:
           RUST_BACKTRACE: 1
         run: |
           cargo xtask prepare-deps --platform windows
-          cargo xtask publish-server --gpl
+          cargo xtask package-server --gpl
           $file = Get-ChildItem -Name .\build\*.exe | Select-Object -f 1
           echo "::set-output name=exe_filename::$file"
 
@@ -234,7 +234,7 @@ jobs:
           ANDROID_HOME: '${{ github.workspace }}\android-sdk'
           ANDROID_SDK_ROOT: '${{ github.workspace }}\android-sdk'
           RUST_BACKTRACE: 1
-        run: cargo xtask publish-client
+        run: cargo xtask package-client
 
       - name: Sign Oculus Quest APK
         uses: r0adkll/sign-android-release@v1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           $versionarg = "${{ github.event.inputs.version }}"
           $versionarg = If ($versionarg.Length -gt 0) { "--version $versionarg" } else { "" }
-          $out = cargo xtask bump-versions $versionarg.split()
+          $out = cargo xtask bump $versionarg.split()
           echo $out
           cargo update -p alvr_common
           echo "::set-output name=version_tag::$(echo $out | sls -CaseSensitive -Pattern '^v.*$')"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -115,45 +115,6 @@ jobs:
           asset_name: alvr_server_windows.zip
           asset_content_type: application/zip
 
-  build_linux_server_portable:
-    runs-on: ubuntu-latest
-    needs: [prepare_release]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ needs.prepare_release.outputs.release_ref }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Build and install dependencies
-        env:
-          RUST_BACKTRACE: 1
-        run: |
-          sudo apt update
-          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libgtk-3-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit
-          cp packaging/deb/cuda.pc /usr/share/pkgconfig
-          cargo xtask prepare-deps --platform linux
-
-      - name: Build and package ALVR (.tar.gz)
-        id: build
-        env:
-          RUST_BACKTRACE: 1
-        run: |
-          cargo xtask package-server --gpl
-
-      - name: Upload portable server for Linux
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/alvr_server_linux.tar.gz
-          asset_name: alvr_server_linux_portable.tar.gz
-          asset_content_type: application/gzip
-
   build_linux_server:
     runs-on: ubuntu-latest
     needs: [prepare_release]
@@ -175,6 +136,7 @@ jobs:
           sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libgtk-3-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit
           cp packaging/deb/cuda.pc /usr/share/pkgconfig
           cargo xtask prepare-deps --platform linux
+          cd deps/linux/FFmpeg-n4.4 && sudo make install && cd ../../..
 
       - name: Build and package ALVR (.tar.gz)
         id: build
@@ -183,7 +145,7 @@ jobs:
         run: |
           cargo xtask package-server
 
-      - name: Upload portable server for Linux
+      - name: Upload server for Linux
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -192,6 +154,23 @@ jobs:
           asset_path: ./build/alvr_server_linux.tar.gz
           asset_name: alvr_server_linux.tar.gz
           asset_content_type: application/gzip
+
+      - name: Build and package ALVR portable (.tar.gz)
+        id: build_portable
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          cargo xtask package-server --gpl
+
+      - name: Upload portable server for Linux
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
+          asset_path: ./build/alvr_server_linux.tar.gz
+          asset_name: alvr_server_linux_portable.tar.gz
+          asset_content_type: application/gzip          
 
   build_android_client:
     # Windows latest has Rust, Android NDK and LLVM already installed.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -132,8 +132,8 @@ jobs:
         env:
           RUST_BACKTRACE: 1
         run: |
-          sudo apt update
-          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libgtk-3-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit
+          sudo apt-get update
+          sudo apt-get install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libgtk-3-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit
           cp packaging/deb/cuda.pc /usr/share/pkgconfig
           cargo xtask prepare-deps --platform linux
           cd deps/linux/ffmpeg && sudo make install && cd ../../..

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -90,7 +90,7 @@ jobs:
           WIX: "wix314-binaries"
           RUST_BACKTRACE: 1
         run: |
-          cargo xtask build-windows-deps
+          cargo xtask prepare-deps --platform windows
           cargo xtask publish-server --gpl
           $file = Get-ChildItem -Name .\build\*.exe | Select-Object -f 1
           echo "::set-output name=exe_filename::$file"
@@ -135,8 +135,7 @@ jobs:
           sudo apt update
           sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libgtk-3-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit
           cp packaging/deb/cuda.pc /usr/share/pkgconfig
-          cargo xtask build-ffmpeg-linux
-          cd deps/linux/FFmpeg-n4.4 && sudo make install && cd ../../..
+          cargo xtask prepare-deps --platform linux
 
       - name: Build and package ALVR (.tar.gz)
         id: build
@@ -175,8 +174,7 @@ jobs:
           sudo apt update
           sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libgtk-3-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit
           cp packaging/deb/cuda.pc /usr/share/pkgconfig
-          cargo xtask build-ffmpeg-linux
-          cd deps/linux/FFmpeg-n4.4 && sudo make install && cd ../../..
+          cargo xtask prepare-deps --platform linux
 
       - name: Build and package ALVR (.tar.gz)
         id: build
@@ -228,7 +226,7 @@ jobs:
       - name: Build dependencies
         env:
           RUST_BACKTRACE: 1
-        run: cargo xtask build-android-deps
+        run: cargo xtask prepare-deps --platform android
 
       - name: Build and package ALVR (.apk)
         id: build

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -143,8 +143,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
         run: |
-          cargo xtask build-server --release --bundle-ffmpeg
-          tar -czvf ./build/alvr_server_linux_portable.tar.gz -C ./build/alvr_server_linux .
+          cargo xtask package-server --gpl
 
       - name: Upload portable server for Linux
         uses: actions/upload-release-asset@v1
@@ -152,7 +151,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/alvr_server_linux_portable.tar.gz
+          asset_path: ./build/alvr_server_linux.tar.gz
           asset_name: alvr_server_linux_portable.tar.gz
           asset_content_type: application/gzip
 
@@ -184,8 +183,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
         run: |
-          cargo xtask build-server --release
-          tar -czvf ./build/alvr_server_linux.tar.gz -C ./build/alvr_server_linux .
+          cargo xtask package-server
 
       - name: Upload portable server for Linux
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -136,7 +136,7 @@ jobs:
           sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libgtk-3-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit
           cp packaging/deb/cuda.pc /usr/share/pkgconfig
           cargo xtask prepare-deps --platform linux
-          cd deps/linux/FFmpeg-n4.4 && sudo make install && cd ../../..
+          cd deps/linux/ffmpeg && sudo make install && cd ../../..
 
       - name: Build and package ALVR (.tar.gz)
         id: build

--- a/alvr/xtask/src/command.rs
+++ b/alvr/xtask/src/command.rs
@@ -140,7 +140,7 @@ pub fn targz(source: &Path) -> Result<(), Box<dyn Error>> {
                 &format!("{}.tar.gz", source.to_string_lossy()),
                 "-C",
                 &source.join("..").to_string_lossy(),
-                source.file_name().unwrap().to_str().unwrap()
+                source.file_name().unwrap().to_str().unwrap(),
             ],
         )
     }

--- a/alvr/xtask/src/command.rs
+++ b/alvr/xtask/src/command.rs
@@ -128,6 +128,24 @@ pub fn unzip(source: &Path, destination: &Path) -> Result<(), Box<dyn Error>> {
     }
 }
 
+pub fn targz(source: &Path) -> Result<(), Box<dyn Error>> {
+    println!("{:?}", source);
+    if cfg!(windows) {
+        Ok(())
+    } else {
+        run_without_shell(
+            "tar",
+            &[
+                "-czvf",
+                &format!("{}.tar.gz", source.to_string_lossy()),
+                "-C",
+                &source.join("..").to_string_lossy(),
+                source.file_name().unwrap().to_str().unwrap()
+            ],
+        )
+    }
+}
+
 pub fn download(url: &str, destination: &Path) -> Result<(), Box<dyn Error>> {
     run_without_shell(
         "curl",

--- a/alvr/xtask/src/packaging.rs
+++ b/alvr/xtask/src/packaging.rs
@@ -135,9 +135,9 @@ pub fn package_server(root: Option<String>, gpl: bool) {
         .ok();
     }
 
-    command::zip(&afs::server_build_dir()).unwrap();
-
     if cfg!(windows) {
+        command::zip(&afs::server_build_dir()).unwrap();
+
         fs::copy(
             afs::target_dir().join("release").join("alvr_server.pdb"),
             afs::build_dir().join("alvr_server.pdb"),
@@ -145,5 +145,7 @@ pub fn package_server(root: Option<String>, gpl: bool) {
         .unwrap();
 
         build_windows_installer();
+    } else {
+        command::targz(&afs::server_build_dir()).unwrap();
     }
 }


### PR DESCRIPTION
- Fixes release workflow (broken due to xtask changes)
- Adds .tar.gz support to `package-server` (only creation, and only on linux)
- Merges `build_linux_server` and `build_linux_server_portable` to avoid building twice.
- The portable build should now include all required libraries