### PR TITLE
Make ALVR client detect changes of audio devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_audio"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -113,12 +113,12 @@ dependencies = [
  "serde",
  "tokio",
  "widestring 1.0.1",
- "windows",
+ "windows 0.38.0",
 ]
 
 [[package]]
 name = "alvr_client_core"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_audio",
  "alvr_common",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_commands"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_common"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "backtrace",
  "glam",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_events"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_filesystem"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "dirs",
  "once_cell",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_launcher"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_commands",
  "alvr_common",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alcro",
  "alvr_audio",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_data"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_common",
  "alvr_events",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_session"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_common",
  "bytemuck",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_sockets"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_common",
  "alvr_events",
@@ -288,14 +288,14 @@ dependencies = [
 
 [[package]]
 name = "alvr_vrcompositor_wrapper"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "exec",
 ]
 
 [[package]]
 name = "alvr_vulkan_layer"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_filesystem",
  "bindgen 0.60.1",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_xtask"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 dependencies = [
  "alvr_filesystem",
  "pico-args",
@@ -452,9 +452,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -518,7 +518,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap 3.2.8",
+ "clap 3.2.12",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
 dependencies = [
  "atty",
  "bitflags",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.13.5"
-source = "git+https://github.com/RustAudio/cpal#32cee3949b802038bb368c9c408af81650873d80"
+source = "git+https://github.com/RustAudio/cpal#417b7fff6fc2dc5a4e9970cdbff157f70f05a108"
 dependencies = [
  "alsa",
  "core-foundation-sys 0.8.3",
@@ -1000,7 +1000,7 @@ dependencies = [
  "stdweb 0.1.3",
  "thiserror",
  "web-sys",
- "winapi",
+ "windows 0.37.0",
 ]
 
 [[package]]
@@ -1068,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
+checksum = "2ccfd8c0ee4cce11e45b3fd6f9d5e69e0cc62912aa6a0cb1bf4617b0eba5a12f"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1145,7 +1145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.12.1",
+ "hashbrown 0.12.2",
  "lock_api",
  "parking_lot_core 0.9.3",
 ]
@@ -2154,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 
 [[package]]
 name = "headers"
@@ -2261,9 +2261,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2320,7 +2320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.1",
+ "hashbrown 0.12.2",
 ]
 
 [[package]]
@@ -2937,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
@@ -2978,15 +2978,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3016,9 +3016,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
@@ -3471,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3482,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -3780,18 +3780,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2 1.0.40",
  "quote 1.0.20",
@@ -4128,9 +4128,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d80929a3b477bce3a64360ca82bfb361eacce1dcb7b1fb31e8e5e181e37c212"
+checksum = "0b6e19da72a8d75be4d40e4dd4686afca31507f26c3ffdf6bd3073278d9de0a0"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys 0.8.3",
@@ -4309,10 +4309,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -4349,9 +4350,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
@@ -4422,9 +4423,9 @@ checksum = "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
  "base64",
  "byteorder",
@@ -4456,9 +4457,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unic-bidi"
@@ -4576,9 +4577,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9399fa2f927a3d327187cbd201480cee55bee6ac5d3c77dd27f0c6814cff16d5"
+checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
  "base64",
  "chunked_transfer",
@@ -4853,9 +4854,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki",
 ]
