### PR TITLE
AMF refactor

### DIFF
--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -214,8 +214,11 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_ENABLE_VBAQ, true);
 		
-		//Fixes rythmic pixelation. I-frames were overcompressed on default settings
+		//Fixes rythmic pixelation.
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_MAX_QP, 30);
+		
+		//Turns Off IDR/I Frames
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, 0);
 	}
 	else
 	{
@@ -249,8 +252,11 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, true);
 
-		//Fixes rythmic pixelation. I-frames were overcompressed on default settings
-		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, 30);
+		//Fixes rythmic pixelation.
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP, 30);
+		
+		//Turns Off IDR/I Frames
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, 0);
 	}
 
 	Debug("Configured %s.\n", pCodec);

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -253,10 +253,11 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, true);
 
 		//Fixes rythmic pixelation.
-		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_MAX_QP, 30);
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, 30);
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_P, 30);
 		
 		//Turns Off IDR/I Frames
-		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, 0);
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, 0);
 	}
 
 	Debug("Configured %s.\n", pCodec);

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -166,6 +166,9 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 
 	switch (codec) {
 	case ALVR_CODEC_H264:
+		if (m_use10bit) {
+			throw MakeException("H.264 10-bit encoding is not supported");
+		}
 		pCodec = AMFVideoEncoderVCE_AVC;
 		break;
 	case ALVR_CODEC_H265:
@@ -200,12 +203,6 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 			default:
 				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, AMF_VIDEO_ENCODER_QUALITY_PRESET_QUALITY);
 				break;
-		}
-
-		if (m_use10bit) {
-			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_COLOR_BIT_DEPTH, AMF_COLOR_BIT_DEPTH_10);
-		} else {
-			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_COLOR_BIT_DEPTH, AMF_COLOR_BIT_DEPTH_8);
 		}
 
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -116,6 +116,7 @@ void AMFPipeline::Run()
 		{
 			(*it)->doPassthrough();
 		}
+		amf_sleep(1);
 	}
 }
 
@@ -125,6 +126,7 @@ void AMFPipeline::RunReceive()
 	while (isRunning)
 	{
 		m_pipes.back()->doPassthrough();
+		amf_sleep(1);
 	}
 }
 

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -246,18 +246,7 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		//Fixes rythmic pixelation. I-frames were overcompressed on default settings
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, 30);
 	}
-	amf::AMFCapsPtr caps;
-	amfEncoder->GetCaps(&caps);
-	amf::AMFIOCapsPtr iocaps;
-	caps->GetOutputCaps(&iocaps);
-	amf_int32 formats = iocaps->GetNumOfFormats();
-	Debug("Supported formats num: %d\n", formats);
-	for (int i = 0; i < formats; i++) {
-		amf::AMF_SURFACE_FORMAT format;
-		bool isNative;
-		iocaps->GetFormatAt(i, &format, &isNative);
-		Debug("Accepts format: %d, native: %d", format, isNative);
-	}
+
 	Debug("Configured amfEncoder.\n");
 	AMF_THROW_IF(amfEncoder->Init(inputFormat, width, height));
 

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -260,6 +260,8 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		
 		//Turns Off IDR/I Frames
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, 0);
+		//Set infinite GOP length
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, 0);
 		
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, bitRateIn / frameRateIn);
 	}

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -222,9 +222,6 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_ENABLE_VBAQ, true);
 		
-		//Fixes rythmic pixelation.
-		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_MAX_QP, 30);
-		
 		//Turns Off IDR/I Frames
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, 0);
 
@@ -265,10 +262,6 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, true);
-
-		//Fixes rythmic pixelation.
-		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, 30);
-		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_P, 30);
 		
 		//Turns Off IDR/I Frames
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, 0);

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -253,7 +253,7 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, true);
 
 		//Fixes rythmic pixelation.
-		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP, 30);
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_MAX_QP, 30);
 		
 		//Turns Off IDR/I Frames
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, 0);

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -219,6 +219,8 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		
 		//Turns Off IDR/I Frames
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, 0);
+
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, bitRateIn / frameRateIn);
 	}
 	else
 	{
@@ -258,6 +260,8 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		
 		//Turns Off IDR/I Frames
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, 0);
+		
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, bitRateIn / frameRateIn);
 	}
 
 	Debug("Configured %s.\n", pCodec);
