### PR TITLE
vulkan_layer: Rewrite vsync fence to wait on conditional

### DIFF
--- a/alvr/vulkan_layer/layer/device_api.hpp
+++ b/alvr/vulkan_layer/layer/device_api.hpp
@@ -39,6 +39,12 @@ VKAPI_ATTR VkResult VKAPI_CALL wsi_layer_vkRegisterDisplayEventEXT(
 VKAPI_ATTR void VKAPI_CALL wsi_layer_vkDestroyFence(VkDevice device, VkFence fence,
                                                     const VkAllocationCallbacks *pAllocator);
 
+VKAPI_ATTR VkResult VKAPI_CALL wsi_layer_vkWaitForFences(VkDevice device, uint32_t fenceCount,
+                                                         const VkFence *pFences, VkBool32 waitAll,
+                                                         uint64_t timeout);
+
+VKAPI_ATTR VkResult wsi_layer_vkGetFenceStatus(VkDevice device, VkFence fence);
+
 VKAPI_ATTR VkResult VKAPI_CALL wsi_layer_vkCreateDisplayModeKHR(
     VkPhysicalDevice                            physicalDevice,
     VkDisplayKHR                                display,

--- a/alvr/vulkan_layer/layer/layer.cpp
+++ b/alvr/vulkan_layer/layer/layer.cpp
@@ -258,51 +258,6 @@ VKAPI_ATTR VkResult create_device(VkPhysicalDevice physicalDevice,
     modified_info.ppEnabledExtensionNames = modified_enabled_extensions.data();
     modified_info.enabledExtensionCount = modified_enabled_extensions.size();
 
-    // Add one queue to safely submit vsync from our thread
-    std::vector<VkDeviceQueueCreateInfo> queueCreateInfo(pCreateInfo->pQueueCreateInfos, pCreateInfo->pQueueCreateInfos + pCreateInfo->queueCreateInfoCount);
-    assert(queueCreateInfo.size() > 0);
-    uint32_t size = 0;
-    inst_data.disp.GetPhysicalDeviceQueueFamilyProperties(physicalDevice, &size, nullptr);
-    std::vector<VkQueueFamilyProperties> props(size);
-    inst_data.disp.GetPhysicalDeviceQueueFamilyProperties(physicalDevice, &size, props.data());
-    std::vector<float> queuePriorities;
-    size_t display_queue = 0;
-    for (; display_queue < queueCreateInfo.size() ; ++display_queue)
-    {
-      if (queueCreateInfo[display_queue].queueCount >= props[queueCreateInfo[display_queue].queueFamilyIndex].queueCount)
-        continue;
-      queuePriorities = std::vector<float>(queueCreateInfo[display_queue].pQueuePriorities, queueCreateInfo[display_queue].pQueuePriorities + queueCreateInfo[display_queue].queueCount);
-      queueCreateInfo[display_queue].queueCount += 1;
-      queuePriorities.push_back(1);
-      queueCreateInfo[display_queue].pQueuePriorities = queuePriorities.data();
-      break;
-    }
-    float queue_prio = 1.0;
-    if (display_queue == queueCreateInfo.size()) {
-      for (size_t i = 0; i < props.size(); ++i) {
-        bool used = false;
-        for (const VkDeviceQueueCreateInfo &info : queueCreateInfo) {
-          if (info.queueFamilyIndex == i) {
-            used = true;
-            break;
-          }
-        }
-        if (used)
-          continue;
-        VkDeviceQueueCreateInfo info;
-        info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-        info.pNext = nullptr;
-        info.flags = 0;
-        info.queueFamilyIndex = i;
-        info.queueCount = 1;
-        info.pQueuePriorities = &queue_prio;
-        queueCreateInfo.push_back(info);
-        break;
-      }
-    }
-    modified_info.pQueueCreateInfos = queueCreateInfo.data();
-    modified_info.queueCreateInfoCount = queueCreateInfo.size();
-
     // Enable timeline semaphores
     VkPhysicalDeviceFeatures2 features = {};
     features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
@@ -352,7 +307,7 @@ VKAPI_ATTR VkResult create_device(VkPhysicalDevice physicalDevice,
 
     std::unique_ptr<device_private_data> device{
         new device_private_data{inst_data, physicalDevice, *pDevice, table, loader_callback}};
-    device->display = std::make_unique<wsi::display>(*device, queueCreateInfo[display_queue].queueFamilyIndex, queueCreateInfo[display_queue].queueCount - 1);
+    device->display = std::make_unique<wsi::display>();
     device_private_data::set(*pDevice, std::move(device));
     return VK_SUCCESS;
 }
@@ -451,6 +406,8 @@ VK_LAYER_EXPORT PFN_vkVoidFunction VKAPI_CALL wsi_layer_vkGetDeviceProcAddr(VkDe
     GET_PROC_ADDR(vkGetSwapchainCounterEXT);
     GET_PROC_ADDR(vkRegisterDisplayEventEXT);
     GET_PROC_ADDR(vkDestroyFence);
+    GET_PROC_ADDR(vkWaitForFences);
+    GET_PROC_ADDR(vkGetFenceStatus);
 
     return layer::device_private_data::get(device).disp.GetDeviceProcAddr(device, funcName);
 }

--- a/alvr/vulkan_layer/wsi/display.cpp
+++ b/alvr/vulkan_layer/wsi/display.cpp
@@ -1,14 +1,10 @@
 #include "display.hpp"
-#include "layer/private_data.hpp"
 
 #include"layer/settings.h"
 
 #include <chrono>
 
-wsi::display::display(layer::device_private_data& device_data, uint32_t queue_family_index, uint32_t queue_index):
-  m_queue_family_index(queue_family_index),
-  m_queue_index(queue_index),
-  m_device_data(device_data)
+wsi::display::display()
 {
 }
 
@@ -16,34 +12,37 @@ VkFence wsi::display::get_vsync_fence()
 {
   if (not std::atomic_exchange(&m_thread_running, true))
   {
-  VkQueue queue;
-  VkFenceCreateInfo fence_info = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0};
-  m_device_data.disp.CreateFence(m_device_data.device, &fence_info, nullptr, &vsync_fence);
-  m_device_data.disp.GetDeviceQueue(m_device_data.device, m_queue_family_index, m_queue_index, &queue);
-  m_device_data.SetDeviceLoaderData(m_device_data.device, queue);
-  m_vsync_thread = std::thread([this, queue]()
+  vsync_fence = reinterpret_cast<VkFence>(this);
+  m_vsync_thread = std::thread([this]()
       {
       auto refresh = Settings::Instance().m_refreshRate;
       auto next_frame = std::chrono::steady_clock::now();
       auto frame_time = std::chrono::duration_cast<decltype(next_frame)::duration>(std::chrono::duration<double>(1. / refresh));
       while (not m_exiting) {
-        if (m_device_data.disp.GetFenceStatus(m_device_data.device, vsync_fence) == VK_NOT_READY)
-        {
-          m_device_data.disp.QueueSubmit(queue, 0, nullptr, vsync_fence);
-        }
-        m_device_data.disp.QueueWaitIdle(queue);
         std::this_thread::sleep_until(next_frame);
+        m_signaled = true;
+        m_cond.notify_all();
         m_vsync_count += 1;
         next_frame += frame_time;
       }
-      m_device_data.disp.DestroyFence(m_device_data.device, vsync_fence, nullptr);
       });
   }
+  m_signaled = false;
   return vsync_fence;
 }
 
 wsi::display::~display() {
+  std::unique_lock<std::mutex> lock(m_mutex);
   m_exiting = true;
   if (m_vsync_thread.joinable())
     m_vsync_thread.join();
+}
+
+bool wsi::display::wait_for_vsync(uint64_t timeoutNs)
+{
+  if (!m_signaled) {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    return m_cond.wait_for(lock, std::chrono::nanoseconds(timeoutNs)) == std::cv_status::no_timeout;
+  }
+  return true;
 }


### PR DESCRIPTION
Throw away the queue hacks and implement it correctly by waiting on conditional variable.
This also fixes validation errors that would complain about using VkFence from multiple threads.