@@ -5023,6 +5024,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c47017195a790490df51a3e27f669a7d4f285920d90d03ef970c5d886ef0af1"
@@ -5055,6 +5069,12 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b12add87e2fb192fff3f4f7e4342b3694785d79f3a64e2c20d5ceb5ccbcfc3cd"
@@ -5064,6 +5084,12 @@ name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5079,6 +5105,12 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf0569be0f2863ab6a12a6ba841fcfa7d107cbc7545a3ebd57685330db0a3ff"
@@ -5091,6 +5123,12 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "905858262c8380a36f32cb8c1990d7e7c3b7a8170e58ed9a98ca6d940b7ea9f1"
@@ -5100,6 +5138,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/alvr/audio/Cargo.toml
+++ b/alvr/audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_audio"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/client_core/Cargo.toml
+++ b/alvr/client_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_client_core"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/client_core/src/audio.rs
+++ b/alvr/client_core/src/audio.rs
@@ -1,3 +1,6 @@
+use crate::{
+    IS_RESUMED, AUDIO_INPUT_DEVICE, AUDIO_INPUT_UPDATED, AUDIO_OUTPUT_DEVICE, AUDIO_OUTPUT_UPDATED,
+};
 use alvr_audio::AudioDevice;
 use alvr_common::{parking_lot::Mutex, prelude::*};
 use alvr_session::AudioBufferingConfig;
@@ -5,18 +8,21 @@ use alvr_sockets::{StreamReceiver, StreamSender};
 use oboe::{
     AudioInputCallback, AudioInputStreamSafe, AudioOutputCallback, AudioOutputStreamSafe,
     AudioStream, AudioStreamBuilder, DataCallbackResult, InputPreset, Mono, PerformanceMode,
-    SampleRateConversionQuality, Stereo, Usage,
+    SampleRateConversionQuality, Stereo, Usage, Error,
 };
 use std::{
     collections::VecDeque,
     mem,
     sync::{mpsc as smpsc, Arc},
+    sync::atomic::{AtomicBool, Ordering},
     thread,
+    time::Duration,
 };
 use tokio::sync::mpsc as tmpsc;
 
 struct RecorderCallback {
     sender: tmpsc::UnboundedSender<Vec<u8>>,
+    shutdown_notifier: smpsc::Sender<()>,
 }
 
 impl AudioInputCallback for RecorderCallback {
@@ -35,7 +41,23 @@ impl AudioInputCallback for RecorderCallback {
 
         self.sender.send(sample_buffer).ok();
 
-        DataCallbackResult::Continue
+        if !AUDIO_INPUT_UPDATED.load(Ordering::Relaxed) {
+            DataCallbackResult::Continue
+        }else{
+            self.shutdown_notifier.send(()).unwrap();
+            DataCallbackResult::Stop
+        }
+    }
+    
+    fn on_error_after_close(
+        &mut self,
+        _audio_stream: &mut dyn AudioInputStreamSafe,
+        error: Error
+    ) {
+        if error != Error::Disconnected {
+            info!("AudioInputCallback::on_error_after_close with error {}", error);
+        }
+        self.shutdown_notifier.send(()).unwrap();
     }
 }
 
