### PR TITLE
Renderer debug

### DIFF
--- a/alvr/server/cpp/alvr_server/Settings.cpp
+++ b/alvr/server/cpp/alvr_server/Settings.cpp
@@ -181,7 +181,9 @@ void Settings::Load()
 		m_nvencRcMaxBitrate = config.get("rc_max_bitrate").get<int64_t>();
 		m_nvencRcAverageBitrate = config.get("rc_average_bitrate").get<int64_t>();
 		m_nvencEnableAQ = config.get("enable_aq").get<int64_t>();
-		
+
+		m_captureFrameDir = config.get("capture_frame_dir").get<std::string>();
+
 		Debug("Config JSON: %hs\n", json.c_str());
 		Info("Serial Number: %hs\n", mSerialNumber.c_str());
 		Info("Model Number: %hs\n", mModelNumber.c_str());

--- a/alvr/server/cpp/alvr_server/Settings.h
+++ b/alvr/server/cpp/alvr_server/Settings.h
@@ -148,4 +148,6 @@ public:
 	int64_t m_nvencRcMaxBitrate;
 	int64_t m_nvencRcAverageBitrate;
 	int64_t m_nvencEnableAQ;
+
+	std::string m_captureFrameDir;
 };

--- a/alvr/server/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server/cpp/alvr_server/alvr_server.cpp
@@ -312,3 +312,9 @@ void SetBitrateParameters(unsigned long long bitrate_mbs,
         }
     }
 }
+
+void CaptureFrame() {
+    if (g_driver_provider.hmd && g_driver_provider.hmd->m_encoder) {
+        g_driver_provider.hmd->m_encoder->CaptureFrame();
+    }
+}

--- a/alvr/server/cpp/alvr_server/bindings.h
+++ b/alvr/server/cpp/alvr_server/bindings.h
@@ -157,3 +157,5 @@ extern "C" void SetButton(unsigned long long path, AlvrButtonValue value);
 extern "C" void SetBitrateParameters(unsigned long long bitrate_mbs,
                                      bool adaptive_bitrate_enabled,
                                      unsigned long long bitrate_max);
+
+extern "C" void CaptureFrame();

