### PR TITLE
Workaround symbol clash in openvr.h / openvr_driver.h 

### DIFF
--- a/alvr/server/cpp/alvr_server/ChaperoneUpdater.cpp
+++ b/alvr/server/cpp/alvr_server/ChaperoneUpdater.cpp
@@ -4,10 +4,13 @@
 #include <mutex>
 
 #ifndef __APPLE__
+// Workaround symbol clash in openvr.h / openvr_driver.h
+namespace alvr_chaperone {
 #include <openvr.h>
+}
 #endif
 
-using namespace std;
+using namespace alvr_chaperone;
 
 static std::mutex chaperone_mutex;
 


### PR DESCRIPTION
These headers are not meant to be used together in one
executable, and issues will arise when compiler decides
to not inline some methods.
Workaround by adding namespace around openvr.h include.

Fixes crash on startup in debug build.