### PR TITLE
Send trackpad touch event from thumb rest

### DIFF
--- a/alvr/server/cpp/alvr_server/OvrController.cpp
+++ b/alvr/server/cpp/alvr_server/OvrController.cpp
@@ -1094,7 +1094,7 @@ bool OvrController::onPoseUpdate(const TrackingInfo::Controller &c) {
                 m_handles[ALVR_INPUT_TRACKPAD_X], c.trackpadPosition.x, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(m_handles[ALVR_INPUT_TRACKPAD_Y], 0, 0.0);
             vr::VRDriverInput()->UpdateBooleanComponent(
-                m_handles[ALVR_INPUT_TRACKPAD_TOUCH], false, 0.0);
+                m_handles[ALVR_INPUT_TRACKPAD_TOUCH],  (c.buttons & ALVR_BUTTON_FLAG(ALVR_INPUT_THUMB_REST_TOUCH)) != 0, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
                 m_handles[ALVR_INPUT_JOYSTICK_X], c.trackpadPosition.x, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(


### PR DESCRIPTION
Just send index trackpad touch event if finger on thumb rest zone on quest 2. 
Checked on mine local build, works as intended (look to right controller trackpad)
![photo_2022-05-29_05-07-30](https://user-images.githubusercontent.com/4980321/170849078-2384c6a6-ea08-4a70-bc24-4db3b940d13d.jpg)
.