### PR TITLE
Windows: Remove SkipAUD from AMF code

### DIFF
--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.h
@@ -96,14 +96,8 @@ private:
 	int m_renderHeight;
 	int m_bitrateInMBits;
 
-	char *m_audByteSequence;
-	int m_audNalSize;
-	int m_audHeaderSize;
-
 	bool m_hasQueryTimeout;
 
 	void ApplyFrameProperties(const amf::AMFSurfacePtr &surface, bool insertIDR);
-	void SkipAUD(char **buffer, int *length);
-	void LoadAUDByteSequence();
 };
 


### PR DESCRIPTION
The main reason to keep it was buggy handling of AUD insertion in H.264 by older AMD drivers (22.3.1 and prior), and for H.265 for very old drivers. But since https://github.com/alvr-org/ALVR/pull/1227, `AMF_VIDEO_ENCODER_INSERT_AUD` and `AMF_VIDEO_ENCODER_HEVC_INSERT_AUD` were enabled for encoder and the issue was gone. I think this code can be safely removed.