### PR TITLE
Always create FFmpeg Vulkan hw context

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipeline.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipeline.cpp
@@ -92,7 +92,7 @@ std::unique_ptr<alvr::EncodePipeline> alvr::EncodePipeline::Create(Renderer *ren
         Info("failed to create AMF encoder: %s", e.what());
       }
       try {
-        auto vaapi = std::make_unique<alvr::EncodePipelineVAAPI>(vk_ctx, input_frame, vk_frame_ctx, width, height);
+        auto vaapi = std::make_unique<alvr::EncodePipelineVAAPI>(vk_ctx, input_frame, width, height);
         Info("using VAAPI encoder");
         return vaapi;
       } catch (std::exception &e)

--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.h
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.h
@@ -10,11 +10,11 @@ extern "C" struct AVFrame;
 
 namespace alvr
 {
-  
+
 #define PRESET_MODE_SPEED   (0)
 #define PRESET_MODE_BALANCE (1)
 #define PRESET_MODE_QUALITY (2)
-  
+
 enum EncoderQualityPreset {
 	QUALITY = 0,
 	BALANCED = 1,
@@ -25,18 +25,19 @@ class EncodePipelineVAAPI: public EncodePipeline
 {
 public:
   ~EncodePipelineVAAPI();
-  EncodePipelineVAAPI(VkContext &vk_ctx, VkFrame &input_frame, VkFrameCtx& vk_frame_ctx, uint32_t width, uint32_t height);
+  EncodePipelineVAAPI(VkContext &vk_ctx, VkFrame &input_frame, uint32_t width, uint32_t height);
 
   void PushFrame(uint64_t targetTimestampNs, bool idr) override;
 
 private:
   AVBufferRef *hw_ctx = nullptr;
+  AVBufferRef *drm_ctx = nullptr;
   AVFrame *mapped_frame = nullptr;
   AVFrame *encoder_frame = nullptr;
   AVFilterGraph *filter_graph = nullptr;
   AVFilterContext *filter_in = nullptr;
   AVFilterContext *filter_out = nullptr;
-  
+
    union vlVaQualityBits {
       unsigned int quality;
       struct {

--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.h
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.h
@@ -60,7 +60,6 @@ public:
   std::vector<const char*> instanceExtensions;
   std::vector<const char*> deviceExtensions;
   bool nvidia = false;
-  bool drmContext = false;
   std::string devicePath;
 };
 
@@ -87,16 +86,17 @@ public:
   VkImage image() { return vkimage;}
   VkImageCreateInfo imageInfo() { return vkimageinfo;}
   VkFormat format() { return vkimageinfo.format;}
+  AVPixelFormat avFormat() { return avformat;}
   operator AVVkFrame*() const { return av_vkframe;}
+  operator AVDRMFrameDescriptor*() const { return av_drmframe;}
   std::unique_ptr<AVFrame, std::function<void(AVFrame*)>> make_av_frame(VkFrameCtx & frame_ctx);
 private:
   AVVkFrame* av_vkframe = nullptr;
   AVDRMFrameDescriptor* av_drmframe = nullptr;
-  const uint32_t width;
-  const uint32_t height;
   vk::Device device;
   VkImage vkimage;
   VkImageCreateInfo vkimageinfo;
+  AVPixelFormat avformat;
 };
 
 }


### PR DESCRIPTION
Vulkan ffmpeg context is not currently needed for AMD GPUs, but it will eventually be required for Vulkan encoder.
This simplifies shared ffmpeg code and moves DRM hw context creation to VAAPI encoder.