### PR TITLE
Remove SenderBuffer and send data directly

### DIFF
--- a/alvr/audio/src/lib.rs
+++ b/alvr/audio/src/lib.rs
@@ -1,6 +1,6 @@
 use alvr_common::{once_cell::sync::Lazy, parking_lot::Mutex, prelude::*};
 use alvr_session::{AudioBufferingConfig, AudioDeviceId, LinuxAudioBackend};
-use alvr_sockets::{ReceiverBuffer, SenderBuffer, StreamReceiver, StreamSender};
+use alvr_sockets::{ReceiverBuffer, StreamReceiver, StreamSender};
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
     BufferSize, Device, Sample, SampleFormat, StreamConfig,
@@ -362,11 +362,8 @@ pub async fn record_audio_loop(
     });
 
     // todo: reuse buffers also in the audio callback
-    let mut sender_buffer = SenderBuffer::new();
     while let Some(maybe_data) = data_receiver.recv().await {
-        sender_buffer.payload_mut().clear();
-        sender_buffer.payload_mut().extend_from_slice(&maybe_data?);
-        sender.send_buffer(&sender_buffer).await.ok();
+        sender.send(&(), maybe_data?).await.ok();
     }
 
     Ok(())

--- a/alvr/client_core/src/audio.rs
+++ b/alvr/client_core/src/audio.rs
@@ -1,7 +1,7 @@
 use alvr_audio::AudioDevice;
 use alvr_common::{parking_lot::Mutex, prelude::*};
 use alvr_session::AudioBufferingConfig;
-use alvr_sockets::{SenderBuffer, StreamReceiver, StreamSender};
+use alvr_sockets::{StreamReceiver, StreamSender};
 use oboe::{
     AudioInputCallback, AudioInputStreamSafe, AudioOutputCallback, AudioOutputStreamSafe,
     AudioStream, AudioStreamBuilder, DataCallbackResult, InputPreset, Mono, PerformanceMode,
@@ -78,11 +78,8 @@ pub async fn record_audio_loop(
         Ok(())
     });
 
-    let mut sender_buffer = SenderBuffer::new();
     while let Some(data) = data_receiver.recv().await {
-        sender_buffer.payload_mut().clear();
-        sender_buffer.payload_mut().extend_from_slice(&data);
-        sender.send_buffer(&sender_buffer).await.ok();
+        sender.send(&(), data).await.ok();
     }
 
     Ok(())

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -14,9 +14,8 @@ use alvr_common::{glam::UVec2, prelude::*, ALVR_VERSION, HEAD_ID};
 use alvr_session::{AudioDeviceId, SessionDesc};
 use alvr_sockets::{
     spawn_cancelable, BatteryPacket, ClientConnectionResult, ClientControlPacket, Haptics,
-    PeerType, ProtoControlSocket, ReceiverBuffer, SenderBuffer, ServerControlPacket,
-    StreamConfigPacket, StreamSocketBuilder, VideoStreamingCapabilities, AUDIO, HAPTICS,
-    STATISTICS, TRACKING, VIDEO,
+    PeerType, ProtoControlSocket, ReceiverBuffer, ServerControlPacket, StreamConfigPacket,
+    StreamSocketBuilder, VideoStreamingCapabilities, AUDIO, HAPTICS, STATISTICS, TRACKING, VIDEO,
 };
 use futures::future::BoxFuture;
 use serde_json as json;
@@ -281,10 +280,8 @@ async fn stream_pipeline(
             let (data_sender, mut data_receiver) = tmpsc::unbounded_channel();
             *TRACKING_SENDER.lock() = Some(data_sender);
 
-            let mut sender_buffer = SenderBuffer::new();
             while let Some(tracking) = data_receiver.recv().await {
-                sender_buffer.set_header(&tracking)?;
-                socket_sender.send_buffer(&sender_buffer).await.ok();
+                socket_sender.send(&tracking, vec![]).await.ok();
 
                 // Note: this is not the best place to report the acquired input. Instead it should
                 // be done as soon as possible (or even just before polling the input). Instead this
@@ -306,10 +303,8 @@ async fn stream_pipeline(
             let (data_sender, mut data_receiver) = tmpsc::unbounded_channel();
             *STATISTICS_SENDER.lock() = Some(data_sender);
 
-            let mut sender_buffer = SenderBuffer::new();
             while let Some(stats) = data_receiver.recv().await {
-                sender_buffer.set_header(&stats)?;
-                socket_sender.send_buffer(&sender_buffer).await.ok();
+                socket_sender.send(&stats, vec![]).await.ok();
             }
 
             Ok(())


### PR DESCRIPTION
Reduces the necessity in additional copy pass by passing the header and payload directly to StreamReceiver and sends them in separate packets, but removes SenderBuffer API. Improves performance at high load.

Before:
![image](https://user-images.githubusercontent.com/6103913/213006599-3cedc02c-0b00-4431-8c58-16d6be800045.png)

After:
![image](https://user-images.githubusercontent.com/6103913/213006669-1e1e768f-6be6-41bd-926a-40e22cad1cba.png)