### PR TITLE
reuse ovr singleton references

### DIFF
--- a/alvr/server/cpp/alvr_server/OvrHMD.cpp
+++ b/alvr/server/cpp/alvr_server/OvrHMD.cpp
@@ -143,56 +143,58 @@ std::string OvrHmd::GetSerialNumber() const { return Settings::Instance().mSeria
 vr::EVRInitError OvrHmd::Activate(vr::TrackedDeviceIndex_t unObjectId) {
     Debug("CRemoteHmd Activate %d\n", unObjectId);
 
-    this->object_id = unObjectId;
-    this->prop_container = vr::VRProperties()->TrackedDeviceToPropertyContainer(this->object_id);
+    auto vr_properties = vr::VRProperties();
 
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    this->object_id = unObjectId;
+    this->prop_container = vr_properties->TrackedDeviceToPropertyContainer(this->object_id);
+
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_TrackingSystemName_String,
                                           Settings::Instance().mTrackingSystemName.c_str());
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_ModelNumber_String,
                                           Settings::Instance().mModelNumber.c_str());
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_ManufacturerName_String,
                                           Settings::Instance().mManufacturerName.c_str());
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_RenderModelName_String,
                                           Settings::Instance().mRenderModelName.c_str());
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_RegisteredDeviceType_String,
                                           Settings::Instance().mRegisteredDeviceType.c_str());
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_DriverVersion_String,
                                           Settings::Instance().mDriverVersion.c_str());