@@ -378,10 +382,12 @@ void VideoEncoderVCE::Transmit(ID3D11Texture2D *pTexture, uint64_t presentationT
 			if (m_codec == ALVR_CODEC_H264)
 			{
 				m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE, bitRateIn);
+				m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, bitRateIn / m_refreshRate);
 			}
 			else
 			{
 				m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, bitRateIn);
+				m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, bitRateIn / m_refreshRate);
 			}
 		}
 	}

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -168,7 +168,7 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 	const wchar_t *pCodec;
 
 	amf_int32 frameRateIn = refreshRate;
-	amf_int64 bitRateIn = bitrateInMbits * 1000000L; // in bits
+	amf_int64 bitRateIn = bitrateInMbits * 1'000'000L; // in bits
 
 	switch (codec) {
 	case ALVR_CODEC_H264:
@@ -380,7 +380,7 @@ void VideoEncoderVCE::Transmit(ID3D11Texture2D *pTexture, uint64_t presentationT
 	if (m_Listener) {
 		if (m_Listener->GetStatistics()->CheckBitrateUpdated()) {
 			m_bitrateInMBits = m_Listener->GetStatistics()->GetBitrate();
-			amf_int64 bitRateIn = m_bitrateInMBits * 1000000L; // in bits
+			amf_int64 bitRateIn = m_bitrateInMBits * 1'000'000L; // in bits
 			if (m_codec == ALVR_CODEC_H264)
 			{
 				m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE, bitRateIn);

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -253,10 +253,10 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_QP_I, 30);
 	}
 
-	Debug("Configured amfEncoder.\n");
+	Debug("Configured %s.\n", pCodec);
 	AMF_THROW_IF(amfEncoder->Init(inputFormat, width, height));
 
-	Debug("Initialized amfEncoder.\n");
+	Debug("Initialized %s.\n", pCodec);
 
 	return amfEncoder;
 }
@@ -273,7 +273,7 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeConverter(
 
 	AMF_THROW_IF(amfConverter->Init(inputFormat, width, height));
 
-	Debug("Initialized amfConverter.\n");
+	Debug("Initialized %s.\n", AMFVideoConverter);
 	return amfConverter;
 }
 
@@ -289,7 +289,7 @@ amf::AMFComponentPtr VideoEncoderVCE::MakePreprocessor(
 
 	AMF_THROW_IF(amfPreprocessor->Init(inputFormat, width, height));
 
-	Debug("Initialized amfPreprocessor.\n");
+	Debug("Initialized %s.\n", AMFPreProcessing);
 	return amfPreprocessor;
 }
 

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
@@ -44,8 +44,10 @@ public:
 	void Connect(AMFPipePtr pipe);
 	void Start();
 	void Run();
+	void RunReceive();
 protected:
 	std::thread *m_thread;
+	std::thread *m_receiveThread;
 	std::vector<AMFPipePtr> m_pipes;
 	bool isRunning;
 };

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
@@ -104,6 +104,7 @@ private:
 	uint32_t m_preProcSigma;
 	uint32_t m_preProcTor;
 	EncoderQualityPreset m_encoderQualityPreset;
+	amf::AMF_SURFACE_FORMAT m_surfaceFormat;
 
 	int m_codec;
 	int m_refreshRate;

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
@@ -78,9 +78,6 @@ private:
 	static const wchar_t *START_TIME_PROPERTY;
 	static const wchar_t *FRAME_INDEX_PROPERTY;
 
-	const uint64_t MILLISEC_TIME = 10000;
-	const uint64_t MICROSEC_TIME = 10;
-
 	amf::AMFComponentPtr MakeConverter(
 		amf::AMF_SURFACE_FORMAT inputFormat, int width, int height, amf::AMF_SURFACE_FORMAT outputFormat
 	);

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
@@ -109,7 +109,12 @@ private:
 	int m_renderHeight;
 	int m_bitrateInMBits;
 
+	char *m_audByteSequence;
+	int m_audNalSize;
+	int m_audHeaderSize;
+
 	void ApplyFrameProperties(const amf::AMFSurfacePtr &surface, bool insertIDR);
 	void SkipAUD(char **buffer, int *length);
+	void LoadAUDByteSequence();
 };
 


### PR DESCRIPTION
- Fixes high CPU usage (regression introduced by https://github.com/alvr-org/ALVR/pull/1220) and slightly reduces CPU usage comparing to older code.
- Moves out video transmission and encoding pipeline to separate threads.
- Remove AUD reliably for all codecs (fixes H.264 stream with 22.3.1 and 22.5.1).
- Use Infinite GOP for H.264 and HEVC encoding.
- Throw error when 10-bit mode selected with H.264.