### PR TITLE
Minor AMF fixes for Windows

### DIFF
--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -32,7 +32,7 @@ void AMFPipe::doPassthrough(bool hasQueryTimeout)
 			Debug("Failed to get AMF component data. Last status: %d.\n", res);
 		}
 	} else {
-		uint8_t timeout = 1000; // 1s timeout
+		uint16_t timeout = 1000; // 1s timeout
 		AMF_RESULT res = m_amfComponentSrc->QueryOutput(&data);
 		while (!data && --timeout != 0) {
 			amf_sleep(1);

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -21,7 +21,7 @@ AMFPipe::~AMFPipe()
 	m_amfComponentSrc->Drain();
 }
 
-void AMFPipe::doPassthrough(bool hasQueryTimeout) 
+void AMFPipe::doPassthrough(bool hasQueryTimeout, uint32_t timerResolution) 
 {
 	amf::AMFDataPtr data = nullptr;
 	if (hasQueryTimeout) {
@@ -34,10 +34,14 @@ void AMFPipe::doPassthrough(bool hasQueryTimeout)
 	} else {
 		uint16_t timeout = 1000; // 1s timeout
 		AMF_RESULT res = m_amfComponentSrc->QueryOutput(&data);
+
+		timeBeginPeriod(timerResolution);
 		while (!data && --timeout != 0) {
 			amf_sleep(1);
 			res = m_amfComponentSrc->QueryOutput(&data);
 		}
+		timeEndPeriod(timerResolution);
+
 		if (data) {
 			m_receiver(data);
 		} else {
@@ -71,7 +75,10 @@ void AMFSolidPipe::Passthrough(AMFDataPtr data)
 
 AMFPipeline::AMFPipeline() 
 	: m_pipes()
-{}
+{
+	TIMECAPS tc;
+	m_timerResolution = timeGetDevCaps(&tc, sizeof(tc)) == TIMERR_NOERROR ? tc.wPeriodMin : 1;
+}
 
 AMFPipeline::~AMFPipeline() 
 {
@@ -90,7 +97,7 @@ void AMFPipeline::Run(bool hasQueryTimeout)
 {
 	for (auto &pipe : m_pipes)
 	{
-		pipe->doPassthrough(hasQueryTimeout);
+		pipe->doPassthrough(hasQueryTimeout, m_timerResolution);
 	}
 }
 
@@ -327,8 +334,6 @@ void VideoEncoderVCE::Initialize()
 
 	LoadAUDByteSequence();
 
-	::amf_increase_timer_precision();
-
 	AMF_THROW_IF(g_AMFFactory.GetFactory()->CreateContext(&m_amfContext));
 	AMF_THROW_IF(m_amfContext->InitDX11(m_d3dRender->GetDevice()));
 
@@ -382,8 +387,6 @@ void VideoEncoderVCE::Shutdown()
 	m_amfContext = NULL;
 
 	g_AMFFactory.Terminate();
-
-	amf_restore_timer_precision();
 
 	if (fpOut) {
 		fpOut.close();

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
@@ -19,7 +19,7 @@ public:
 	AMFPipe(amf::AMFComponentPtr src, AMFDataReceiver receiver);
 	virtual ~AMFPipe();
 
-	void doPassthrough(bool hasQueryTimeout);
+	void doPassthrough(bool hasQueryTimeout, uint32_t timerResolution);
 protected:
 	amf::AMFComponentPtr m_amfComponentSrc;
 	AMFDataReceiver m_receiver;
@@ -44,6 +44,8 @@ public:
 	void Connect(AMFPipePtr pipe);
 	void Run(bool hasQueryTimeout);
 protected:
+	uint32_t m_timerResolution;
+
 	std::vector<AMFPipePtr> m_pipes;
 };
 


### PR DESCRIPTION
1. Fix timeout bug when query timeout is not available.
2. Use timeBeginPeriod/timeEndPeriod only when necessary instead of globally (see https://learn.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod).