### PR TITLE
Unbreak Linux audio by selecting 48kHz sampling rate if given choice

### DIFF
--- a/alvr/audio/src/lib.rs
+++ b/alvr/audio/src/lib.rs
@@ -3,7 +3,7 @@ use alvr_session::{AudioConfig, AudioDeviceId, LinuxAudioBackend};
 use alvr_sockets::{StreamReceiver, StreamSender};
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    BufferSize, Device, Sample, SampleFormat, StreamConfig,
+    BufferSize, Device, Sample, SampleFormat, SampleRate, StreamConfig,
 };
 use rodio::{OutputStream, Source};
 use std::{
@@ -286,9 +286,18 @@ pub fn get_sample_rate(device: &AudioDevice) -> StrResult<u32> {
             .ok_or_else(enone!())?
     };
 
-    // Assumption: device is in shared mode: this means that there is one and fixed sample rate,
-    // format and channel count
-    Ok(config.min_sample_rate().0)
+    // In theory we should check all configs for a 48000 sample rate.
+    // In practice it seems like most stuff we care about supports one sample rate
+    // or arbitrary ones, and this is enough to unbreak the common Linux desktop
+    // audio setups. Could be revisited later if this ever turns out to matter.
+
+    if config.min_sample_rate().0 <= 48000 && config.max_sample_rate().0 >= 48000 {
+        Ok(48000)
+    } else {
+        // Assumption: device is in shared mode: this means that there is one and fixed sample rate,
+        // format and channel count
+        Ok(config.min_sample_rate().0)
+    }
 }
 
 #[cfg_attr(not(windows), allow(unused_variables))]
@@ -315,7 +324,7 @@ pub async fn record_audio_loop(
             .ok_or_else(enone!())?
     };
 
-    if sample_rate != config.min_sample_rate().0 {
+    if sample_rate < config.min_sample_rate().0 || sample_rate > config.max_sample_rate().0 {
         return fmt_e!("Sample rate not supported");
     }
 
@@ -328,7 +337,7 @@ pub async fn record_audio_loop(
 
     let stream_config = StreamConfig {
         channels: config.channels(),
-        sample_rate: config.min_sample_rate(),
+        sample_rate: SampleRate(sample_rate),
         buffer_size: BufferSize::Default,
     };
 


### PR DESCRIPTION
Surprisingly, the main thing breaking audio support on Linux is that sound servers like PulseAudio support arbitrary sample rates (often all the way down to 1 Hz) and ALVR assumes that it can just select the minimum allowed sampling rate for game audio. This breaks pretty badly, especially as the client code is not designed to handle such unreasonable sample rates. This patch uses 48kHz sampling instead if it's supported and arbitrary sampling rates are allowed - this should be a reasonable choice as modern systems tend to use this internally, including Linux, Android, and even recent Windows versions. Otherwise it keeps the previous behaviour. 

With this patch users still need to use an external program like pavucontrol to route ALVR's audio to and from the correct sources, but other than that it should just work on all common desktop Linux audio setups without the workarounds that were needed before. Note that I can't easily test this on master (don't have a client that works with it) or on other platforms, but it was a totally clean port from v18 and this change is unlikely to cause issues - 48kHz is almost always a safe choice of sample rate and this only changes ALVR's behaviour under very narrow circumstances where the old code was probably broken anyway.