### PR TITLE
AMF changes

### DIFF
--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -71,7 +71,6 @@ void AMFSolidPipe::Passthrough(AMFDataPtr data)
 
 AMFPipeline::AMFPipeline() 
 	: m_thread(nullptr)
-	, m_receiveThread(nullptr)
 	, m_pipes()
 	, isRunning(false) 
 {}
@@ -87,13 +86,6 @@ AMFPipeline::~AMFPipeline()
 		delete m_thread;
 		m_thread = nullptr;
 	}
-	if (m_receiveThread) {
-		Debug("AMFPipeline::~AMFPipeline() m_receiveThread->join\n");
-		m_receiveThread->join();
-		Debug("AMFPipeline::~AMFPipeline() m_receiveThread joined.\n");
-		delete m_receiveThread;
-		m_receiveThread = nullptr;
-	}
 	for (auto &pipe : m_pipes) 
 	{
 		delete pipe;
@@ -108,24 +100,12 @@ void AMFPipeline::Connect(AMFPipePtr pipe)
 void AMFPipeline::Run()
 {
 	Debug("Start AMFPipeline Run() thread. Thread Id=%d\n", GetCurrentThreadId());
-	auto it = m_pipes.begin();
-	auto itEnd = std::prev(m_pipes.end());
 	while (isRunning)
 	{
-		for (it = m_pipes.begin(); it != itEnd; it++)
+		for (auto &pipe : m_pipes)
 		{
-			(*it)->doPassthrough();
+			pipe->doPassthrough();
 		}
-		amf_sleep(1);
-	}
-}
-
-void AMFPipeline::RunReceive()
-{
-	Debug("Start AMFPipeline RunReceive() thread. Thread Id=%d\n", GetCurrentThreadId());
-	while (isRunning)
-	{
-		m_pipes.back()->doPassthrough();
 		amf_sleep(1);
 	}
 }
@@ -134,7 +114,6 @@ void AMFPipeline::Start()
 {
 	isRunning = true;
 	m_thread = new std::thread(&AMFPipeline::Run, this);
-	m_receiveThread = new std::thread(&AMFPipeline::RunReceive, this);
 }
 
 //

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -240,7 +240,6 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD, AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR);
 		// Required for CBR to work correctly
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FILLER_DATA_ENABLE, true);
-		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_TIER, AMF_VIDEO_ENCODER_HEVC_TIER_HIGH);
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, bitRateIn);
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMESIZE, ::AMFConstructSize(width, height));
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMERATE, ::AMFConstructRate(frameRateIn, 1));

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -210,15 +210,15 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_B_PIC_PATTERN, 0);
 
 		switch (m_encoderQualityPreset) {
-			case SPEED:
-				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, AMF_VIDEO_ENCODER_QUALITY_PRESET_SPEED);
+			case QUALITY:
+				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, AMF_VIDEO_ENCODER_QUALITY_PRESET_QUALITY);
 				break;
 			case BALANCED:
 				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, AMF_VIDEO_ENCODER_QUALITY_PRESET_BALANCED);
 				break;
-			case QUALITY:
+			case SPEED:
 			default:
-				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, AMF_VIDEO_ENCODER_QUALITY_PRESET_QUALITY);
+				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, AMF_VIDEO_ENCODER_QUALITY_PRESET_SPEED);
 				break;
 		}
 
@@ -245,15 +245,15 @@ amf::AMFComponentPtr VideoEncoderVCE::MakeEncoder(
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMERATE, ::AMFConstructRate(frameRateIn, 1));
 
 		switch (m_encoderQualityPreset) {
-			case SPEED:
-				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_SPEED);
+			case QUALITY:
+				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_QUALITY);
 				break;
 			case BALANCED:
 				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_BALANCED);
 				break;
-			case QUALITY:
+			case SPEED:
 			default:
-				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_QUALITY);
+				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET_SPEED);
 				break;
 		}
 

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
@@ -47,7 +47,6 @@ public:
 	void RunReceive();
 protected:
 	std::thread *m_thread;
-	std::thread *m_receiveThread;
 	std::vector<AMFPipePtr> m_pipes;
 	bool isRunning;
 };

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -667,7 +667,7 @@ pub fn session_settings_default() -> SettingsDefault {
                     preproc_sigma: 4,
                     preproc_tor: 7,
                     encoder_quality_preset: EncoderQualityPresetDefault {
-                        variant: EncoderQualityPresetDefaultVariant::Quality,
+                        variant: EncoderQualityPresetDefaultVariant::Speed,
                     },
                 },
                 mediacodec_extra_options: DictionaryDefault {


### PR DESCRIPTION
1. Remove `High` HEVC tier (introduced in https://github.com/alvr-org/ALVR/pull/1220) as it seems not to work as intended (ignores AUD NAL skip setting in earlier driver versions) and looks like causing crashes.
2. Make `Speed` quality preset the default option. Speed is safe default and let the user decide if Balanced or Quality is better for them.
3. Remove separate receiver thread (added in https://github.com/alvr-org/ALVR/pull/1227).