### PR TITLE
Vulkan: Fallback to first device

### DIFF
--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -204,7 +204,7 @@ void CEncoder::Run() {
           deviceExtensions = alvr::AMFContext::get()->requiredDeviceExtensions();
       }
 
-      alvr::VkContext vk_ctx(useAmf ? nullptr : init.device_name.data(), deviceExtensions);
+      alvr::VkContext vk_ctx(init.device_name.data(), deviceExtensions);
 
       FrameRender render(vk_ctx, init, m_fds);
       auto output = render.CreateOutput();

--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.h
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.h
@@ -60,6 +60,7 @@ public:
   uint32_t queueFamilyIndex;
   std::vector<const char*> instanceExtensions;
   std::vector<const char*> deviceExtensions;
+  bool nvidia = false;
   bool drmContext = false;
 };
 


### PR DESCRIPTION
If device lookup fails for whatever reason, fallback to first device.

Also remove special case when using AMF as it's no longer needed.