### PR TITLE
Linux encoder gop size increase

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -75,7 +75,7 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(std::vector<VkFrame> &input_frame
     encoder_ctx->framerate = AVRational{settings.m_refreshRate, 1};
     encoder_ctx->sample_aspect_ratio = AVRational{1, 1};
     encoder_ctx->max_b_frames = 0;
-    encoder_ctx->gop_size = 30;
+    encoder_ctx->gop_size = 128;
     encoder_ctx->bit_rate = settings.mEncodeBitrateMBs * 1000 * 1000;
 
     err = AVCODEC.avcodec_open2(encoder_ctx, codec, NULL);

--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
@@ -145,6 +145,7 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(std::vector<VkFrame>& input_frame
   encoder_ctx->sample_aspect_ratio = AVRational{1, 1};
   encoder_ctx->pix_fmt = AV_PIX_FMT_VAAPI;
   encoder_ctx->max_b_frames = 0;
+  encoder_ctx->gop_size = 128;
   encoder_ctx->bit_rate = settings.mEncodeBitrateMBs * 1000 * 1000;
 
   set_hwframe_ctx(encoder_ctx, hw_ctx);


### PR DESCRIPTION
This should decrease the amount of latency spikes you see on linux.