@@ -48,34 +70,59 @@ pub async fn record_audio_loop(
 ) -> StrResult {
     let sample_rate = device.input_sample_rate()?;
 
-    let (_shutdown_notifier, shutdown_receiver) = smpsc::channel::<()>();
+    let (shutdown_notifier, shutdown_receiver) = smpsc::channel::<()>();
     let (data_sender, mut data_receiver) = tmpsc::unbounded_channel();
 
-    thread::spawn(move || -> StrResult {
-        let mut stream = AudioStreamBuilder::default()
-            .set_shared()
-            .set_performance_mode(PerformanceMode::LowLatency)
-            .set_sample_rate(sample_rate as _)
-            .set_sample_rate_conversion_quality(SampleRateConversionQuality::Fastest)
-            .set_mono()
-            .set_i16()
-            .set_input()
-            .set_usage(Usage::VoiceCommunication)
-            .set_input_preset(InputPreset::VoiceCommunication)
-            .set_callback(RecorderCallback {
-                sender: data_sender,
-            })
-            .open_stream()
-            .map_err(err!())?;
+    // make sure the following loop will be stopped once this function is finished.
+    let is_finished = Arc::new(AtomicBool::new(false));
 
-        stream.start().map_err(err!())?;
+    thread::spawn({
+        let is_finished = Arc::clone(&is_finished);
+        move || loop {
+            let device_id = AUDIO_INPUT_DEVICE.load(Ordering::Relaxed);
+            // Reset the AUDIO_INTPUT_UPDATED flag, as it has been handled.
+            AUDIO_INPUT_UPDATED.store(false, Ordering::Relaxed);
+            info!("record_audio_loop stream with device_id {device_id}");
 
-        shutdown_receiver.recv().ok();
+            let mut audio_stream_builder = AudioStreamBuilder::default()
+                .set_shared()
+                .set_performance_mode(PerformanceMode::LowLatency)
+                .set_sample_rate(sample_rate as _)
+                .set_sample_rate_conversion_quality(SampleRateConversionQuality::Fastest)
+                .set_mono()
+                .set_i16()
+                .set_input()
+                .set_usage(Usage::Game)
+                .set_input_preset(InputPreset::VoicePerformance);
+            if device_id > 0 {
+                audio_stream_builder = audio_stream_builder.set_device_id(device_id);
+            }
+            let stream = audio_stream_builder
+                .set_callback(RecorderCallback {
+                    sender: data_sender.clone(),
+                    shutdown_notifier: shutdown_notifier.clone(),
+                })
+                .open_stream()
+                .map_err(err!());
 
-        // This call gets stuck if the headset goes to sleep, but finishes when the headset wakes up
-        stream.stop_with_timeout(0).ok();
+            match stream {
+                Err(e) => info!("record_audio_loop audio_stream_builder.open_stream() failed {e}"),
+                Ok(mut stream) => match stream.start().map_err(err!()) {
+                    Err(e) => info!("record_audio_loop stream.start() failed {e}"),
+                    Ok(_) => {
+                        shutdown_receiver.recv().ok();
 
-        Ok(())
+                        // This call gets stuck if the headset goes to sleep, but finishes when the headset wakes up
+                        stream.stop_with_timeout(0).ok();
+                    },
+                },
+            }
+            
+            if is_finished.load(Ordering::Relaxed) || !IS_RESUMED.value() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
     });
 
     while let Some(data) = data_receiver.recv().await {
@@ -83,13 +130,14 @@ pub async fn record_audio_loop(
         buffer.get_mut().extend(data);
         sender.send_buffer(buffer).await.ok();
     }
-
+    is_finished.store(true, Ordering::Relaxed);
     Ok(())
 }
 
 struct PlayerCallback {
     sample_buffer: Arc<Mutex<VecDeque<f32>>>,
     batch_frames_count: usize,
+    shutdown_notifier: smpsc::Sender<()>,
 }
 
 impl AudioOutputCallback for PlayerCallback {
@@ -112,7 +160,23 @@ impl AudioOutputCallback for PlayerCallback {
             out_frames[f] = (samples[f * 2], samples[f * 2 + 1]);
         }
 
-        DataCallbackResult::Continue
+        if !AUDIO_OUTPUT_UPDATED.load(Ordering::Relaxed) {
+            DataCallbackResult::Continue
+        }else{
+            self.shutdown_notifier.send(()).unwrap();
+            DataCallbackResult::Stop
+        }
+    }
+
+    fn on_error_after_close(
+        &mut self,
+        _audio_stream: &mut dyn AudioOutputStreamSafe,
+        error: Error
+    ) {
+        if error != Error::Disconnected {
+            info!("AudioOutputCallback::on_error_after_close with error {}", error);
+        }
+        self.shutdown_notifier.send(()).unwrap();
     }
 }
 
@@ -136,12 +200,22 @@ pub async fn play_audio_loop(
 
     let sample_buffer = Arc::new(Mutex::new(VecDeque::new()));
 
+    // make sure the following loop will be stopped once this function is finished.
+    let is_finished = Arc::new(AtomicBool::new(false));
+
     // store the stream in a thread (because !Send) and extract the playback handle
-    let (_shutdown_notifier, shutdown_receiver) = smpsc::channel::<()>();
+    let (shutdown_notifier, shutdown_receiver) = smpsc::channel::<()>();
     thread::spawn({
         let sample_buffer = Arc::clone(&sample_buffer);
-        move || -> StrResult {
-            let mut stream = AudioStreamBuilder::default()
+        let is_finished = Arc::clone(&is_finished);
+        move || loop {
+            // If there is a newly plugged headphone, use it.
+            let device_id = AUDIO_OUTPUT_DEVICE.load(Ordering::Relaxed);
+            // Reset the AUDIO_OUTPUT_UPDATED flag, as it is handled now.
+            AUDIO_OUTPUT_UPDATED.store(false, Ordering::Relaxed);
+            info!("play_audio_loop stream with device_id {device_id}");
+
+            let mut audio_stream_builder = AudioStreamBuilder::default()
                 .set_shared()
                 .set_performance_mode(PerformanceMode::LowLatency)
                 .set_sample_rate(sample_rate as _)
@@ -150,31 +224,48 @@ pub async fn play_audio_loop(
                 .set_f32()
                 .set_frames_per_callback(batch_frames_count as _)
                 .set_output()
-                .set_usage(Usage::Game)
+                .set_usage(Usage::Game);
+            if device_id > 0 {
+                audio_stream_builder = audio_stream_builder.set_device_id(device_id);
+            }
+            let stream = audio_stream_builder
                 .set_callback(PlayerCallback {
-                    sample_buffer,
+                    sample_buffer: sample_buffer.clone(),
                     batch_frames_count,
+                    shutdown_notifier: shutdown_notifier.clone(),
                 })
                 .open_stream()
-                .map_err(err!())?;
+                .map_err(err!());
 
-            stream.start().map_err(err!())?;
+            match stream {
+                Err(e) => info!("play_audio_loop audio_stream_builder.open_stream() failed {e}"),
+                Ok(mut stream) => match stream.start().map_err(err!()) {
+                    Err(e) => info!("play_audio_loop stream.start() failed {e}"),
+                    Ok(_) => {
+                        shutdown_receiver.recv().ok();
 
-            shutdown_receiver.recv().ok();
+                        // Note: Oboe crahes if stream.stop() is NOT called on AudioPlayer
+                        stream.stop_with_timeout(0).ok();
+                    },
+                }
+            }
 
-            // Note: Oboe crahes if stream.stop() is NOT called on AudioPlayer
-            stream.stop_with_timeout(0).ok();
-
-            Ok(())
+            // keep reopening audio stream if ALVR is still running.
+            if is_finished.load(Ordering::Relaxed) || !IS_RESUMED.value() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(100));
         }
     });
 
-    alvr_audio::receive_samples_loop(
+    let res = alvr_audio::receive_samples_loop(
         receiver,
         sample_buffer,
         2,
         batch_frames_count,
         average_buffer_frames_count,
     )
-    .await
+    .await;
+    is_finished.store(true, Ordering::Relaxed);
+    res
 }

--- a/alvr/commands/Cargo.toml
+++ b/alvr/commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_commands"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/common/Cargo.toml
+++ b/alvr/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_common"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/events/Cargo.toml
+++ b/alvr/events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_events"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/filesystem/Cargo.toml
+++ b/alvr/filesystem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_filesystem"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Patrick Nicolas <patricknicolas@laposte.net>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/launcher/Cargo.toml
+++ b/alvr/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_launcher"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/server/Cargo.toml
+++ b/alvr/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_server"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "polygraphene", "Valve Corporation"]
 license = "MIT"
 edition = "2021"

--- a/alvr/server_data/Cargo.toml
+++ b/alvr/server_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_server_data"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/session/Cargo.toml
+++ b/alvr/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_session"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/sockets/Cargo.toml
+++ b/alvr/sockets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_sockets"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/vrcompositor_wrapper/Cargo.toml
+++ b/alvr/vrcompositor_wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_vrcompositor_wrapper"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Patrick Nicolas <patricknicolas@laposte.net>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/vulkan_layer/Cargo.toml
+++ b/alvr/vulkan_layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_vulkan_layer"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "ARM", "Patrick Nicolas <patricknicolas@laposte.net>"]
 license = "MIT"
 edition = "2021"

--- a/alvr/xtask/Cargo.toml
+++ b/alvr/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alvr_xtask"
-version = "19.0.0-dev00"
+version = "19.0.0-dev01"
 authors = ["alvr-org", "Riccardo Zaglia <riccardo.zaglia5@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "alvr.client.quest"
         minSdkVersion 24
         targetSdkVersion 31
-        versionCode 79
-        versionName "19.0.0-dev00"
+        versionCode 80
+        versionName "19.0.0-dev01"
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++17 -fexceptions -frtti"

--- a/android/app/src/main/cpp/cpp_main.cpp
+++ b/android/app/src/main/cpp/cpp_main.cpp
@@ -1138,6 +1138,11 @@ extern "C" JNIEXPORT void JNICALL Java_com_polygraphene_alvr_OvrActivity_onBatte
     g_ctx.hmdPlugged = plugged;
 }
 
+extern "C" JNIEXPORT void JNICALL Java_com_polygraphene_alvr_OvrActivity_onAudioDeviceChangedNative(
+        JNIEnv *_env, jobject _context, jint deviceID, jboolean added, jboolean isInput, jboolean isOutput) {
+    alvr_audio_change(deviceID, (bool) added, (bool) isInput, (bool) isOutput);
+}
+
 extern "C" JNIEXPORT void JNICALL Java_com_polygraphene_alvr_DecoderThread_setWaitingNextIDR(
         JNIEnv *_env, jclass _class, jboolean waiting) {
     alvr_set_waiting_next_idr(waiting);

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -34,7 +34,7 @@ Vcs-Browser: https://github.com/alvr-org/ALVR
 Vcs-Git: https://github.com/alvr-org/ALVR.git
 Rules-Requires-Root: no
 Package: alvr
-Version: 19.0.0-dev00
+Version: 19.0.0-dev01
 Architecture: amd64
 Recommends: steam
 Description: Stream VR games from your PC to your headset via Wi-Fi

--- a/packaging/rpm/alvr.spec
+++ b/packaging/rpm/alvr.spec
@@ -1,9 +1,9 @@
 Name: alvr
 Version: 19.0.0
-Release: 0.0.1dev00
+Release: 0.0.1dev01
 Summary: Stream VR games from your PC to your headset via Wi-Fi
 License: MIT
-Source: https://github.com/alvr-org/ALVR/archive/refs/tags/v19.0.0-dev00.tar.gz
+Source: https://github.com/alvr-org/ALVR/archive/refs/tags/v19.0.0-dev01.tar.gz
 URL: https://github.com/alvr-org/ALVR/
 ExclusiveArch: x86_64
 BuildRequires: alsa-lib-devel cairo-gobject-devel cargo clang-devel ffmpeg-devel gcc gcc-c++ cmake ImageMagick (jack-audio-connection-kit-devel or pipewire-jack-audio-connection-kit-devel) libunwind-devel openssl-devel rpmdevtools rust rust-atk-sys-devel rust-cairo-sys-rs-devel rust-gdk-sys-devel rust-glib-sys-devel rust-pango-sys-devel selinux-policy-devel vulkan-headers vulkan-loader-devel


### PR DESCRIPTION
The changes updates the logic of `play_audio_loop` and `record_audio_loop`, to support detection of changing audio device. The idea is using the native API `android.media.AudioDeviceCallback` to listen the change of audio device, and pass the ID and the properties back to the client core lib.

In the logic of `play_audio_loop` and `record_audio_loop`, the audio streaming thread will be changed to a loop, and keep openning the audio stream as long as the loop is still running. The stream will be closed once it detects the audio device is added or removed, and letting the thread re-open an updated stream.

There is an issue at the moment when I test it. The input stream sometimes stuck at open_stream() without returning, which can only be resolve by pause-resume. I am not sure why it happens or how to solve it in code.