### PR TITLE
Enable largeHeap in manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
     <application
         android:extractNativeLibs="true"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:largeHeap="true">
 
         <meta-data
             android:name="com.samsung.android.vr.application.mode"


### PR DESCRIPTION
By default (on quest for a sample) we have 256M heapsize, but with largeHeap=true, we can utilize all 512M heap limit. Its helps to avoiding OutOfMemory crashes with large stream resolutions.  https://developer.android.com/guide/topics/manifest/application-element#largeHeap