### PR TITLE
Use non-blocking socket in vulkan layer

### DIFF
--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -77,7 +77,7 @@ int accept_timeout(pollfd socket, std::atomic_bool &exiting) {
         if (count < 0) {
             throw MakeException("poll failed: %s", strerror(errno));
         } else if (count == 1) {
-          return accept(socket.fd, NULL, NULL);
+          return accept4(socket.fd, NULL, NULL, SOCK_CLOEXEC);
         }
     }
     return -1;
@@ -152,7 +152,7 @@ void CEncoder::Run() {
     // run
     ret = unlink(m_socketPath.c_str());
 
-    m_socket.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    m_socket.fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     struct sockaddr_un name;
     if (m_socket.fd == -1) {
         perror("socket");

--- a/alvr/vulkan_layer/wsi/headless/swapchain.cpp
+++ b/alvr/vulkan_layer/wsi/headless/swapchain.cpp
@@ -251,7 +251,7 @@ bool swapchain::try_connect() {
 
     int ret;
     if (m_socket == -1) {
-        m_socket = socket(AF_UNIX, SOCK_STREAM, 0);
+        m_socket = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
         if (m_socket == -1) {
             perror("socket");
             exit(1);


### PR DESCRIPTION
Layer would eventually deadlock on attempting to write to socket if server wasn't able to drain the buffer fast enough for whatever reason (usually encoder failing).

Also set CLOEXEC to sockets.

Closes #1332

This does fix the crash in linked issue, however it doesn't fix the underlying problem (most likely encoder failing).