### PR TITLE
Windows: Refactor software encoding

### DIFF
--- a/alvr/server/cpp/platform/win32/VideoEncoderSW.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderSW.cpp
@@ -17,7 +17,7 @@ VideoEncoderSW::VideoEncoderSW(std::shared_ptr<CD3DRender> d3dRender
 	, int width, int height)
 	: m_d3dRender(d3dRender)
 	, m_Listener(listener)
-	, m_codec((ALVR_CODEC)Settings::Instance().m_codec)
+	, m_codec(static_cast<ALVR_CODEC>(Settings::Instance().m_codec))
 	, m_refreshRate(Settings::Instance().m_refreshRate)
 	, m_renderWidth(width)
 	, m_renderHeight(height)
@@ -42,6 +42,12 @@ void VideoEncoderSW::Initialize() {
 	int err;
 	Debug("Initializing VideoEncoderSW.\n");
 
+	if (m_codec == ALVR_CODEC_H265) {
+		throw MakeException("H.265 encoding is not supported by software encoding.");
+	}
+
+	const auto& settings = Settings::Instance();
+
 	// Query codec
 	AVCodecID codecId = ToFFMPEGCodec(m_codec);
 	if(!codecId) throw MakeException("Invalid requested codec %d", m_codec);
@@ -57,11 +63,10 @@ void VideoEncoderSW::Initialize() {
 	AVDictionary* opt = NULL;
 	av_dict_set(&opt, "preset", "ultrafast", 0);
 	av_dict_set(&opt, "tune", "zerolatency", 0);
-	av_dict_set(&opt, "intra-refresh", "1", 0);
 	switch (m_codec) {
 		case ALVR_CODEC_H264:
-			m_codecContext->profile = Settings::Instance().m_use10bitEncoder ? FF_PROFILE_H264_HIGH_10_INTRA : (FF_PROFILE_H264_HIGH | FF_PROFILE_H264_INTRA);
-			switch (Settings::Instance().m_entropyCoding) {
+			m_codecContext->profile = settings.m_use10bitEncoder ? FF_PROFILE_H264_HIGH_10 : FF_PROFILE_H264_HIGH;
+			switch (settings.m_entropyCoding) {
 				case ALVR_CABAC:
 					av_dict_set(&opt, "coder", "ac", 0);
 					break;
@@ -71,21 +76,21 @@ void VideoEncoderSW::Initialize() {
 			}
 			break;
 		case ALVR_CODEC_H265:
-			m_codecContext->profile = Settings::Instance().m_use10bitEncoder ? FF_PROFILE_HEVC_MAIN_10 : FF_PROFILE_HEVC_MAIN;
+			m_codecContext->profile = settings.m_use10bitEncoder ? FF_PROFILE_HEVC_MAIN_10 : FF_PROFILE_HEVC_MAIN;
 			break;
 	}
 
-	m_codecContext->width = Settings::Instance().m_renderWidth;
-	m_codecContext->height = Settings::Instance().m_renderHeight;
+	m_codecContext->width = m_renderWidth;
+	m_codecContext->height = m_renderHeight;
 	m_codecContext->time_base = AVRational{1, (int)(1e9)};
-	m_codecContext->framerate = AVRational{Settings::Instance().m_refreshRate, 1};
+	m_codecContext->framerate = AVRational{settings.m_refreshRate, 1};
 	m_codecContext->sample_aspect_ratio = AVRational{1, 1};
-	m_codecContext->pix_fmt = Settings::Instance().m_use10bitEncoder ? AV_PIX_FMT_YUV420P10LE : AV_PIX_FMT_YUV420P;
+	m_codecContext->pix_fmt = settings.m_use10bitEncoder && m_codec == ALVR_CODEC_H265 ? AV_PIX_FMT_YUV420P10 : AV_PIX_FMT_YUV420P;
 	m_codecContext->max_b_frames = 0;
 	m_codecContext->gop_size = 0;
-	m_codecContext->bit_rate = Settings::Instance().mEncodeBitrateMBs * 1'000'000L;
-	m_codecContext->rc_buffer_size = m_codecContext->bit_rate / Settings::Instance().m_refreshRate * 1.1;
-	switch (Settings::Instance().m_rateControlMode) {
+	m_codecContext->bit_rate = m_bitrateInMBits * 1'000'000L;
+	m_codecContext->rc_buffer_size = m_codecContext->bit_rate / settings.m_refreshRate * 1.1;
+	switch (settings.m_rateControlMode) {
 		case ALVR_CBR:
 			av_dict_set(&opt, "nal-hrd", "cbr", 0);
 			break;
@@ -94,7 +99,7 @@ void VideoEncoderSW::Initialize() {
 			break;
 	}
 	m_codecContext->rc_max_rate = m_codecContext->bit_rate;
-	m_codecContext->thread_count = Settings::Instance().m_swThreadCount;
+	m_codecContext->thread_count = settings.m_swThreadCount;
 
 	if((err = avcodec_open2(m_codecContext, codec, &opt))) throw MakeException("Cannot open video encoder codec: %d", err);
 
@@ -102,8 +107,8 @@ void VideoEncoderSW::Initialize() {
 	m_transferredFrame = av_frame_alloc();
 	m_transferredFrame->buf[0] = av_buffer_alloc(1);
 	m_encoderFrame = av_frame_alloc();
-	m_encoderFrame->width = Settings::Instance().m_renderWidth;
-	m_encoderFrame->height = Settings::Instance().m_renderHeight;
+	m_encoderFrame->width = m_codecContext->width;
+	m_encoderFrame->height = m_codecContext->height;
 	m_encoderFrame->format = m_codecContext->pix_fmt;
 	if((err = av_frame_get_buffer(m_encoderFrame, 0))) throw MakeException("Error when allocating encoder frame: %d", err);
 
@@ -123,57 +128,17 @@ void VideoEncoderSW::Shutdown() {
 	Debug("Successfully shutdown VideoEncoderSW.\n");
 }
 
-bool VideoEncoderSW::should_keep_nal_h264(const uint8_t *header_start) {
- 	uint8_t nal_type = (header_start[2] == 0 ? header_start[4] : header_start[3]) & 0x1F;
-    switch (nal_type) {
-		case 6: // supplemental enhancement information
-		case 9: // access unit delimiter
-			return false;
-		default:
-			return true;
-    }
-}
-
-bool VideoEncoderSW::should_keep_nal_h265(const uint8_t *header_start) {
-	uint8_t nal_type = ((header_start[2] == 0 ? header_start[4] : header_start[3]) >> 1) & 0x3F;
-	switch (nal_type) {
-		case 35: // access unit delimiter
-		case 39: // supplemental enhancement information
-		return false;
-		default:
-		return true;
-	}
-}
-
-void VideoEncoderSW::filter_NAL(const uint8_t *input, size_t input_size, std::vector<uint8_t> &out)
-{
-	if (input_size < 4) return;
-	ALVR_CODEC codec = m_codec;
-	std::array<uint8_t, 3> header = {{0, 0, 1}};
-	const uint8_t *end = input + input_size;
-	const uint8_t *header_start = input;
-	while (header_start != end) {
-		const uint8_t *next_header = std::search(header_start + 3, end, header.begin(), header.end());
-		if (next_header != end && next_header[-1] == 0) next_header--;
-		if (codec == ALVR_CODEC_H264 && should_keep_nal_h264(header_start))
-		out.insert(out.end(), header_start, next_header);
-		if (codec == ALVR_CODEC_H265 && should_keep_nal_h265(header_start))
-		out.insert(out.end(), header_start, next_header);
-		header_start = next_header;
-	}
-}
-
 void VideoEncoderSW::Transmit(ID3D11Texture2D *pTexture, uint64_t presentationTime, uint64_t targetTimestampNs, bool insertIDR) {
 	// Handle bitrate changes
 	if(m_Listener->GetStatistics()->CheckBitrateUpdated()) {
 		//Debug("Bitrate changed");
-		m_codecContext->bit_rate = m_Listener->GetStatistics()->GetBitrate() * 1000000L;
-		m_codecContext->rc_buffer_size = m_codecContext->bit_rate / Settings::Instance().m_refreshRate * 1.1;
+		m_codecContext->bit_rate = m_Listener->GetStatistics()->GetBitrate() * 1'000'000L;
+		m_codecContext->rc_buffer_size = m_codecContext->bit_rate / m_refreshRate * 1.1;
 		m_codecContext->rc_max_rate = m_codecContext->bit_rate;
 	}
 
 	// Setup staging texture if not defined yet; we can only define it here as we now have the texture's size
-	if(!stagingTex) {
+	if(!m_stagingTex) {
 		HRESULT hr = SetupStagingTexture(pTexture);
 		if(FAILED(hr)) {
 			Error("Failed to create staging texture: %p %ls", hr, GetErrorStr(hr).c_str());
@@ -195,22 +160,22 @@ void VideoEncoderSW::Transmit(ID3D11Texture2D *pTexture, uint64_t presentationTi
 	// Setup software scaler if not defined yet; we can only define it here as we now have the texture's size
 	// FIXME: Hardcoded to DirectX's R8G8B8A8, make more robust system if needed
 	if(!m_scalerContext) {
-		m_scalerContext = sws_getContext(stagingTexDesc.Width, stagingTexDesc.Height, AV_PIX_FMT_RGBA,
-		m_codecContext->width, m_codecContext->height, m_codecContext->pix_fmt,
-		SWS_BILINEAR, NULL, NULL, NULL);
+		m_scalerContext = sws_getContext(m_stagingTexDesc.Width, m_stagingTexDesc.Height, AV_PIX_FMT_RGBA,
+			m_codecContext->width, m_codecContext->height, m_codecContext->pix_fmt,
+			SWS_BILINEAR, NULL, NULL, NULL);
 		if(!m_scalerContext) {
 			Error("Couldn't initialize SWScaler.");
-			m_d3dRender->GetContext()->Unmap(stagingTex.Get(), 0);
+			m_d3dRender->GetContext()->Unmap(m_stagingTex.Get(), 0);
 			return;
 		}
 		Debug("Successfully initialized SWScaler.");
 	}
 
 	// We got the texture, populate tansferredFrame with data
-	m_transferredFrame->width = stagingTexDesc.Width;
-	m_transferredFrame->height = stagingTexDesc.Height;
-	m_transferredFrame->data[0] = (uint8_t*)stagingTexMap.pData;
-	m_transferredFrame->linesize[0] = stagingTexMap.RowPitch;
+	m_transferredFrame->width = m_stagingTexDesc.Width;
+	m_transferredFrame->height = m_stagingTexDesc.Height;
+	m_transferredFrame->data[0] = (uint8_t*)m_stagingTexMap.pData;
+	m_transferredFrame->linesize[0] = m_stagingTexMap.RowPitch;
 	m_transferredFrame->format = AV_PIX_FMT_RGBA;
 	m_transferredFrame->pts = targetTimestampNs;
 
@@ -218,7 +183,7 @@ void VideoEncoderSW::Transmit(ID3D11Texture2D *pTexture, uint64_t presentationTi
 	if(sws_scale(m_scalerContext, m_transferredFrame->data, m_transferredFrame->linesize,
 				0, m_transferredFrame->height, m_encoderFrame->data, m_encoderFrame->linesize) == 0) {
 		Error("SWScale failed.");
-		m_d3dRender->GetContext()->Unmap(stagingTex.Get(), 0);
+		m_d3dRender->GetContext()->Unmap(m_stagingTex.Get(), 0);
 		return;
 	}
 	//Debug("SWScale succeeded.");
@@ -230,7 +195,7 @@ void VideoEncoderSW::Transmit(ID3D11Texture2D *pTexture, uint64_t presentationTi
 	int err;
 	if((err = avcodec_send_frame(m_codecContext, m_encoderFrame)) < 0) {
 		Error("Encoding frame failed: err code %d", err);
-		m_d3dRender->GetContext()->Unmap(stagingTex.Get(), 0);
+		m_d3dRender->GetContext()->Unmap(m_stagingTex.Get(), 0);
 		return;
 	}
 	//Debug("Send frame succeeded.");
@@ -238,54 +203,47 @@ void VideoEncoderSW::Transmit(ID3D11Texture2D *pTexture, uint64_t presentationTi
 	// Retrieve frames from encoding and send them until buffer is emptied
 	while(true) {
 		AVPacket *packet = av_packet_alloc();
-		if((err = avcodec_receive_packet(m_codecContext, packet))) {
-			if(err == AVERROR(EAGAIN)) {
-				// Output buffer was emptied, move on
-				break;
-			} else {
-				Error("Received encoded frame failed: err code %d", err);
-				av_packet_free(&packet);
-				m_d3dRender->GetContext()->Unmap(stagingTex.Get(), 0);
-				return;
-			}
+		err = avcodec_receive_packet(m_codecContext, packet);
+		if (err != 0) {
+			av_packet_free(&packet);
+			break;
 		}
-		//Debug("Received encoded packet");
-
 		// Send encoded frame to client
-		std::vector<uint8_t> encoded_data;
-		filter_NAL(packet->data, packet->size, encoded_data);
-		m_Listener->SendVideo(encoded_data.data(), encoded_data.size(), packet->pts);
-		av_packet_free(&packet);
+		m_Listener->SendVideo(packet->data, packet->size, packet->pts);
 		//Debug("Sent encoded packet to client");
+		av_packet_free(&packet);
+	}
+	if (err == AVERROR(EINVAL)) {
+		Error("Received encoded frame failed: err code %d", err);
 	}
 
 	// Send statistics to client
 	m_Listener->GetStatistics()->EncodeOutput();
 
 	// Unmap the copied texture and delete it
-	m_d3dRender->GetContext()->Unmap(stagingTex.Get(), 0);
+	m_d3dRender->GetContext()->Unmap(m_stagingTex.Get(), 0);
 }
 
 HRESULT VideoEncoderSW::SetupStagingTexture(ID3D11Texture2D *pTexture) {
 	D3D11_TEXTURE2D_DESC desc;
 	pTexture->GetDesc(&desc);
-	stagingTexDesc.Width = desc.Width;
-	stagingTexDesc.Height = desc.Height;
-	stagingTexDesc.MipLevels = desc.MipLevels;
-	stagingTexDesc.ArraySize = desc.ArraySize;
-	stagingTexDesc.Format = desc.Format;
-	stagingTexDesc.SampleDesc = desc.SampleDesc;
-	stagingTexDesc.Usage = D3D11_USAGE_STAGING;
-	stagingTexDesc.BindFlags = 0;
-	stagingTexDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-	stagingTexDesc.MiscFlags = 0;
+	m_stagingTexDesc.Width = desc.Width;
+	m_stagingTexDesc.Height = desc.Height;
+	m_stagingTexDesc.MipLevels = desc.MipLevels;
+	m_stagingTexDesc.ArraySize = desc.ArraySize;
+	m_stagingTexDesc.Format = desc.Format;
+	m_stagingTexDesc.SampleDesc = desc.SampleDesc;
+	m_stagingTexDesc.Usage = D3D11_USAGE_STAGING;
+	m_stagingTexDesc.BindFlags = 0;
+	m_stagingTexDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+	m_stagingTexDesc.MiscFlags = 0;
 
-	return m_d3dRender->GetDevice()->CreateTexture2D(&stagingTexDesc, nullptr, &stagingTex);
+	return m_d3dRender->GetDevice()->CreateTexture2D(&m_stagingTexDesc, nullptr, &m_stagingTex);
 }
 
 HRESULT VideoEncoderSW::CopyTexture(ID3D11Texture2D *pTexture) {
-	m_d3dRender->GetContext()->CopyResource(stagingTex.Get(), pTexture);
-	return m_d3dRender->GetContext()->Map(stagingTex.Get(), 0, D3D11_MAP_READ, 0, &stagingTexMap);
+	m_d3dRender->GetContext()->CopyResource(m_stagingTex.Get(), pTexture);
+	return m_d3dRender->GetContext()->Map(m_stagingTex.Get(), 0, D3D11_MAP_READ, 0, &m_stagingTexMap);
 }
 
 AVCodecID VideoEncoderSW::ToFFMPEGCodec(ALVR_CODEC codec) {

--- a/alvr/server/cpp/platform/win32/VideoEncoderSW.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderSW.h
@@ -31,10 +31,6 @@ public:
 
 	static void LibVALog(void*, int level, const char* data, va_list va);
 
-	bool should_keep_nal_h264(const uint8_t *header_start);
-	bool should_keep_nal_h265(const uint8_t *header_start);
-	void filter_NAL(const uint8_t *input, size_t input_size, std::vector<uint8_t> &out);
-
 	AVCodecID ToFFMPEGCodec(ALVR_CODEC codec);
 
 	void Transmit(ID3D11Texture2D *pTexture, uint64_t presentationTime, uint64_t targetTimestampNs, bool insertIDR);
@@ -48,9 +44,9 @@ private:
 	AVFrame *m_transferredFrame, *m_encoderFrame;
 	SwsContext *m_scalerContext = nullptr;
 
-	ComPtr<ID3D11Texture2D> stagingTex;
-	D3D11_TEXTURE2D_DESC stagingTexDesc;
-	D3D11_MAPPED_SUBRESOURCE stagingTexMap;
+	ComPtr<ID3D11Texture2D> m_stagingTex;
+	D3D11_TEXTURE2D_DESC m_stagingTexDesc;
+	D3D11_MAPPED_SUBRESOURCE m_stagingTexMap;
 
     ALVR_CODEC m_codec;
 	int m_refreshRate;


### PR DESCRIPTION
1. Removes NAL filtering and corresponding buffer copy.
2. Fixes encoding resolution.
3. Disallows usage of H.264 10-bit encoding (x264 produces a proper stream but quest is apparently unable to decode it for some reason).
4. Disallows usage of HEVC (due to some bug with ffmpeg).
5. Fixes VBV buffer size when encoder first created.
6. Removes useless intra-refresh option.

Rock-solid 80fps go brrrr... If we could have a dx11 shader with conversion from rgb to yuv420, that would be great I think.
![image](https://user-images.githubusercontent.com/6103913/213922816-c226e167-de46-45ef-bb19-d7aa279adae5.png)
![image](https://user-images.githubusercontent.com/6103913/214091300-a42ce405-fe47-44c5-8be0-1e24c6a7f105.png)