-    vr::VRProperties()->SetFloatProperty(
+    vr_properties->SetFloatProperty(
         this->prop_container, vr::Prop_UserIpdMeters_Float, Settings::Instance().m_flIPD);
-    vr::VRProperties()->SetFloatProperty(
+    vr_properties->SetFloatProperty(
         this->prop_container, vr::Prop_UserHeadToEyeDepthMeters_Float, 0.f);
-    vr::VRProperties()->SetFloatProperty(this->prop_container,
+    vr_properties->SetFloatProperty(this->prop_container,
                                          vr::Prop_DisplayFrequency_Float,
                                          static_cast<float>(Settings::Instance().m_refreshRate));
-    vr::VRProperties()->SetFloatProperty(
+    vr_properties->SetFloatProperty(
         this->prop_container, vr::Prop_SecondsFromVsyncToPhotons_Float, 0.);
-    // vr::VRProperties()->SetFloatProperty(this->prop_container,
+    // vr_properties->SetFloatProperty(this->prop_container,
     // vr::Prop_SecondsFromVsyncToPhotons_Float,
     // Settings::Instance().m_flSecondsFromVsyncToPhotons);
 
     // return a constant that's not 0 (invalid) or 1 (reserved for Oculus)
-    vr::VRProperties()->SetUint64Property(
+    vr_properties->SetUint64Property(
         this->prop_container, vr::Prop_CurrentUniverseId_Uint64, Settings::Instance().m_universeId);
 
 #ifdef _WIN32
     // avoid "not fullscreen" warnings from vrmonitor
-    vr::VRProperties()->SetBoolProperty(this->prop_container, vr::Prop_IsOnDesktop_Bool, false);
+    vr_properties->SetBoolProperty(this->prop_container, vr::Prop_IsOnDesktop_Bool, false);
 
     // Manually send VSync events on direct mode.
     // ref:https://github.com/ValveSoftware/virtual_display/issues/1
-    vr::VRProperties()->SetBoolProperty(
+    vr_properties->SetBoolProperty(
         this->prop_container, vr::Prop_DriverDirectModeSendsVsyncEvents_Bool, true);
 #endif
 
     // Set battery as true
-    vr::VRProperties()->SetBoolProperty(
+    vr_properties->SetBoolProperty(
         this->prop_container, vr::Prop_DeviceProvidesBatteryStatus_Bool, true);
 
 #ifdef _WIN32
@@ -206,22 +208,22 @@ vr::EVRInitError OvrHmd::Activate(vr::TrackedDeviceIndex_t unObjectId) {
     HmdMatrix_SetIdentity(&m_eyeToHeadRight);
 
     // set the icons in steamvr to the default icons used for Oculus Link
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_NamedIconPathDeviceOff_String,
                                           "{oculus}/icons/quest_headset_off.png");
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_NamedIconPathDeviceSearching_String,
                                           "{oculus}/icons/quest_headset_searching.gif");
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_NamedIconPathDeviceSearchingAlert_String,
                                           "{oculus}/icons/quest_headset_alert_searching.gif");
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_NamedIconPathDeviceReady_String,
                                           "{oculus}/icons/quest_headset_ready.png");
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_NamedIconPathDeviceReadyAlert_String,
                                           "{oculus}/icons/quest_headset_ready_alert.png");
-    vr::VRProperties()->SetStringProperty(this->prop_container,
+    vr_properties->SetStringProperty(this->prop_container,
                                           vr::Prop_NamedIconPathDeviceStandby_String,
                                           "{oculus}/icons/quest_headset_standby.png");
 

--- a/alvr/server/cpp/alvr_server/OvrViveTrackerProxy.cpp
+++ b/alvr/server/cpp/alvr_server/OvrViveTrackerProxy.cpp
@@ -17,64 +17,66 @@ vr::DriverPose_t OvrViveTrackerProxy::GetPose()
 
 vr::EVRInitError OvrViveTrackerProxy::Activate( vr::TrackedDeviceIndex_t unObjectId )
 {
+    auto vr_properties = vr::VRProperties();
+
     m_unObjectId = unObjectId;
     assert(m_unObjectId != vr::k_unTrackedDeviceIndexInvalid);
-	const auto propertyContainer = vr::VRProperties()->TrackedDeviceToPropertyContainer( m_unObjectId );
+	const auto propertyContainer = vr_properties->TrackedDeviceToPropertyContainer( m_unObjectId );
 
     // Normally a vive tracker emulator would (logically) always set the tracking system to "lighthouse" but in order to do space calibration
     // with existing tools such as OpenVR Space calibrator and be able to calibrate to/from ALVR HMD (and the proxy tracker) space to/from
     // a native HMD/tracked device which is already using "lighthouse" as the tracking system the proxy tracker needs to be in a different
     // tracking system to treat them differently and prevent those tools doing the same space transform to the proxy tracker.
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_TrackingSystemName_String, Settings::Instance().mTrackingSystemName.c_str());//"lighthouse");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_ModelNumber_String, "Vive Tracker Pro MV");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_SerialNumber_String, GetSerialNumber()); // Changed
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_RenderModelName_String, "{htc}vr_tracker_vive_1_0");
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_WillDriftInYaw_Bool, false);
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_ManufacturerName_String, "HTC");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_TrackingFirmwareVersion_String, "1541800000 RUNNER-WATCHMAN$runner-watchman@runner-watchman 2018-01-01 FPGA 512(2.56/0/0) BL 0 VRC 1541800000 Radio 1518800000"); // Changed
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_HardwareRevision_String, "product 128 rev 2.5.6 lot 2000/0/0 0"); // Changed
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_ConnectedWirelessDongle_String, "D0000BE000"); // Changed
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_DeviceIsWireless_Bool, true);
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_DeviceIsCharging_Bool, false);
-    vr::VRProperties()->SetFloatProperty(propertyContainer, vr::Prop_DeviceBatteryPercentage_Float, 1.f); // Always charged
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_TrackingSystemName_String, Settings::Instance().mTrackingSystemName.c_str());//"lighthouse");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_ModelNumber_String, "Vive Tracker Pro MV");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_SerialNumber_String, GetSerialNumber()); // Changed
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_RenderModelName_String, "{htc}vr_tracker_vive_1_0");
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_WillDriftInYaw_Bool, false);
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_ManufacturerName_String, "HTC");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_TrackingFirmwareVersion_String, "1541800000 RUNNER-WATCHMAN$runner-watchman@runner-watchman 2018-01-01 FPGA 512(2.56/0/0) BL 0 VRC 1541800000 Radio 1518800000"); // Changed
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_HardwareRevision_String, "product 128 rev 2.5.6 lot 2000/0/0 0"); // Changed
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_ConnectedWirelessDongle_String, "D0000BE000"); // Changed
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_DeviceIsWireless_Bool, true);
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_DeviceIsCharging_Bool, false);
+    vr_properties->SetFloatProperty(propertyContainer, vr::Prop_DeviceBatteryPercentage_Float, 1.f); // Always charged
 
     vr::HmdMatrix34_t l_transform = {{{-1.f, 0.f, 0.f, 0.f}, {0.f, 0.f, -1.f, 0.f}, {0.f, -1.f, 0.f, 0.f}}};
