### PR TITLE
Use AV_PIX_FMT_DRM_PRIME format with VAAPI

### DIFF
--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -202,7 +202,7 @@ void CEncoder::Run() {
       auto output = render.CreateOutput();
 
       alvr::VkFrameCtx vk_frame_ctx(vk_ctx, output.imageInfo);
-      alvr::VkFrame frame(vk_ctx, output.image, output.imageInfo, output.size, output.memory);
+      alvr::VkFrame frame(vk_ctx, output.image, output.imageInfo, output.size, output.memory, output.drm);
       auto encode_pipeline = alvr::EncodePipeline::Create(frame, vk_frame_ctx, render.GetEncodingWidth(), render.GetEncodingHeight());
 
       fprintf(stderr, "CEncoder starting to read present packets");

--- a/alvr/server/cpp/platform/linux/Renderer.h
+++ b/alvr/server/cpp/platform/linux/Renderer.h
@@ -2,7 +2,17 @@
 
 #include <vector>
 #include <string>
+#include <array>
 #include <vulkan/vulkan.h>
+
+struct DrmImage {
+    int fd = -1;
+    uint32_t format = 0;
+    uint64_t modifier = 0;
+    uint32_t planes = 0;
+    std::array<uint32_t, 4> strides;
+    std::array<uint32_t, 4> offsets;
+};
 
 class RenderPipeline;
 
@@ -17,6 +27,8 @@ public:
         // ---
         VkImageView view;
         VkFramebuffer framebuffer;
+        // ---
+        DrmImage drm;
     };
 
     explicit Renderer(const VkInstance &inst, const VkDevice &dev, const VkPhysicalDevice &physDev, uint32_t queueFamilyIndex, const std::vector<const char *> &devExtensions);
@@ -56,6 +68,8 @@ private:
 
     struct {
         PFN_vkImportSemaphoreFdKHR vkImportSemaphoreFdKHR;
+        PFN_vkGetMemoryFdKHR vkGetMemoryFdKHR;
+        PFN_vkGetImageDrmFormatModifierPropertiesEXT vkGetImageDrmFormatModifierPropertiesEXT;
         bool haveDrmModifiers = false;
     } d;
 

--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.h
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.h
@@ -9,6 +9,8 @@
 #include "generated/avfilter_loader.h"
 #include "generated/swscale_loader.h"
 
+#include "Renderer.h"
+
 namespace alvr
 {
 
@@ -58,6 +60,7 @@ public:
   uint32_t queueFamilyIndex;
   std::vector<const char*> instanceExtensions;
   std::vector<const char*> deviceExtensions;
+  bool drmContext = false;
 };
 
 class VkFrameCtx
@@ -77,12 +80,14 @@ public:
       VkImage image,
       VkImageCreateInfo image_info,
       VkDeviceSize size,
-      VkDeviceMemory memory);
+      VkDeviceMemory memory,
+      DrmImage drm);
   ~VkFrame();
   operator AVVkFrame*() const { return av_vkframe;}
   std::unique_ptr<AVFrame, std::function<void(AVFrame*)>> make_av_frame(VkFrameCtx & frame_ctx);
 private:
-  AVVkFrame* av_vkframe;
+  AVVkFrame* av_vkframe = nullptr;
+  AVDRMFrameDescriptor* av_drmframe = nullptr;
   const uint32_t width;
   const uint32_t height;
   vk::Device device;

--- a/alvr/server/cpp/platform/linux/generated/avutil_loader.h
+++ b/alvr/server/cpp/platform/linux/generated/avutil_loader.h
@@ -11,6 +11,7 @@ extern "C" {
 #include <libavutil/opt.h>
 #include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_vulkan.h>
+#include <libavutil/hwcontext_drm.h>
 
 }
 

--- a/alvr/server/gen_loader.sh
+++ b/alvr/server/gen_loader.sh
@@ -13,7 +13,8 @@ mkdir -p cpp/platform/linux/generated
 #include <libavutil/dict.h>
 #include <libavutil/opt.h>
 #include <libavutil/hwcontext.h>
-#include <libavutil/hwcontext_vulkan.h>' \
+#include <libavutil/hwcontext_vulkan.h>
+#include <libavutil/hwcontext_drm.h>' \
 	--use-extern-c \
 	av_buffer_alloc av_buffer_ref av_buffer_unref av_dict_set av_frame_alloc av_frame_free av_frame_get_buffer av_frame_unref av_free av_hwdevice_ctx_alloc av_hwdevice_ctx_init av_hwdevice_ctx_create av_hwframe_ctx_alloc av_hwframe_ctx_init av_hwframe_get_buffer av_hwframe_map av_hwframe_transfer_data av_log_set_callback av_log_set_level av_opt_set av_strdup av_strerror av_vkfmt_from_pixfmt av_vk_frame_alloc
 


### PR DESCRIPTION
Fixes compatibility with drivers without DRM modifiers support (notably AMD Polaris GPUs).

Closes #1256