### PR TITLE
VAAPI: Use same device as Vulkan context

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipeline.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipeline.cpp
@@ -92,7 +92,7 @@ std::unique_ptr<alvr::EncodePipeline> alvr::EncodePipeline::Create(Renderer *ren
         Info("failed to create AMF encoder: %s", e.what());
       }
       try {
-        auto vaapi = std::make_unique<alvr::EncodePipelineVAAPI>(input_frame, vk_frame_ctx, width, height);
+        auto vaapi = std::make_unique<alvr::EncodePipelineVAAPI>(vk_ctx, input_frame, vk_frame_ctx, width, height);
         Info("using VAAPI encoder");
         return vaapi;
       } catch (std::exception &e)

--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
@@ -88,7 +88,7 @@ AVFrame *map_frame(AVBufferRef *hw_device_ctx, alvr::VkFrame &input_frame, alvr:
 
 }
 
-alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(VkFrame &input_frame, VkFrameCtx& vk_frame_ctx, uint32_t width, uint32_t height)
+alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(VkContext &vk_ctx, VkFrame &input_frame, VkFrameCtx& vk_frame_ctx, uint32_t width, uint32_t height)
 {
   /* VAAPI Encoding pipeline
    * The encoding pipeline has 3 frame types:
@@ -100,7 +100,7 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(VkFrame &input_frame, VkFrameCtx&
    * The pipeline is simply made of a scale_vaapi object, that does the conversion between formats
    * and the encoder that takes the converted frame and produces packets.
    */
-  int err = av_hwdevice_ctx_create(&hw_ctx, AV_HWDEVICE_TYPE_VAAPI, NULL, NULL, 0);
+  int err = av_hwdevice_ctx_create(&hw_ctx, AV_HWDEVICE_TYPE_VAAPI, vk_ctx.devicePath.c_str(), NULL, 0);
   if (err < 0) {
     throw alvr::AvException("Failed to create a VAAPI device:", err);
   }

--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.h
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.h
@@ -25,7 +25,7 @@ class EncodePipelineVAAPI: public EncodePipeline
 {
 public:
   ~EncodePipelineVAAPI();
-  EncodePipelineVAAPI(VkFrame &input_frame, VkFrameCtx& vk_frame_ctx, uint32_t width, uint32_t height);
+  EncodePipelineVAAPI(VkContext &vk_ctx, VkFrame &input_frame, VkFrameCtx& vk_frame_ctx, uint32_t width, uint32_t height);
 
   void PushFrame(uint64_t targetTimestampNs, bool idr) override;
 

--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.cpp
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.cpp
@@ -1,8 +1,11 @@
 #include "ffmpeg_helper.h"
 
 #include <chrono>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 
-#include "alvr_server/Settings.h"
 #include "alvr_server/bindings.h"
 #include "alvr_server/Logger.h"
 
@@ -49,6 +52,7 @@ alvr::VkContext::VkContext(const char *deviceName, const std::vector<const char*
       VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME,
       VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME,
       VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME,
+      VK_EXT_PHYSICAL_DEVICE_DRM_EXTENSION_NAME
   };
   device_extensions.insert(device_extensions.end(), requiredDeviceExtensions.begin(), requiredDeviceExtensions.end());
 
@@ -106,11 +110,17 @@ alvr::VkContext::VkContext(const char *deviceName, const std::vector<const char*
     throw std::runtime_error("Failed to find vulkan device.");
   }
 
-  VkPhysicalDeviceProperties props;
-  vkGetPhysicalDeviceProperties(physicalDevice, &props);
-  nvidia = props.vendorID == 0x10de;
+  VkPhysicalDeviceDrmPropertiesEXT drmProps = {};
+  drmProps.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT;
+
+  VkPhysicalDeviceProperties2 deviceProps = {};
+  deviceProps.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+  deviceProps.pNext = &drmProps;
+  vkGetPhysicalDeviceProperties2(physicalDevice, &deviceProps);
+
+  nvidia = deviceProps.properties.vendorID == 0x10de;
   drmContext = !nvidia;
-  Info("Using Vulkan device %s", props.deviceName);
+  Info("Using Vulkan device %s", deviceProps.properties.deviceName);
 
   uint32_t deviceExtensionCount = 0;
   vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &deviceExtensionCount, nullptr);
@@ -171,10 +181,29 @@ alvr::VkContext::VkContext(const char *deviceName, const std::vector<const char*
   deviceInfo.ppEnabledExtensionNames = deviceExtensions.data();
   vkCreateDevice(physicalDevice, &deviceInfo, nullptr, &device);
 
-  // AV_HWDEVICE_TYPE_DRM doesn't work with SW encoder
-  if (Settings::Instance().m_force_sw_encoding) {
-    drmContext = false;
+  for (int i = 128; i < 136; ++i) {
+    auto path = "/dev/dri/renderD" + std::to_string(i);
+    int fd = open(path.c_str(), O_RDONLY);
+    if (fd == -1) {
+      continue;
+    }
+    struct stat s = {};
+    int ret = fstat(fd, &s);
+    close(fd);
+    if (ret != 0) {
+      continue;
+    }
+    dev_t primaryDev = makedev(drmProps.primaryMajor, drmProps.primaryMinor);
+    dev_t renderDev = makedev(drmProps.renderMajor, drmProps.renderMinor);
+    if (primaryDev == s.st_rdev || renderDev == s.st_rdev) {
+      devicePath = path;
+      break;
+    }
   }
+  if (devicePath.empty()) {
+    throw std::runtime_error("Failed to find device path");
+  }
+  Info("Found device path %s", devicePath.c_str());
 
   if (drmContext) {
     ctx = av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_DRM);

--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.h
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.h
@@ -61,6 +61,7 @@ public:
   std::vector<const char*> deviceExtensions;
   bool nvidia = false;
   bool drmContext = false;
+  std::string devicePath;
 };
 
 class VkFrameCtx


### PR DESCRIPTION
On multi-gpu system it may end up using wrong device otherwise.