### PR TITLE
Replace BytesMut extend with extend_from_slice

### DIFF
--- a/alvr/audio/src/lib.rs
+++ b/alvr/audio/src/lib.rs
@@ -365,7 +365,7 @@ pub async fn record_audio_loop(
     let mut sender_buffer = SenderBuffer::new();
     while let Some(maybe_data) = data_receiver.recv().await {
         sender_buffer.payload_mut().clear();
-        sender_buffer.payload_mut().extend(maybe_data?);
+        sender_buffer.payload_mut().extend_from_slice(&maybe_data?);
         sender.send_buffer(&sender_buffer).await.ok();
     }
 

--- a/alvr/client_core/src/audio.rs
+++ b/alvr/client_core/src/audio.rs
@@ -81,7 +81,7 @@ pub async fn record_audio_loop(
     let mut sender_buffer = SenderBuffer::new();
     while let Some(data) = data_receiver.recv().await {
         sender_buffer.payload_mut().clear();
-        sender_buffer.payload_mut().extend(data);
+        sender_buffer.payload_mut().extend_from_slice(&data);
         sender.send_buffer(&sender_buffer).await.ok();
     }
 

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -772,7 +772,7 @@ async fn connection_pipeline(
             let mut sender_buffer = SenderBuffer::new();
             while let Some(VideoPacket { timestamp, payload }) = data_receiver.recv().await {
                 sender_buffer.set_header(&timestamp)?;
-                sender_buffer.payload_mut().extend(payload);
+                sender_buffer.payload_mut().extend_from_slice(&payload);
                 socket_sender.send_buffer(&sender_buffer).await.ok();
             }
 


### PR DESCRIPTION
Extend iterates over the iterable and copies the contents byte by byte which incurs big performance penalty. Just copy slices.

Before:
![image](https://user-images.githubusercontent.com/6103913/212935253-2916fc07-9a38-4ecb-8c6a-36ba38630be0.png)

After:
![image](https://user-images.githubusercontent.com/6103913/212935478-00ca8f8b-9843-477b-a5bb-3a6ad4537d5d.png)