### PR TITLE
Retry audio loop when the output audio device is unplugged or switched

### DIFF
--- a/alvr/audio/src/lib.rs
+++ b/alvr/audio/src/lib.rs
@@ -57,7 +57,7 @@ pub struct AudioDevice {
 impl AudioDevice {
     pub fn new(
         linux_backend: Option<LinuxAudioBackend>,
-        id: AudioDeviceId,
+        id: &AudioDeviceId,
         device_type: AudioDeviceType,
     ) -> StrResult<Self> {
         #[cfg(target_os = "linux")]

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -539,7 +539,7 @@ async fn connection_pipeline(headset_info: &HeadsetInfoPacket) -> StrResult {
     });
 
     let game_audio_loop: BoxFuture<_> = if let Switch::Enabled(desc) = settings.audio.game_audio {
-        let device = AudioDevice::new(None, AudioDeviceId::Default, AudioDeviceType::Output)
+        let device = AudioDevice::new(None, &AudioDeviceId::Default, AudioDeviceType::Output)
             .map_err(err!())?;
 
         let game_audio_receiver = stream_socket.subscribe_to_stream(AUDIO).await?;
@@ -555,7 +555,7 @@ async fn connection_pipeline(headset_info: &HeadsetInfoPacket) -> StrResult {
     };
 
     let microphone_loop: BoxFuture<_> = if matches!(settings.audio.microphone, Switch::Enabled(_)) {
-        let device = AudioDevice::new(None, AudioDeviceId::Default, AudioDeviceType::Input)
+        let device = AudioDevice::new(None, &AudioDeviceId::Default, AudioDeviceType::Input)
             .map_err(err!())?;
 
         let microphone_sender = stream_socket.request_stream(AUDIO).await?;

--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -259,7 +259,7 @@ pub unsafe extern "C" fn alvr_resume(
     let preferred_refresh_rate = available_refresh_rates.last().cloned().unwrap_or(60_f32);
 
     let microphone_sample_rate =
-        AudioDevice::new(None, AudioDeviceId::Default, AudioDeviceType::Input)
+        AudioDevice::new(None, &AudioDeviceId::Default, AudioDeviceType::Input)
             .unwrap()
             .input_sample_rate()
             .unwrap();

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -661,8 +661,8 @@ async fn connection_pipeline() -> StrResult {
                 match alvr_audio::record_audio_loop(device, 2, mute_when_streaming, new_sender)
                     .await
                 {
-                    Ok(_) => warn!("Audio Normal exit."),
-                    Err(e) => warn!("Audio Normal exit Failed : {e}"),
+                    Ok(_) => (),
+                    Err(e) => warn!("Audio task exit with error : {e}"),
                 };
 
                 #[cfg(windows)]

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -180,14 +180,14 @@ async fn client_handshake(
     {
         let game_audio_device = AudioDevice::new(
             Some(settings.audio.linux_backend),
-            game_audio_desc.device_id,
+            &game_audio_desc.device_id,
             AudioDeviceType::Output,
         )?;
 
         if let Switch::Enabled(microphone_desc) = settings.audio.microphone {
             let microphone_device = AudioDevice::new(
                 Some(settings.audio.linux_backend),
-                microphone_desc.input_device_id,
+                &microphone_desc.input_device_id,
                 AudioDeviceType::VirtualMicrophoneInput,
             )?;
             #[cfg(not(target_os = "linux"))]
@@ -625,61 +625,77 @@ async fn connection_pipeline() -> StrResult {
 
     unsafe { crate::InitializeStreaming() };
     let _stream_guard = StreamCloseGuard;
-
     let game_audio_loop: BoxFuture<_> = if let Switch::Enabled(desc) = settings.audio.game_audio {
-        let device = AudioDevice::new(
-            Some(settings.audio.linux_backend),
-            desc.device_id,
-            AudioDeviceType::Output,
-        )?;
         let sender = stream_socket.request_stream(AUDIO).await?;
-        let mute_when_streaming = desc.mute_when_streaming;
-
-        Box::pin(async move {
-            #[cfg(windows)]
-            unsafe {
-                let device_id = alvr_audio::get_windows_device_id(&device)?;
-                crate::SetOpenvrProperty(
-                    *HEAD_ID,
-                    crate::to_cpp_openvr_prop(
-                        OpenvrPropertyKey::AudioDefaultPlaybackDeviceId,
-                        OpenvrPropValue::String(device_id),
-                    ),
-                )
-            }
-
-            alvr_audio::record_audio_loop(device, 2, mute_when_streaming, sender).await?;
-
-            #[cfg(windows)]
-            {
-                let default_device = AudioDevice::new(
-                    None,
-                    alvr_session::AudioDeviceId::Default,
+        Box::pin(async move{
+            loop{
+                let device = match AudioDevice::new(
+                    Some(settings.audio.linux_backend),
+                    &desc.device_id,
                     AudioDeviceType::Output,
-                )?;
-                let default_device_id = alvr_audio::get_windows_device_id(&default_device)?;
-
+                ){
+                    Ok(data) => data,
+                    Err(e) => {
+                        warn!("New audio device Failed : {e}");
+                        time::sleep(CONTROL_CONNECT_RETRY_PAUSE).await;
+                        continue;
+                    },                    
+                };
+                let mute_when_streaming = desc.mute_when_streaming;
+    
+                #[cfg(windows)]
                 unsafe {
+                    let device_id = match alvr_audio::get_windows_device_id(&device){
+                        Ok(data) => data,
+                        Err(e) => continue,
+                    };
                     crate::SetOpenvrProperty(
                         *HEAD_ID,
                         crate::to_cpp_openvr_prop(
                             OpenvrPropertyKey::AudioDefaultPlaybackDeviceId,
-                            OpenvrPropValue::String(default_device_id),
+                            OpenvrPropValue::String(device_id),
                         ),
                     )
                 }
+                let new_sender = sender.clone();
+                match alvr_audio::record_audio_loop(device, 2, mute_when_streaming, new_sender).await{
+                        Ok(_) => warn!("Audio Normal exit."),
+                        Err(e) => warn!("Audio Normal exit Failed : {e}"),
+                    };
+    
+                #[cfg(windows)]
+                {
+                    let default_device = match AudioDevice::new(
+                        None,
+                        &alvr_session::AudioDeviceId::Default,
+                        AudioDeviceType::Output,
+                    ){
+                        Ok(data) => data,
+                        Err(_) => continue,                          
+                    };
+                    let default_device_id = match alvr_audio::get_windows_device_id(&default_device){
+                        Ok(data) => data,
+                        Err(_) => continue,                        
+                    };    
+                    unsafe {
+                        crate::SetOpenvrProperty(
+                            *HEAD_ID,
+                            crate::to_cpp_openvr_prop(
+                                OpenvrPropertyKey::AudioDefaultPlaybackDeviceId,
+                                OpenvrPropValue::String(default_device_id),
+                            ),
+                        )
+                    }
+                }
             }
-
-            Ok(())
         })
     } else {
         Box::pin(future::pending())
     };
-
     let microphone_loop: BoxFuture<_> = if let Switch::Enabled(desc) = settings.audio.microphone {
         let input_device = AudioDevice::new(
             Some(settings.audio.linux_backend),
-            desc.input_device_id,
+            &desc.input_device_id,
             AudioDeviceType::VirtualMicrophoneInput,
         )?;
         let receiver = stream_socket.subscribe_to_stream(AUDIO).await?;
@@ -688,7 +704,7 @@ async fn connection_pipeline() -> StrResult {
         {
             let microphone_device = AudioDevice::new(
                 None,
-                desc.output_device_id,
+                &desc.output_device_id,
                 AudioDeviceType::VirtualMicrophoneOutput {
                     matching_input_device_name: input_device.name()?,
                 },

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -627,13 +627,13 @@ async fn connection_pipeline() -> StrResult {
     let _stream_guard = StreamCloseGuard;
     let game_audio_loop: BoxFuture<_> = if let Switch::Enabled(desc) = settings.audio.game_audio {
         let sender = stream_socket.request_stream(AUDIO).await?;
-        Box::pin(async move{
-            loop{
+        Box::pin(async move {
+            loop {
                 let device = match AudioDevice::new(
                     Some(settings.audio.linux_backend),
                     &desc.device_id,
                     AudioDeviceType::Output,
-                ){
+                ) {
                     Ok(data) => data,
                     Err(e) => {
                         warn!("New audio device Failed : {e}");
@@ -647,7 +647,7 @@ async fn connection_pipeline() -> StrResult {
                 unsafe {
                     let device_id = match alvr_audio::get_windows_device_id(&device){
                         Ok(data) => data,
-                        Err(e) => continue,
+                        Err(_) => continue,
                     };
                     crate::SetOpenvrProperty(
                         *HEAD_ID,
@@ -658,10 +658,12 @@ async fn connection_pipeline() -> StrResult {
                     )
                 }
                 let new_sender = sender.clone();
-                match alvr_audio::record_audio_loop(device, 2, mute_when_streaming, new_sender).await{
-                        Ok(_) => warn!("Audio Normal exit."),
-                        Err(e) => warn!("Audio Normal exit Failed : {e}"),
-                    };
+                match alvr_audio::record_audio_loop(device, 2, mute_when_streaming, new_sender)
+                    .await
+                {
+                    Ok(_) => warn!("Audio Normal exit."),
+                    Err(e) => warn!("Audio Normal exit Failed : {e}"),
+                };
     
                 #[cfg(windows)]
                 {
@@ -669,11 +671,12 @@ async fn connection_pipeline() -> StrResult {
                         None,
                         &alvr_session::AudioDeviceId::Default,
                         AudioDeviceType::Output,
-                    ){
+                    ) {
                         Ok(data) => data,
                         Err(_) => continue,                          
                     };
-                    let default_device_id = match alvr_audio::get_windows_device_id(&default_device){
+                    let default_device_id = match alvr_audio::get_windows_device_id(&default_device)
+                    {
                         Ok(data) => data,
                         Err(_) => continue,                        
                     };    

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -639,13 +639,13 @@ async fn connection_pipeline() -> StrResult {
                         warn!("New audio device Failed : {e}");
                         time::sleep(CONTROL_CONNECT_RETRY_PAUSE).await;
                         continue;
-                    },                    
+                    }
                 };
                 let mute_when_streaming = desc.mute_when_streaming;
-    
+
                 #[cfg(windows)]
                 unsafe {
-                    let device_id = match alvr_audio::get_windows_device_id(&device){
+                    let device_id = match alvr_audio::get_windows_device_id(&device) {
                         Ok(data) => data,
                         Err(_) => continue,
                     };
@@ -664,7 +664,7 @@ async fn connection_pipeline() -> StrResult {
                     Ok(_) => warn!("Audio Normal exit."),
                     Err(e) => warn!("Audio Normal exit Failed : {e}"),
                 };
-    
+
                 #[cfg(windows)]
                 {
                     let default_device = match AudioDevice::new(
@@ -673,13 +673,13 @@ async fn connection_pipeline() -> StrResult {
                         AudioDeviceType::Output,
                     ) {
                         Ok(data) => data,
-                        Err(_) => continue,                          
+                        Err(_) => continue,
                     };
                     let default_device_id = match alvr_audio::get_windows_device_id(&default_device)
                     {
                         Ok(data) => data,
-                        Err(_) => continue,                        
-                    };    
+                        Err(_) => continue,
+                    };
                     unsafe {
                         crate::SetOpenvrProperty(
                             *HEAD_ID,

--- a/alvr/sockets/src/stream_socket/mod.rs
+++ b/alvr/sockets/src/stream_socket/mod.rs
@@ -82,7 +82,7 @@ impl<T> SenderBuffer<T> {
         }
     }
 }
-
+#[derive(Clone)]
 pub struct StreamSender<T> {
     stream_id: u16,
     socket: StreamSendSocket,


### PR DESCRIPTION
When the audio output device switched or unplugged on the PC which run the ALVR server,the streaming would be cut off,and then sometimes the alvr in the HMD crashed at the same time. This modify can retry the game_audio_loop in order to avoid this situation.