### PR TITLE
Fix readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This is a fork of [ALVR](https://github.com/polygraphene/ALVR).
 -   High-end gaming PC
     -   Windows 10 May 2020 update is recommended. If you are on an older version, you need to install Chrome or another Chromium based browser.  
     -   Minimum supported OS version is Windows 8.  
-    -   NVIDIA GPU that supports NVENC ([Supported GPUs](https://github.com/polygraphene/ALVR/wiki/Supported-GPU)) (or with an AMD GPU that supports AMF VCE) with the latest driver.  
+    -   NVIDIA GPU that supports NVENC (1000 GTX Series or higher) (or with an AMD GPU that supports AMF VCE) with the latest driver.  
     -   Laptops with an onboard (Intel HD, AMD iGPU) and an additional dedicated GPU (NVidia GTX/RTX, AMD HD/R5/R7): you should assign the dedicated GPU or "high performance graphics adapter" to the applications ALVR, SteamVR for best performance and compatibility. (NVidia: Nvidia control panel->3d settings->application settings; AMD: similiar way) 
 
 -   802.11ac 5Ghz wireless or ethernet wired connection  


### PR DESCRIPTION
In the requirements section, the link to the list of supported GPUs is on the old wiki and outdated. [Most](https://en.wikipedia.org/wiki/Nvidia_NVENC) modern GPUs are compatible. I feel like drawing the line in the 1000 Series is a reasonable decision, due to older GPUs not having some features (H.264 and H.265) or not having NVENC Cores; although the line could be changed to the older GPUs still having some of the features.