### PR TITLE
Fix ffmpeg dependency dead link

### DIFF
--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -63,14 +63,14 @@ pub fn prepare_ffmpeg_windows() {
         &sh,
         &format!(
             "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/{}",
-            "ffmpeg-n5.0-latest-win64-gpl-shared-5.0.zip"
+            "ffmpeg-n5.1-latest-win64-gpl-shared-5.1.zip"
         ),
         &download_path,
     )
     .unwrap();
 
     fs::rename(
-        download_path.join("ffmpeg-n5.0-latest-win64-gpl-shared-5.0"),
+        download_path.join("ffmpeg-n5.1-latest-win64-gpl-shared-5.1"),
         download_path.join("ffmpeg"),
     )
     .unwrap();


### PR DESCRIPTION
ffmpeg link is dead, this PR bumps the version to 5.1.

From the [ffmpeg releases page](https://github.com/BtbN/FFmpeg-Builds/releases), 5.0 and 5.1 have the same ABI so it should be functionally the same. 

> Bump release from 5.0 to 5.1.
> 5.1 and 5.0 share the same ABI, so instead of cluttering the list even more, just bump to 5.1 entirely.