--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -232,13 +232,11 @@ void CEncoder::Run() {
         // Close enough to present
         ReportPresent(pose->targetTimestampNs);
 
-        if (access("/tmp/alvr-capture-input", F_OK) == 0) {
-          unlink("/tmp/alvr-capture-input");
-          render.CaptureInputFrame("/tmp/alvr-capture-input.ppm");
-        }
-        if (access("/tmp/alvr-capture-output", F_OK) == 0) {
-          unlink("/tmp/alvr-capture-output");
-          render.CaptureOutputFrame("/tmp/alvr-capture-output.ppm");
+        if (m_captureFrame) {
+          m_captureFrame = false;
+          render.Wait(frame_info.image, frame_info.semaphore_value);
+          render.CaptureInputFrame(Settings::Instance().m_captureFrameDir + "/alvr_frame_input.ppm");
+          render.CaptureOutputFrame(Settings::Instance().m_captureFrameDir + "/alvr_frame_output.ppm");
         }
 
         render.Render(frame_info.image, frame_info.semaphore_value);
@@ -282,3 +280,5 @@ void CEncoder::Stop() {
 void CEncoder::OnPacketLoss() { m_scheduler.OnPacketLoss(); }
 
 void CEncoder::InsertIDR() { m_scheduler.InsertIDR(); }
+
+void CEncoder::CaptureFrame() { m_captureFrame = true; }

--- a/alvr/server/cpp/platform/linux/CEncoder.h
+++ b/alvr/server/cpp/platform/linux/CEncoder.h
@@ -21,6 +21,7 @@ class CEncoder : public CThread {
     void OnPacketLoss();
     void InsertIDR();
     bool IsConnected() { return m_connected; }
+    void CaptureFrame();
 
   private:
     void GetFds(int client, int (*fds)[6]);
@@ -32,4 +33,5 @@ class CEncoder : public CThread {
     std::string m_socketPath;
     int m_fds[6];
     bool m_connected = false;
+    std::atomic_bool m_captureFrame = false;
 };

--- a/alvr/server/cpp/platform/linux/Renderer.cpp
+++ b/alvr/server/cpp/platform/linux/Renderer.cpp
@@ -22,7 +22,7 @@ struct Vertex {
     float position[2];
 };
 
-static const char *result_to_str(VkResult result)
+static std::string result_to_str(VkResult result)
 {
     switch (result) {
 #define VAL(x) case x: return #x
@@ -65,8 +65,8 @@ static const char *result_to_str(VkResult result)
 { \
     VkResult res = (f); \
     if (res != VK_SUCCESS) { \
-        std::cout << "Fatal : VkResult is \"" << result_to_str(res) << "\" in " << __FILE__ << " at line " << __LINE__ << std::endl; \
-        assert(res == VK_SUCCESS); \
+        std::cerr << result_to_str(res) << "at" << __FILE__ << ":" << __LINE__ << std::endl; \
+        throw std::runtime_error("Vulkan: " + result_to_str(res) + "at " __FILE__ ":" + std::to_string(__LINE__)); \
     } \
 }
 

--- a/alvr/server/cpp/platform/linux/Renderer.cpp
+++ b/alvr/server/cpp/platform/linux/Renderer.cpp
@@ -424,7 +424,7 @@ Renderer::Output Renderer::CreateOutput(uint32_t width, uint32_t height)
     m_output.imageInfo.mipLevels = 1;
     m_output.imageInfo.arrayLayers = 1;
     m_output.imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-    m_output.imageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    m_output.imageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     m_output.imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     m_output.imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
@@ -608,6 +608,11 @@ Renderer::Output Renderer::CreateOutput(uint32_t width, uint32_t height)
 
 void Renderer::Render(uint32_t index, uint64_t waitValue)
 {
+    if (!m_inputImageCapture.empty()) {
+        dumpImage(m_images[index].image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, m_imageSize.width, m_imageSize.height, m_inputImageCapture);
+        m_inputImageCapture.clear();
+    }
+
     VkCommandBufferBeginInfo commandBufferBegin = {};
     commandBufferBegin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     VK_CHECK(vkBeginCommandBuffer(m_commandBuffer, &commandBufferBegin));
@@ -653,6 +658,31 @@ void Renderer::Render(uint32_t index, uint64_t waitValue)
 
     VK_CHECK(vkWaitForFences(m_dev, 1, &m_fence, VK_TRUE, UINT64_MAX));
     VK_CHECK(vkResetFences(m_dev, 1, &m_fence));
+
+    if (!m_outputImageCapture.empty()) {
+        dumpImage(m_output.image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, m_output.imageInfo.extent.width, m_output.imageInfo.extent.height, m_outputImageCapture);
+        m_outputImageCapture.clear();
+    }
+}
+
+void Renderer::Wait(uint32_t index, uint64_t waitValue)
+{
+    VkSemaphoreWaitInfo waitInfo = {};
+    waitInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
+    waitInfo.semaphoreCount = 1;
+    waitInfo.pSemaphores = &m_images[index].semaphore;
+    waitInfo.pValues = &waitValue;
+    VK_CHECK(vkWaitSemaphores(m_dev, &waitInfo, UINT64_MAX));
+}
+
+void Renderer::CaptureInputFrame(const char *filename)
+{
+    m_inputImageCapture = filename;
+}
+
+void Renderer::CaptureOutputFrame(const char *filename)
+{
+    m_outputImageCapture = filename;
 }
 
 void Renderer::CopyOutput(VkImage image, VkFormat format, VkImageLayout layout, VkSemaphore *semaphore)
@@ -843,6 +873,137 @@ void Renderer::addStagingImage(uint32_t width, uint32_t height)
     vkUpdateDescriptorSets(m_dev, 1, &descriptorWriteSet, 0, nullptr);
 
     m_stagingImages.push_back({image, memory, view, framebuffer, descriptor});
+}
+
+void Renderer::dumpImage(VkImage image, VkImageLayout imageLayout, uint32_t width, uint32_t height, const std::string &filename)
+{
+    VkImageCreateInfo imageInfo = {};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
+    imageInfo.extent.width = width;
+    imageInfo.extent.height = height;
+    imageInfo.extent.depth = 1;
+    imageInfo.arrayLayers = 1;
+    imageInfo.mipLevels = 1;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.tiling = VK_IMAGE_TILING_LINEAR;
+    imageInfo.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    VkImage dstImage;
+    VK_CHECK(vkCreateImage(m_dev, &imageInfo, nullptr, &dstImage));
+
+    VkMemoryRequirements memReqs;
+    VkMemoryAllocateInfo memAllocInfo {};
+    memAllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    vkGetImageMemoryRequirements(m_dev, dstImage, &memReqs);
+    memAllocInfo.allocationSize = memReqs.size;
+    memAllocInfo.memoryTypeIndex = memoryTypeIndex(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, memReqs.memoryTypeBits);
+    VkDeviceMemory dstMemory;
+    VK_CHECK(vkAllocateMemory(m_dev, &memAllocInfo, nullptr, &dstMemory));
+    VK_CHECK(vkBindImageMemory(m_dev, dstImage, dstMemory, 0));
+
+    std::array<VkImageMemoryBarrier, 2> imageBarrierIn;
+    imageBarrierIn[0] = {};
+    imageBarrierIn[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    imageBarrierIn[0].oldLayout = imageLayout;
+    imageBarrierIn[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    imageBarrierIn[0].image = image;
+    imageBarrierIn[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    imageBarrierIn[0].subresourceRange.layerCount = 1;
+    imageBarrierIn[0].subresourceRange.levelCount = 1;
+    imageBarrierIn[0].srcAccessMask = 0;
+    imageBarrierIn[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+    imageBarrierIn[1] = {};
+    imageBarrierIn[1].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    imageBarrierIn[1].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    imageBarrierIn[1].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    imageBarrierIn[1].image = dstImage;
+    imageBarrierIn[1].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    imageBarrierIn[1].subresourceRange.layerCount = 1;
+    imageBarrierIn[1].subresourceRange.levelCount = 1;
+    imageBarrierIn[1].srcAccessMask = 0;
+    imageBarrierIn[1].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+    VkImageBlit imageBlit;
+    imageBlit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    imageBlit.srcSubresource.mipLevel = 0;
+    imageBlit.srcSubresource.baseArrayLayer = 0;
+    imageBlit.srcSubresource.layerCount = 1;
+    imageBlit.srcOffsets[0].x = 0;
+    imageBlit.srcOffsets[0].y = 0;
+    imageBlit.srcOffsets[0].z = 0;
+    imageBlit.srcOffsets[1].x = width;
+    imageBlit.srcOffsets[1].y = height;
+    imageBlit.srcOffsets[1].z = 1;
+    imageBlit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    imageBlit.dstSubresource.mipLevel = 0;
+    imageBlit.dstSubresource.baseArrayLayer = 0;
+    imageBlit.dstSubresource.layerCount = 1;
+    imageBlit.dstOffsets[0].x = 0;
+    imageBlit.dstOffsets[0].y = 0;
+    imageBlit.dstOffsets[0].z = 0;
+    imageBlit.dstOffsets[1].x = width;
+    imageBlit.dstOffsets[1].y = height;
+    imageBlit.dstOffsets[1].z = 1;
+
+    std::array<VkImageMemoryBarrier, 2> imageBarrierOut;
+    imageBarrierOut[0] = {};
+    imageBarrierOut[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    imageBarrierOut[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    imageBarrierOut[0].newLayout = imageLayout;
+    imageBarrierOut[0].image = image;
+    imageBarrierOut[0].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    imageBarrierOut[0].subresourceRange.layerCount = 1;
+    imageBarrierOut[0].subresourceRange.levelCount = 1;
+    imageBarrierOut[0].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+    imageBarrierOut[0].dstAccessMask = 0;
+    imageBarrierOut[1] = {};
+    imageBarrierOut[1].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    imageBarrierOut[1].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    imageBarrierOut[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    imageBarrierOut[1].image = dstImage;
+    imageBarrierOut[1].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    imageBarrierOut[1].subresourceRange.layerCount = 1;
+    imageBarrierOut[1].subresourceRange.levelCount = 1;
+    imageBarrierOut[1].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    imageBarrierOut[1].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+
+    commandBufferBegin();
+    vkCmdPipelineBarrier(m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, imageBarrierIn.size(), imageBarrierIn.data());
+    vkCmdBlitImage(m_commandBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &imageBlit, VK_FILTER_NEAREST);
+    vkCmdPipelineBarrier(m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, imageBarrierOut.size(), imageBarrierOut.data());
+    commandBufferSubmit();
+
+    VkImageSubresource subresource = {};
+    subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    VkSubresourceLayout layout;
+    vkGetImageSubresourceLayout(m_dev, dstImage, &subresource, &layout);
+
+    const char *imageData;
+    VK_CHECK(vkMapMemory(m_dev, dstMemory, 0, VK_WHOLE_SIZE, 0, (void**)&imageData));
+    imageData += layout.offset;
+
+    std::ofstream file(filename, std::ios::out | std::ios::binary);
+
+    // PPM header
+    file << "P6\n" << width << "\n" << height << "\n" << 255 << "\n";
+
+    // PPM binary pixel data
+    for (uint32_t y = 0; y < height; y++) {
+        unsigned int *row = (unsigned int*)imageData;
+        for (uint32_t x = 0; x < width; x++) {
+            file.write((char*)row++, 3);
+        }
+        imageData += layout.rowPitch;
+    }
+    file.close();
+
+    std::cout << "Image saved to \"" << filename << "\"" << std::endl;
+
+    vkUnmapMemory(m_dev, dstMemory);
+    vkFreeMemory(m_dev, dstMemory, nullptr);
+    vkDestroyImage(m_dev, dstImage, nullptr);
 }
 
 uint32_t Renderer::memoryTypeIndex(VkMemoryPropertyFlags properties, uint32_t typeBits) const

--- a/alvr/server/cpp/platform/linux/Renderer.cpp
+++ b/alvr/server/cpp/platform/linux/Renderer.cpp
@@ -675,12 +675,12 @@ void Renderer::Wait(uint32_t index, uint64_t waitValue)
     VK_CHECK(vkWaitSemaphores(m_dev, &waitInfo, UINT64_MAX));
 }
 
-void Renderer::CaptureInputFrame(const char *filename)
+void Renderer::CaptureInputFrame(const std::string &filename)
 {
     m_inputImageCapture = filename;
 }
 
-void Renderer::CaptureOutputFrame(const char *filename)
+void Renderer::CaptureOutputFrame(const std::string &filename)
 {
     m_outputImageCapture = filename;
 }
@@ -991,7 +991,7 @@ void Renderer::dumpImage(VkImage image, VkImageLayout imageLayout, uint32_t widt
 
     // PPM binary pixel data
     for (uint32_t y = 0; y < height; y++) {
-        unsigned int *row = (unsigned int*)imageData;
+        uint32_t *row = (uint32_t*)imageData;
         for (uint32_t x = 0; x < width; x++) {
             file.write((char*)row++, 3);
         }

--- a/alvr/server/cpp/platform/linux/Renderer.h
+++ b/alvr/server/cpp/platform/linux/Renderer.h
@@ -47,8 +47,8 @@ public:
     void CopyOutput(VkImage image, VkFormat format, VkImageLayout layout, VkSemaphore *semaphore);
 
     void Wait(uint32_t index, uint64_t waitValue);
-    void CaptureInputFrame(const char *filename);
-    void CaptureOutputFrame(const char *filename);
+    void CaptureInputFrame(const std::string &filename);
+    void CaptureOutputFrame(const std::string &filename);
 
 private:
     struct InputImage {

--- a/alvr/server/cpp/platform/linux/Renderer.h
+++ b/alvr/server/cpp/platform/linux/Renderer.h
@@ -46,6 +46,10 @@ public:
 
     void CopyOutput(VkImage image, VkFormat format, VkImageLayout layout, VkSemaphore *semaphore);
 
+    void Wait(uint32_t index, uint64_t waitValue);
+    void CaptureInputFrame(const char *filename);
+    void CaptureOutputFrame(const char *filename);
+
 private:
     struct InputImage {
         VkImage image;
@@ -66,6 +70,7 @@ private:
     void commandBufferBegin();
     void commandBufferSubmit();
     void addStagingImage(uint32_t width, uint32_t height);
+    void dumpImage(VkImage image, VkImageLayout imageLayout, uint32_t width, uint32_t height, const std::string &filename);
     uint32_t memoryTypeIndex(VkMemoryPropertyFlags properties, uint32_t typeBits) const;
 
     struct {
@@ -96,6 +101,9 @@ private:
     VkDescriptorSetLayout m_descriptorLayout;
     VkCommandBuffer m_commandBuffer;
     VkFence m_fence;
+
+    std::string m_inputImageCapture;
+    std::string m_outputImageCapture;
 
     friend class RenderPipeline;
 };

--- a/alvr/server/cpp/platform/win32/CEncoder.cpp
+++ b/alvr/server/cpp/platform/win32/CEncoder.cpp
@@ -124,3 +124,6 @@
 		void CEncoder::InsertIDR() {
 			m_scheduler.InsertIDR();
 		}
+
+		void CEncoder::CaptureFrame() {
+		}

--- a/alvr/server/cpp/platform/win32/CEncoder.h
+++ b/alvr/server/cpp/platform/win32/CEncoder.h
@@ -53,6 +53,8 @@
 
 		void InsertIDR();
 
+		void CaptureFrame();
+
 	private:
 		CThreadEvent m_newFrameReady, m_encodeFinished;
 		std::shared_ptr<VideoEncoder> m_videoEncoder;

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -461,6 +461,7 @@ fn try_connect(mut client_ips: HashMap<IpAddr, String>) -> IntResult {
         rc_max_bitrate: nvenc_overrides.rc_max_bitrate,
         rc_average_bitrate: nvenc_overrides.rc_average_bitrate,
         enable_aq: nvenc_overrides.enable_aq,
+        capture_frame_dir: settings.extra.capture_frame_dir,
     };
 
     if SERVER_DATA_MANAGER.read().session().openvr_config != new_openvr_config {

--- a/alvr/server/src/web_server.rs
+++ b/alvr/server/src/web_server.rs
@@ -267,6 +267,12 @@ async fn http_api(
             }
             reply(StatusCode::BAD_REQUEST)?
         }
+        "/api/capture-frame" => {
+            unsafe {
+                crate::CaptureFrame();
+            };
+            return reply(StatusCode::OK);
+        }
         other_uri => {
             if other_uri.contains("..") {
                 // Attempted tree traversal

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -116,6 +116,7 @@ pub struct OpenvrConfig {
     pub rc_max_bitrate: i64,
     pub rc_average_bitrate: i64,
     pub enable_aq: i64,
+    pub capture_frame_dir: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -170,6 +171,7 @@ impl Default for SessionDesc {
                 enable_foveated_rendering: false,
                 enable_color_correction: false,
                 linux_async_reprojection: false,
+                capture_frame_dir: "/tmp".into(),
                 ..<_>::default()
             },
             client_connections: HashMap::new(),

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -593,6 +593,8 @@ pub struct ExtraDesc {
     #[schema(advanced)]
     pub exclude_notifications_without_id: bool,
 
+    pub capture_frame_dir: String,
+
     pub patches: Patches,
 }
 
@@ -886,6 +888,11 @@ pub fn session_settings_default() -> SettingsDefault {
                 },
             },
             exclude_notifications_without_id: false,
+            capture_frame_dir: if !cfg!(target_os = "linux") {
+                "/tmp".into()
+            } else {
+                "".into()
+            },
             patches: PatchesDefault {
                 remove_sync_popup: false,
                 linux_async_reprojection: false,

--- a/dashboard/js/app/main.js
+++ b/dashboard/js/app/main.js
@@ -285,6 +285,10 @@ define([
                 });
             });
 
+            $("#captureFrame").click(() => {
+                $.get("api/capture-frame");
+            });
+
             $("#checkForUpdates").click(() => {
                 checkForUpdate(settings, 5000);
             });

--- a/dashboard/js/app/nls/main.js
+++ b/dashboard/js/app/nls/main.js
@@ -5,6 +5,7 @@ define({
         "monitor": "Monitor",
         "settings": "Settings",
         "installation": "Installation",
+        "debug": "Debug",
         "about": "About",
         "languages": "Languages",
         "systemLanguage": "System",
@@ -17,6 +18,8 @@ define({
         "addFirewallRules": "Add firewall rules",
         "removeFirewallRules": "Remove firewall rules",
         "firewallSuccess": "Firewall rules successfully set",
+        // Debug page
+        "captureFrame": "Capture frame",
         // About page
         "aboutText": "Stream VR games from your PC to your headset via Wi-Fi. <br/> ALVR uses technologies like <a target= '_blank' href='https://developer.oculus.com/documentation/native/android/mobile-timewarp-overview/'>Asynchronous TimeWarp (ATW)</a> and <a target= '_blank' href='https://developer.oculus.com/documentation/native/android/mobile-ffr/'>Fixed Foveated Rendering (FFR)</a> for a smoother experience. <br/> All games that work with an Oculus Rift(s) should work with ALVR. <br/> This is a fork of ALVR that works with Oculus Quest and Go. <br/> <br/> Visit us on GitHub <a target= '_blank' href='https://github.com/alvr-org/ALVR/'>https://github.com/alvr-org/ALVR/</a> <br/> Join us on Discord: <a target='_blank' href='https://discord.gg/ALVR'>https://discord.gg/ALVR</a>",
         "openReleasePage": "Open release page",

--- a/dashboard/js/app/templates/main.html
+++ b/dashboard/js/app/templates/main.html
@@ -24,6 +24,12 @@
             </li>
 
             <li>
+                <a href="#debug" data-toggle="tab">
+                    <i class="fa fa-bug fa-lg"></i> <%= debug%>
+                </a>
+            </li>
+
+            <li>
                 <a href="#about" data-toggle="tab">
                     <i class="fa fa-info-circle fa-lg"></i> <%= about%>
                 </a>
@@ -89,6 +95,11 @@
                 <button id="removeFirewallRules" type="button" class="btn btn-primary"> <%= removeFirewallRules%>
                 </button>
                 <div id="registeredDriversInst"></div>
+            </div>
+
+            <div class="tab-pane alvrSection fade" id="debug">
+                <br />
+                <button id="captureFrame" type="button" class="btn btn-primary"> <%= captureFrame%> </button>
             </div>
 
             <div class="tab-pane alvrSection fade" id="about">


### PR DESCRIPTION
Option to capture input/output frames.
Also added convenience `Wait()` which can be called before ReportPresent so that the Server Compositor time in statistics only include render time.