-    vr::VRProperties()->SetProperty(propertyContainer, vr::Prop_StatusDisplayTransform_Matrix34, &l_transform, sizeof(vr::HmdMatrix34_t), vr::k_unHmdMatrix34PropertyTag);
+    vr_properties->SetProperty(propertyContainer, vr::Prop_StatusDisplayTransform_Matrix34, &l_transform, sizeof(vr::HmdMatrix34_t), vr::k_unHmdMatrix34PropertyTag);
 
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_Firmware_UpdateAvailable_Bool, false);
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_Firmware_ManualUpdate_Bool, false);
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_Firmware_ManualUpdateURL_String, "https://developer.valvesoftware.com/wiki/SteamVR/HowTo_Update_Firmware");
-    vr::VRProperties()->SetUint64Property(propertyContainer, vr::Prop_HardwareRevision_Uint64, 2214720000); // Changed
-    vr::VRProperties()->SetUint64Property(propertyContainer, vr::Prop_FirmwareVersion_Uint64, 1541800000); // Changed
-    vr::VRProperties()->SetUint64Property(propertyContainer, vr::Prop_FPGAVersion_Uint64, 512); // Changed
-    vr::VRProperties()->SetUint64Property(propertyContainer, vr::Prop_VRCVersion_Uint64, 1514800000); // Changed
-    vr::VRProperties()->SetUint64Property(propertyContainer, vr::Prop_RadioVersion_Uint64, 1518800000); // Changed
-    vr::VRProperties()->SetUint64Property(propertyContainer, vr::Prop_DongleVersion_Uint64, 8933539758); // Changed, based on vr::Prop_ConnectedWirelessDongle_String above
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_DeviceProvidesBatteryStatus_Bool, true);
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_DeviceCanPowerOff_Bool, true);
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_Firmware_ProgrammingTarget_String, GetSerialNumber());
-    vr::VRProperties()->SetInt32Property(propertyContainer, vr::Prop_DeviceClass_Int32, vr::TrackedDeviceClass_GenericTracker);
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_Firmware_ForceUpdateRequired_Bool, false);
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_ResourceRoot_String, "htc");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_RegisteredDeviceType_String, "ALVR/tracker/hmd_proxy");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_InputProfilePath_String, "{htc}/input/vive_tracker_profile.json");
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_Identifiable_Bool, false);
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_Firmware_RemindUpdate_Bool, false);
-    vr::VRProperties()->SetInt32Property(propertyContainer, vr::Prop_ControllerRoleHint_Int32, vr::TrackedControllerRole_Invalid);
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_ControllerType_String, "vive_tracker_waist");
-    vr::VRProperties()->SetInt32Property(propertyContainer, vr::Prop_ControllerHandSelectionPriority_Int32, -1);
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceOff_String, "{htc}/icons/tracker_status_off.png");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceSearching_String, "{htc}/icons/tracker_status_searching.gif");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceSearchingAlert_String, "{htc}/icons/tracker_status_searching_alert.gif");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceReady_String, "{htc}/icons/tracker_status_ready.png");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceReadyAlert_String, "{htc}/icons/tracker_status_ready_alert.png");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceNotReady_String, "{htc}/icons/tracker_status_error.png");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceStandby_String, "{htc}/icons/tracker_status_standby.png");
-    vr::VRProperties()->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceAlertLow_String, "{htc}/icons/tracker_status_ready_low.png");
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_HasDisplayComponent_Bool, false);
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_HasCameraComponent_Bool, false);
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_HasDriverDirectModeComponent_Bool, false);
-    vr::VRProperties()->SetBoolProperty(propertyContainer, vr::Prop_HasVirtualDisplayComponent_Bool, false);
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_Firmware_UpdateAvailable_Bool, false);
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_Firmware_ManualUpdate_Bool, false);
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_Firmware_ManualUpdateURL_String, "https://developer.valvesoftware.com/wiki/SteamVR/HowTo_Update_Firmware");
+    vr_properties->SetUint64Property(propertyContainer, vr::Prop_HardwareRevision_Uint64, 2214720000); // Changed
+    vr_properties->SetUint64Property(propertyContainer, vr::Prop_FirmwareVersion_Uint64, 1541800000); // Changed
+    vr_properties->SetUint64Property(propertyContainer, vr::Prop_FPGAVersion_Uint64, 512); // Changed
+    vr_properties->SetUint64Property(propertyContainer, vr::Prop_VRCVersion_Uint64, 1514800000); // Changed
+    vr_properties->SetUint64Property(propertyContainer, vr::Prop_RadioVersion_Uint64, 1518800000); // Changed
+    vr_properties->SetUint64Property(propertyContainer, vr::Prop_DongleVersion_Uint64, 8933539758); // Changed, based on vr::Prop_ConnectedWirelessDongle_String above
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_DeviceProvidesBatteryStatus_Bool, true);
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_DeviceCanPowerOff_Bool, true);
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_Firmware_ProgrammingTarget_String, GetSerialNumber());
+    vr_properties->SetInt32Property(propertyContainer, vr::Prop_DeviceClass_Int32, vr::TrackedDeviceClass_GenericTracker);
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_Firmware_ForceUpdateRequired_Bool, false);
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_ResourceRoot_String, "htc");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_RegisteredDeviceType_String, "ALVR/tracker/hmd_proxy");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_InputProfilePath_String, "{htc}/input/vive_tracker_profile.json");
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_Identifiable_Bool, false);
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_Firmware_RemindUpdate_Bool, false);
+    vr_properties->SetInt32Property(propertyContainer, vr::Prop_ControllerRoleHint_Int32, vr::TrackedControllerRole_Invalid);
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_ControllerType_String, "vive_tracker_waist");
+    vr_properties->SetInt32Property(propertyContainer, vr::Prop_ControllerHandSelectionPriority_Int32, -1);
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceOff_String, "{htc}/icons/tracker_status_off.png");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceSearching_String, "{htc}/icons/tracker_status_searching.gif");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceSearchingAlert_String, "{htc}/icons/tracker_status_searching_alert.gif");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceReady_String, "{htc}/icons/tracker_status_ready.png");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceReadyAlert_String, "{htc}/icons/tracker_status_ready_alert.png");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceNotReady_String, "{htc}/icons/tracker_status_error.png");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceStandby_String, "{htc}/icons/tracker_status_standby.png");
+    vr_properties->SetStringProperty(propertyContainer, vr::Prop_NamedIconPathDeviceAlertLow_String, "{htc}/icons/tracker_status_ready_low.png");
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_HasDisplayComponent_Bool, false);
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_HasCameraComponent_Bool, false);
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_HasDriverDirectModeComponent_Bool, false);
+    vr_properties->SetBoolProperty(propertyContainer, vr::Prop_HasVirtualDisplayComponent_Bool, false);
     return vr::VRInitError_None;
 }
 

