### PR TITLE
Fix SteamVR complaining about sync on restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,8 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "semver 1.0.12",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/alvr/commands/src/launcher.rs
+++ b/alvr/commands/src/launcher.rs
@@ -1,15 +1,15 @@
-use alvr_common::{prelude::*, send_control_packet, ControlMessages, ControlPacket};
+use alvr_common::{prelude::*, send_launcher_packet, LauncherMessages, LauncherPacket};
 
 pub fn restart_steamvr() -> StrResult {
-    send_control_packet(ControlPacket {
-        message: ControlMessages::RestartSteamvr,
+    send_launcher_packet(LauncherPacket {
+        message: LauncherMessages::RestartSteamvr,
     });
     Ok(())
 }
 
 pub fn invoke_application_update() -> StrResult {
-    send_control_packet(ControlPacket {
-        message: ControlMessages::Update,
+    send_launcher_packet(LauncherPacket {
+        message: LauncherMessages::Update,
     });
     Ok(())
 }

--- a/alvr/commands/src/launcher.rs
+++ b/alvr/commands/src/launcher.rs
@@ -1,6 +1,5 @@
 use alvr_common::{prelude::*, send_control_packet, ControlMessages, ControlPacket};
 
-
 pub fn restart_steamvr() -> StrResult {
     send_control_packet(ControlPacket {
         message: ControlMessages::RestartSteamvr,

--- a/alvr/commands/src/launcher.rs
+++ b/alvr/commands/src/launcher.rs
@@ -1,19 +1,16 @@
-use alvr_common::prelude::*;
-use std::{path::Path, process::Command};
+use alvr_common::{prelude::*, send_control_packet, ControlMessages, ControlPacket};
 
-fn invoke_launcher(launcher_path: &Path, flag: &str) -> StrResult {
-    Command::new(launcher_path)
-        .arg(flag)
-        .status()
-        .map_err(err!())?;
 
+pub fn restart_steamvr() -> StrResult {
+    send_control_packet(ControlPacket {
+        message: ControlMessages::RestartSteamvr,
+    });
     Ok(())
 }
 
-pub fn restart_steamvr(launcher_path: &Path) -> StrResult {
-    invoke_launcher(launcher_path, "--restart-steamvr")
-}
-
-pub fn invoke_application_update(launcher_path: &Path) -> StrResult {
-    invoke_launcher(launcher_path, "--update")
+pub fn invoke_application_update() -> StrResult {
+    send_control_packet(ControlPacket {
+        message: ControlMessages::Update,
+    });
+    Ok(())
 }

--- a/alvr/common/Cargo.toml
+++ b/alvr/common/Cargo.toml
@@ -13,6 +13,8 @@ log = "0.4"
 once_cell = "1"
 parking_lot = "0.12"
 semver = { version = "1", features = ["serde"] }
+serde = "1"
+serde_json = "1"
 
 [target.'cfg(windows)'.dependencies]
 msgbox = "0.7"

--- a/alvr/common/src/lib.rs
+++ b/alvr/common/src/lib.rs
@@ -1,7 +1,7 @@
 mod logging;
 
 use once_cell::sync::Lazy;
-use semver::{Prerelease, Version};
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::hash_map::DefaultHasher,
@@ -199,6 +199,6 @@ pub fn send_control_packet(control_packet: ControlPacket) {
         .expect("Failed to connect to listening server.");
 
     stream
-        .write(serde_json::to_string(&control_packet).unwrap().as_bytes())
+        .write_all(serde_json::to_string(&control_packet).unwrap().as_bytes())
         .expect("Failed to tell the server to restart steamvr.");
 }

--- a/alvr/common/src/lib.rs
+++ b/alvr/common/src/lib.rs
@@ -29,7 +29,7 @@ pub type StrResult<T = ()> = Result<T, String>;
 pub const ALVR_NAME: &str = "ALVR";
 pub static ALVR_VERSION: Lazy<Version> =
     Lazy::new(|| Version::parse(env!("CARGO_PKG_VERSION")).unwrap());
-pub const ALVR_SERVER_WATCHER_ADDRESS: &str = "127.0.0.1:9999";
+pub const ALVR_LAUNCHER_ADDRESS: &str = "127.0.0.1:9999";
 
 // Consistent across architectures, might not be consistent across different compiler versions.
 pub fn hash_string(string: &str) -> u64 {
@@ -171,34 +171,34 @@ impl RelaxedAtomic {
 }
 
 #[derive(Serialize, Deserialize)]
-pub enum ControlMessages {
+pub enum LauncherMessages {
     Shutdown,
     RestartSteamvr,
-    ClientStarted,
+    DriverStarted,
     Update,
 }
 
-impl Display for ControlMessages {
+impl Display for LauncherMessages {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ControlMessages::Shutdown => write!(f, "Shutdown"),
-            ControlMessages::RestartSteamvr => write!(f, "RestartSteamvr"),
-            ControlMessages::ClientStarted => write!(f, "ClientStarted"),
-            ControlMessages::Update => write!(f, "Update"),
+            LauncherMessages::Shutdown => write!(f, "Shutdown"),
+            LauncherMessages::RestartSteamvr => write!(f, "RestartSteamvr"),
+            LauncherMessages::DriverStarted => write!(f, "DriverStarted"),
+            LauncherMessages::Update => write!(f, "Update"),
         }
     }
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct ControlPacket {
-    pub message: ControlMessages,
+pub struct LauncherPacket {
+    pub message: LauncherMessages,
 }
 
-pub fn send_control_packet(control_packet: ControlPacket) {
-    let mut stream = TcpStream::connect(ALVR_SERVER_WATCHER_ADDRESS)
+pub fn send_launcher_packet(launcher_packet: LauncherPacket) {
+    let mut stream = TcpStream::connect(ALVR_LAUNCHER_ADDRESS)
         .expect("Failed to connect to listening server.");
 
     stream
-        .write_all(serde_json::to_string(&control_packet).unwrap().as_bytes())
+        .write_all(serde_json::to_string(&launcher_packet).unwrap().as_bytes())
         .expect("Failed to tell the server to restart steamvr.");
 }

--- a/alvr/common/src/lib.rs
+++ b/alvr/common/src/lib.rs
@@ -195,8 +195,8 @@ pub struct LauncherPacket {
 }
 
 pub fn send_launcher_packet(launcher_packet: LauncherPacket) {
-    let mut stream = TcpStream::connect(ALVR_LAUNCHER_ADDRESS)
-        .expect("Failed to connect to listening server.");
+    let mut stream =
+        TcpStream::connect(ALVR_LAUNCHER_ADDRESS).expect("Failed to connect to listening server.");
 
     stream
         .write_all(serde_json::to_string(&launcher_packet).unwrap().as_bytes())

--- a/alvr/launcher/src/commands.rs
+++ b/alvr/launcher/src/commands.rs
@@ -34,10 +34,15 @@ pub fn is_steamvr_running() -> bool {
     );
     system.refresh_processes();
 
-    system
+    let vrserver_is_running = system
         .processes_by_name(&afs::exec_fname("vrserver"))
         .count()
-        != 0
+        != 0;
+    let vrmonitor_is_running = system
+        .processes_by_name(&afs::exec_fname("vrmonitor"))
+        .count()
+        != 0;
+    vrserver_is_running || vrmonitor_is_running
 }
 
 pub fn maybe_launch_steamvr() {

--- a/alvr/launcher/src/main.rs
+++ b/alvr/launcher/src/main.rs
@@ -319,14 +319,14 @@ fn handle_driver_launcher_connection(
     match bytes_read {
         Ok(bytes_read) => {
             if bytes_read == 0 {
-                show_e("Empty control packet received");
+                show_e("Empty launcher packet received");
                 return None;
             }
             let packet: LauncherPacket = serde_json::from_slice(&data).unwrap();
             Some(packet)
         }
         Err(e) => {
-            show_e("Error occurred while receiving control message, is another program trying to communicate with ALVR?");
+            show_e("Error occurred while receiving launcher message, is another program trying to communicate with ALVR?");
             show_e(e);
             None
         }

--- a/alvr/launcher/src/main.rs
+++ b/alvr/launcher/src/main.rs
@@ -260,16 +260,16 @@ fn main() {
 
     alvr_common::show_err(make_window());
     start_watcher_thread();
-    let mut is_client_restarting = false;
+    let mut is_driver_restarting = false;
     for conn in listener.incoming() {
-        let packet = match handle_client_server_connection(conn) {
+        let packet = match handle_driver_launcher_connection(conn) {
             Some(value) => value,
             None => continue,
         };
 
         match packet.message {
             LauncherMessages::Shutdown => {
-                if is_client_restarting {
+                if is_driver_restarting {
                     // don't exit if we are expecting restart from client
                     continue;
                 }
@@ -277,10 +277,10 @@ fn main() {
                 process::exit(0);
             }
             LauncherMessages::DriverStarted => {
-                is_client_restarting = false;
+                is_driver_restarting = false;
             }
             LauncherMessages::RestartSteamvr => {
-                is_client_restarting = true;
+                is_driver_restarting = true;
                 commands::restart_steamvr();
             }
             LauncherMessages::Update => {
@@ -309,7 +309,7 @@ fn start_watcher_thread() {
     });
 }
 
-fn handle_client_server_connection(
+fn handle_driver_launcher_connection(
     conn: Result<std::net::TcpStream, io::Error>,
 ) -> Option<LauncherPacket> {
     let conn = conn.unwrap();

--- a/alvr/launcher/src/main.rs
+++ b/alvr/launcher/src/main.rs
@@ -261,7 +261,6 @@ fn main() {
     alvr_common::show_err(make_window());
     start_watcher_thread();
     let mut is_driver_restarting = false;
-    let mut is_update_in_progress = false;
     for conn in listener.incoming() {
         let packet = match handle_driver_launcher_connection(conn) {
             Some(value) => value,
@@ -270,7 +269,7 @@ fn main() {
 
         match packet.message {
             LauncherMessages::Shutdown => {
-                if is_driver_restarting || is_update_in_progress {
+                if is_driver_restarting {
                     // don't exit if we are expecting restart from driver or updating
                     continue;
                 }

--- a/alvr/launcher/src/main.rs
+++ b/alvr/launcher/src/main.rs
@@ -270,7 +270,7 @@ fn main() {
         match packet.message {
             LauncherMessages::Shutdown => {
                 if is_driver_restarting {
-                    // don't exit if we are expecting restart from client
+                    // don't exit if we are expecting restart from driver
                     continue;
                 }
                 commands::kill_steamvr();

--- a/alvr/launcher/src/main.rs
+++ b/alvr/launcher/src/main.rs
@@ -16,7 +16,7 @@ use druid::{
 use std::{
     env,
     io::{self, prelude::*, BufReader},
-    net::{TcpListener},
+    net::TcpListener,
     process, thread,
     time::Duration,
 };
@@ -309,7 +309,9 @@ fn start_watcher_thread() {
     });
 }
 
-fn handle_client_server_connection(conn: Result<std::net::TcpStream, io::Error>) -> Option<ControlPacket> {
+fn handle_client_server_connection(
+    conn: Result<std::net::TcpStream, io::Error>,
+) -> Option<ControlPacket> {
     let conn = conn.unwrap();
     let mut buffer = BufReader::new(conn);
     let mut data = Vec::new();

--- a/alvr/server/src/lib.rs
+++ b/alvr/server/src/lib.rs
@@ -22,7 +22,7 @@ use alvr_common::{
     log,
     once_cell::sync::{Lazy, OnceCell},
     parking_lot::Mutex,
-    send_control_packet, ControlMessages, ControlPacket, ALVR_VERSION,
+    send_launcher_packet, LauncherMessages, LauncherPacket, ALVR_VERSION,
 };
 use alvr_events::EventType;
 use alvr_filesystem::{self as afs, Layout};
@@ -119,8 +119,8 @@ pub fn to_cpp_openvr_prop(key: OpenvrPropertyKey, value: OpenvrPropValue) -> Ope
 }
 
 pub fn shutdown_runtime_by_driver() {
-    send_control_packet(ControlPacket {
-        message: ControlMessages::Shutdown,
+    send_launcher_packet(LauncherPacket {
+        message: LauncherMessages::Shutdown,
     });
     shutdown_runtime();
 }
@@ -239,8 +239,8 @@ fn init() {
         .unwrap()
         .into_raw();
     };
-    send_control_packet(ControlPacket {
-        message: ControlMessages::ClientStarted,
+    send_launcher_packet(LauncherPacket {
+        message: LauncherMessages::DriverStarted,
     });
 }
 

--- a/alvr/server/src/lib.rs
+++ b/alvr/server/src/lib.rs
@@ -27,9 +27,7 @@ use alvr_common::{
 use alvr_events::EventType;
 use alvr_filesystem::{self as afs, Layout};
 use alvr_server_data::ServerDataManager;
-use alvr_session::{
-    OpenvrPropValue, OpenvrPropertyKey,
-};
+use alvr_session::{OpenvrPropValue, OpenvrPropertyKey};
 use alvr_sockets::{ClientListAction, GpuVendor, Haptics, VideoFrameHeaderPacket};
 use statistics::StatisticsManager;
 use std::{


### PR DESCRIPTION
Currently, ALVR closes itself and restarts, but by doing so Steam still thinks that it is running (because Steam treats any process that is launched from him as working one, until it is completely closed).
So, in this PR i refactored launcher and made it as a control process for alvr server driver. Now when driver wants to restart, shutdown, or update itself it talks to launcher process using sockets.
I also made sure that if for whatever reason driver won't send exit signal to launcher, it won't be in the background forever (basically, a watcher that checks for existence of steamvr processes).

I've tested mostly with v18 branch before upstreaming to v19 (with headset), but on v19 it behaves on just restarts from dashboard exactly the same. Would be nice if multiple people test this before merging.
I did not test update mechanism, but as far as i am concerned, it should behave exactly the same as before.