### PR TITLE
Fix too aggressive grip force

### DIFF
--- a/alvr/server/cpp/alvr_server/OvrController.cpp
+++ b/alvr/server/cpp/alvr_server/OvrController.cpp
@@ -843,7 +843,7 @@ bool OvrController::onPoseUpdate(float predictionS,
             vr::VRDriverInput()->UpdateBooleanComponent(
                 m_handles[ALVR_INPUT_SYSTEM_CLICK], false, 0.0);
             vr::VRDriverInput()->UpdateBooleanComponent(
-                m_handles[ALVR_INPUT_GRIP_TOUCH], grip > 0.7f, 0.0);
+                m_handles[ALVR_INPUT_GRIP_TOUCH], grip > 0.75f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
                 m_handles[ALVR_INPUT_GRIP_FORCE], grip - 1.0, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(m_handles[ALVR_INPUT_GRIP_VALUE], grip, 0.0);
@@ -1080,9 +1080,9 @@ bool OvrController::onPoseUpdate(float predictionS,
             vr::VRDriverInput()->UpdateBooleanComponent(
                 m_handles[ALVR_INPUT_GRIP_TOUCH], m_gripValue > 0.35f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
-                m_handles[ALVR_INPUT_GRIP_FORCE], m_gripValue * 2.0 - 1.0, 0.0);
+                m_handles[ALVR_INPUT_GRIP_FORCE], m_gripValue > 0.9f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
-                m_handles[ALVR_INPUT_GRIP_VALUE], m_gripValue * 2.0, 0.0);
+                m_handles[ALVR_INPUT_GRIP_VALUE], m_gripValue * 1.1f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
                 m_handles[ALVR_INPUT_TRACKPAD_X], m_joystickX, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(

--- a/alvr/server/cpp/alvr_server/OvrController.cpp
+++ b/alvr/server/cpp/alvr_server/OvrController.cpp
@@ -845,7 +845,7 @@ bool OvrController::onPoseUpdate(float predictionS,
             vr::VRDriverInput()->UpdateBooleanComponent(
                 m_handles[ALVR_INPUT_GRIP_TOUCH], grip > 0.7f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
-                m_handles[ALVR_INPUT_GRIP_FORCE], grip > 0.9f, 0.0);
+                m_handles[ALVR_INPUT_GRIP_FORCE], (grip > 0.9f) ? 1.0f : 0.0f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
                 m_handles[ALVR_INPUT_GRIP_VALUE], grip * 1.1f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(m_handles[ALVR_INPUT_TRACKPAD_X], 0, 0.0);
@@ -1081,7 +1081,7 @@ bool OvrController::onPoseUpdate(float predictionS,
             vr::VRDriverInput()->UpdateBooleanComponent(
                 m_handles[ALVR_INPUT_GRIP_TOUCH], m_gripValue > 0.7f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
-                m_handles[ALVR_INPUT_GRIP_FORCE], m_gripValue > 0.9f, 0.0);
+                m_handles[ALVR_INPUT_GRIP_FORCE], (m_gripValue > 0.9f) ? 1.0f : 0.0f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
                 m_handles[ALVR_INPUT_GRIP_VALUE], m_gripValue * 1.1f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(

--- a/alvr/server/cpp/alvr_server/OvrController.cpp
+++ b/alvr/server/cpp/alvr_server/OvrController.cpp
@@ -843,7 +843,7 @@ bool OvrController::onPoseUpdate(float predictionS,
             vr::VRDriverInput()->UpdateBooleanComponent(
                 m_handles[ALVR_INPUT_SYSTEM_CLICK], false, 0.0);
             vr::VRDriverInput()->UpdateBooleanComponent(
-                m_handles[ALVR_INPUT_GRIP_TOUCH], grip > 0.75f, 0.0);
+                m_handles[ALVR_INPUT_GRIP_TOUCH], grip > 0.7f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
                 m_handles[ALVR_INPUT_GRIP_FORCE], grip - 1.0, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(m_handles[ALVR_INPUT_GRIP_VALUE], grip, 0.0);

--- a/alvr/server/cpp/alvr_server/OvrController.cpp
+++ b/alvr/server/cpp/alvr_server/OvrController.cpp
@@ -845,7 +845,7 @@ bool OvrController::onPoseUpdate(float predictionS,
             vr::VRDriverInput()->UpdateBooleanComponent(
                 m_handles[ALVR_INPUT_GRIP_TOUCH], grip > 0.7f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
-                m_handles[ALVR_INPUT_GRIP_FORCE], (grip > 0.9f) ? 1.0f : 0.0f, 0.0);
+                m_handles[ALVR_INPUT_GRIP_FORCE], (grip * 1.1f - 1.f) * 10.f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
                 m_handles[ALVR_INPUT_GRIP_VALUE], grip * 1.1f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(m_handles[ALVR_INPUT_TRACKPAD_X], 0, 0.0);
@@ -1081,7 +1081,7 @@ bool OvrController::onPoseUpdate(float predictionS,
             vr::VRDriverInput()->UpdateBooleanComponent(
                 m_handles[ALVR_INPUT_GRIP_TOUCH], m_gripValue > 0.7f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
-                m_handles[ALVR_INPUT_GRIP_FORCE], (m_gripValue > 0.9f) ? 1.0f : 0.0f, 0.0);
+                m_handles[ALVR_INPUT_GRIP_FORCE], (m_gripValue * 1.1f - 1.f) * 10.f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
                 m_handles[ALVR_INPUT_GRIP_VALUE], m_gripValue * 1.1f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(

--- a/alvr/server/cpp/alvr_server/OvrController.cpp
+++ b/alvr/server/cpp/alvr_server/OvrController.cpp
@@ -1079,7 +1079,7 @@ bool OvrController::onPoseUpdate(float predictionS,
                 (m_buttons & ALVR_BUTTON_FLAG(ALVR_INPUT_SYSTEM_CLICK)) != 0,
                 0.0);
             vr::VRDriverInput()->UpdateBooleanComponent(
-                m_handles[ALVR_INPUT_GRIP_TOUCH], m_gripValue > 0.35f, 0.0);
+                m_handles[ALVR_INPUT_GRIP_TOUCH], m_gripValue > 0.7f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
                 m_handles[ALVR_INPUT_GRIP_FORCE], m_gripValue > 0.9f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(

--- a/alvr/server/cpp/alvr_server/OvrController.cpp
+++ b/alvr/server/cpp/alvr_server/OvrController.cpp
@@ -845,8 +845,9 @@ bool OvrController::onPoseUpdate(float predictionS,
             vr::VRDriverInput()->UpdateBooleanComponent(
                 m_handles[ALVR_INPUT_GRIP_TOUCH], grip > 0.7f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(
-                m_handles[ALVR_INPUT_GRIP_FORCE], grip - 1.0, 0.0);
-            vr::VRDriverInput()->UpdateScalarComponent(m_handles[ALVR_INPUT_GRIP_VALUE], grip, 0.0);
+                m_handles[ALVR_INPUT_GRIP_FORCE], grip > 0.9f, 0.0);
+            vr::VRDriverInput()->UpdateScalarComponent(
+                m_handles[ALVR_INPUT_GRIP_VALUE], grip * 1.1f, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(m_handles[ALVR_INPUT_TRACKPAD_X], 0, 0.0);
             vr::VRDriverInput()->UpdateScalarComponent(m_handles[ALVR_INPUT_TRACKPAD_Y], 0, 0.0);
             vr::VRDriverInput()->UpdateBooleanComponent(


### PR DESCRIPTION
Fixes weird finger behaviors in VRChat.
Grip force should not play a big role in games anyways, lets's just turn it 0/1 instead when the grip is pressed 90%-100%. This has been done for finger tracking too anyways.