### PR TITLE
FrameRender: Add support for loading custom shaders

### DIFF
--- a/alvr/server/cpp/platform/linux/FrameRender.h
+++ b/alvr/server/cpp/platform/linux/FrameRender.h
@@ -45,6 +45,7 @@ private:
 
     void setupColorCorrection();
     void setupFoveatedRendering();
+    void setupCustomShaders(const std::string &stage);
 
     uint32_t m_width;
     uint32_t m_height;


### PR DESCRIPTION
Load shaders from ~/.config/alvr/shaders/{pre,post} directory.

Subdirectory "pre" applied before internal shaders.
Subdirectory "post" applied after internal shaders.