--- a/alvr/server/cpp/alvr_server/TrackedDevice.cpp
+++ b/alvr/server/cpp/alvr_server/TrackedDevice.cpp
@@ -4,29 +4,31 @@
 void TrackedDevice::set_prop(OpenvrProperty prop) {
     auto key = (vr::ETrackedDeviceProperty)prop.key;
 
+    auto vr_properties = vr::VRProperties();
+
     vr::ETrackedPropertyError result;
 
     if (prop.type == OpenvrPropertyType::Bool) {
-        result = vr::VRProperties()->SetBoolProperty(this->prop_container, key, prop.value.bool_);
+        result = vr_properties->SetBoolProperty(this->prop_container, key, prop.value.bool_);
     } else if (prop.type == OpenvrPropertyType::Float) {
-        result = vr::VRProperties()->SetFloatProperty(this->prop_container, key, prop.value.float_);
+        result = vr_properties->SetFloatProperty(this->prop_container, key, prop.value.float_);
     } else if (prop.type == OpenvrPropertyType::Int32) {
-        result = vr::VRProperties()->SetInt32Property(this->prop_container, key, prop.value.int32);
+        result = vr_properties->SetInt32Property(this->prop_container, key, prop.value.int32);
     } else if (prop.type == OpenvrPropertyType::Uint64) {
         result =
-            vr::VRProperties()->SetUint64Property(this->prop_container, key, prop.value.uint64);
+            vr_properties->SetUint64Property(this->prop_container, key, prop.value.uint64);
     } else if (prop.type == OpenvrPropertyType::Vector3) {
         auto vec3 = vr::HmdVector3_t{};
         vec3.v[0] = prop.value.vector3[0];
         vec3.v[1] = prop.value.vector3[1];
         vec3.v[2] = prop.value.vector3[2];
-        result = vr::VRProperties()->SetVec3Property(this->prop_container, key, vec3);
+        result = vr_properties->SetVec3Property(this->prop_container, key, vec3);
     } else if (prop.type == OpenvrPropertyType::Double) {
         result =
-            vr::VRProperties()->SetDoubleProperty(this->prop_container, key, prop.value.double_);
+            vr_properties->SetDoubleProperty(this->prop_container, key, prop.value.double_);
     } else if (prop.type == OpenvrPropertyType::String) {
         result =
-            vr::VRProperties()->SetStringProperty(this->prop_container, key, prop.value.string);
+            vr_properties->SetStringProperty(this->prop_container, key, prop.value.string);
     } else {
         Error("Unreachable");
         result = vr::TrackedProp_Success;


### PR DESCRIPTION
Cherry picked this commit from  #1268

> The second commit aims to reduce code bloat with the openvr singletons. Clang isn't allowed to optimize this properly because the invoked function could have side effects.
In release, `OvrController::Activate` went from 18296 to 10424 bytes (-43%)
`OvrController::onPoseUpdate` from 15201 to 9167 bytes (-40%)