### PR TITLE
Replace thread sleep with spin_sleep implementation for vsync thread

### DIFF
--- a/alvr/server/Cargo.toml
+++ b/alvr/server/Cargo.toml
@@ -59,6 +59,7 @@ webbrowser = "0.8" # this is just for opening links in the default browser
 # Miscellaneous
 fern = "0.6"
 winit = "0.27" # needed to get the screen size
+spin_sleep = "1.1.1"
 
 [build-dependencies]
 alvr_filesystem = { path = "../filesystem" }

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -773,15 +773,15 @@ async fn connection_pipeline(
 
     // Vsync thread
     if cfg!(windows) {
-        let frame_interval = Duration::from_secs_f32(1.0 / refresh_rate);
         thread::spawn(move || {
+            let frame_interval = Duration::from_secs_f32(1.0 / refresh_rate);
             let mut deadline = Instant::now();
 
             while is_streaming.value() {
                 unsafe { crate::SendVSync(frame_interval.as_secs_f32()) };
 
                 deadline += frame_interval;
-                std::thread::sleep(deadline.saturating_duration_since(Instant::now()));
+                spin_sleep::sleep(deadline.saturating_duration_since(Instant::now()));
             }
         });
     }


### PR DESCRIPTION
Windows sleep may have poor results due to low timer resolution set by default, and even with high resolution timer, the error can still be within +/- 2ms. `spin_sleep` handles timer resolution change before sleep and then does busy-wait for the remaining time to improve accuracy.

Both tests are done at 90hz (target time is 11.11ms).

Time slept with `spin_sleep::sleep()`:
![image](https://user-images.githubusercontent.com/6103913/211610744-c7e5893a-1b2d-4f55-90bc-fec0226568fb.png)

Time slept with `thread::sleep()`:
![image](https://user-images.githubusercontent.com/6103913/211611029-e7b43d4b-aca7-40bd-b509-217acecc5e90.png)