### PR TITLE
Filter NALs globally

### DIFF
--- a/alvr/server/cpp/alvr_server/ClientConnection.cpp
+++ b/alvr/server/cpp/alvr_server/ClientConnection.cpp
@@ -44,7 +44,7 @@ void extractHeaders(uint8_t **buf, int *len, int nalNum) {
 		b++;
 		headersLen++;
 	}
-	if (headersLen == 0 || foundHeaders != nalNum) {
+	if (foundHeaders != nalNum) {
 		return;
 	}
 	InitializeDecoder((const unsigned char *)b, headersLen);

--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -280,8 +280,6 @@ void CEncoder::Run() {
         m_listener->SendVideo(packet.data, packet.size, packet.pts);
 
         m_listener->GetStatistics()->EncodeOutput();
-
-        encode_pipeline->Free();
       }
     }
     catch (std::exception &e) {

--- a/alvr/server/cpp/platform/linux/EncodePipeline.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipeline.cpp
@@ -60,6 +60,7 @@ alvr::EncodePipeline::~EncodePipeline()
 
 bool alvr::EncodePipeline::GetEncoded(FramePacket &packet)
 {
+  av_packet_free(&encoder_packet);
   encoder_packet = av_packet_alloc();
   int err = avcodec_receive_packet(encoder_ctx, encoder_packet);
   if (err != 0) {
@@ -73,9 +74,4 @@ bool alvr::EncodePipeline::GetEncoded(FramePacket &packet)
   packet.size = encoder_packet->size;
   packet.pts = encoder_packet->pts;
   return true;
-}
-
-void alvr::EncodePipeline::Free()
-{
-  av_packet_free(&encoder_packet);
 }

--- a/alvr/server/cpp/platform/linux/EncodePipeline.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipeline.cpp
@@ -12,59 +12,6 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 }
 
-namespace {
-
-bool should_keep_nal_h264(const uint8_t * header_start)
-{
-  uint8_t nal_type = (header_start[2] == 0 ? header_start[4] : header_start[3]) & 0x1F;
-    switch (nal_type)
-    {
-      case 6: // supplemental enhancement information
-      case 9: // access unit delimiter
-        return false;
-      default:
-        return true;
-    }
-}
-
-bool should_keep_nal_h265(const uint8_t * header_start)
-{
-  uint8_t nal_type = ((header_start[2] == 0 ? header_start[4] : header_start[3]) >> 1) & 0x3F;
-  switch (nal_type)
-  {
-    case 35: // access unit delimiter
-    case 39: // supplemental enhancement information
-      return false;
-    default:
-      return true;
-  }
-}
-
-void filter_NAL(const uint8_t* input, size_t input_size, std::vector<uint8_t> &out)
-{
-  if (input_size < 4)
-    return;
-  auto codec = Settings::Instance().m_codec;
-  std::array<uint8_t, 3> header = {{0, 0, 1}};
-  auto end = input + input_size;
-  auto header_start = input;
-  while (header_start != end)
-  {
-    auto next_header = std::search(header_start + 3, end, header.begin(), header.end());
-    if (next_header != end and next_header[-1] == 0)
-    {
-      next_header--;
-    }
-    if (codec == ALVR_CODEC_H264 and should_keep_nal_h264(header_start))
-      out.insert(out.end(), header_start, next_header);
-    if (codec == ALVR_CODEC_H265 and should_keep_nal_h265(header_start))
-      out.insert(out.end(), header_start, next_header);
-    header_start = next_header;
-  }
-}
-
-}
-
 void alvr::EncodePipeline::SetBitrate(int64_t bitrate) {
   encoder_ctx->bit_rate = bitrate;
   encoder_ctx->rc_buffer_size = bitrate / Settings::Instance().m_refreshRate;
@@ -111,17 +58,24 @@ alvr::EncodePipeline::~EncodePipeline()
   avcodec_free_context(&encoder_ctx);
 }
 
-bool alvr::EncodePipeline::GetEncoded(std::vector<uint8_t> &out, uint64_t *pts)
+bool alvr::EncodePipeline::GetEncoded(FramePacket &packet)
 {
-  AVPacket * enc_pkt = av_packet_alloc();
-  int err = avcodec_receive_packet(encoder_ctx, enc_pkt);
-  if (err == AVERROR(EAGAIN)) {
-    return false;
-  } else if (err) {
+  encoder_packet = av_packet_alloc();
+  int err = avcodec_receive_packet(encoder_ctx, encoder_packet);
+  if (err != 0) {
+    av_packet_free(&encoder_packet);
+    if (err == AVERROR(EAGAIN)) {
+      return false;
+    }
     throw alvr::AvException("failed to encode", err);
   }
-  filter_NAL(enc_pkt->data, enc_pkt->size, out);
-  *pts = enc_pkt->pts;
-  av_packet_free(&enc_pkt);
+  packet.data = encoder_packet->data;
+  packet.size = encoder_packet->size;
+  packet.pts = encoder_packet->pts;
   return true;
+}
+
+void alvr::EncodePipeline::Free()
+{
+  av_packet_free(&encoder_packet);
 }

--- a/alvr/server/cpp/platform/linux/EncodePipeline.h
+++ b/alvr/server/cpp/platform/linux/EncodePipeline.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 extern "C" struct AVCodecContext;
+extern "C" struct AVPacket;
 
 class Renderer;
 
@@ -13,6 +14,12 @@ namespace alvr
 class VkFrame;
 class VkFrameCtx;
 class VkContext;
+
+struct FramePacket {
+  uint8_t *data;
+  int size;
+  uint64_t pts;
+};
 
 class EncodePipeline
 {
@@ -25,13 +32,15 @@ public:
   virtual ~EncodePipeline();
 
   virtual void PushFrame(uint64_t targetTimestampNs, bool idr) = 0;
-  virtual bool GetEncoded(std::vector<uint8_t> & out, uint64_t *pts);
+  virtual bool GetEncoded(FramePacket &data);
+  virtual void Free();
   virtual Timestamp GetTimestamp() { return timestamp; }
 
   virtual void SetBitrate(int64_t bitrate);
   static std::unique_ptr<EncodePipeline> Create(Renderer *render, VkContext &vk_ctx, VkFrame &input_frame, VkFrameCtx &vk_frame_ctx, uint32_t width, uint32_t height);
 protected:
   AVCodecContext *encoder_ctx = nullptr; //shall be initialized by child class
+  AVPacket *encoder_packet = NULL;
   Timestamp timestamp = {};
 };
 

--- a/alvr/server/cpp/platform/linux/EncodePipeline.h
+++ b/alvr/server/cpp/platform/linux/EncodePipeline.h
@@ -33,7 +33,6 @@ public:
 
   virtual void PushFrame(uint64_t targetTimestampNs, bool idr) = 0;
   virtual bool GetEncoded(FramePacket &data);
-  virtual void Free();
   virtual Timestamp GetTimestamp() { return timestamp; }
 
   virtual void SetBitrate(int64_t bitrate);

--- a/alvr/server/cpp/platform/linux/EncodePipelineAMF.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineAMF.cpp
@@ -458,6 +458,7 @@ void EncodePipelineAMF::PushFrame(uint64_t targetTimestampNs, bool idr)
 
 bool EncodePipelineAMF::GetEncoded(FramePacket &packet)
 {
+    m_framePacket = {nullptr, 0, 0};
     if (m_hasQueryTimeout) {
         m_pipeline->Run();
     } else {
@@ -480,10 +481,6 @@ bool EncodePipelineAMF::GetEncoded(FramePacket &packet)
     timestamp.gpu = query * m_render->m_timestampPeriod;
 
     return true;
-}
-
-void EncodePipelineAMF::Free() {
-    m_framePacket = {nullptr, 0, 0};
 }
 
 void EncodePipelineAMF::SetBitrate(int64_t bitrate)

--- a/alvr/server/cpp/platform/linux/EncodePipelineAMF.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineAMF.cpp
@@ -456,32 +456,34 @@ void EncodePipelineAMF::PushFrame(uint64_t targetTimestampNs, bool idr)
     m_amfComponents.front()->SubmitInput(surface);
 }
 
-bool EncodePipelineAMF::GetEncoded(std::vector<uint8_t> &out, uint64_t *pts)
+bool EncodePipelineAMF::GetEncoded(FramePacket &packet)
 {
     if (m_hasQueryTimeout) {
         m_pipeline->Run();
     } else {
         uint32_t timeout = 4 * 1000; // 1 second
-        while (m_outBuffer.empty() && --timeout != 0) {
+        while (m_framePacket.data == nullptr && --timeout != 0) {
             std::this_thread::sleep_for(std::chrono::microseconds(250));
             m_pipeline->Run();
         }
     }
 
-    if (m_outBuffer.empty()) {
+    if (m_framePacket.data == nullptr) {
         Error("Timed out waiting for encoder data");
         return false;
     }
 
-    out = m_outBuffer;
-    *pts = m_targetTimestampNs;
-    m_outBuffer.clear();
+    packet = m_framePacket;
 
     uint64_t query;
     VK_CHECK(vkGetQueryPoolResults(m_render->m_dev, m_queryPool, 0, 1, sizeof(uint64_t), &query, sizeof(uint64_t), VK_QUERY_RESULT_64_BIT));
     timestamp.gpu = query * m_render->m_timestampPeriod;
 
     return true;
+}
+
+void EncodePipelineAMF::Free() {
+    m_framePacket = {nullptr, 0, 0};
 }
 
 void EncodePipelineAMF::SetBitrate(int64_t bitrate)
@@ -501,10 +503,9 @@ void EncodePipelineAMF::Receive(amf::AMFDataPtr data)
 {
     amf::AMFBufferPtr buffer(data); // query for buffer interface
 
-    char *p = reinterpret_cast<char*>(buffer->GetNative());
-    int length = static_cast<int>(buffer->GetSize());
-
-    m_outBuffer = std::vector<uint8_t>(p, p + length);
+    m_framePacket.data = reinterpret_cast<uint8_t *>(buffer->GetNative());
+    m_framePacket.size = static_cast<int>(buffer->GetSize());
+    m_framePacket.pts = m_targetTimestampNs;
 }
 
 void EncodePipelineAMF::ApplyFrameProperties(const amf::AMFSurfacePtr &surface, bool insertIDR)

--- a/alvr/server/cpp/platform/linux/EncodePipelineAMF.h
+++ b/alvr/server/cpp/platform/linux/EncodePipelineAMF.h
@@ -68,8 +68,9 @@ public:
     ~EncodePipelineAMF();
 
     void PushFrame(uint64_t targetTimestampNs, bool idr) override;
-    bool GetEncoded(std::vector<uint8_t> &out, uint64_t *pts) override;
+    bool GetEncoded(FramePacket &packet) override;
     void SetBitrate(int64_t bitrate) override;
+    void Free() override;
 
 private:
     amf::AMFComponentPtr MakeConverter(amf::AMF_SURFACE_FORMAT inputFormat, int width, int height, amf::AMF_SURFACE_FORMAT outputFormat);
@@ -96,7 +97,7 @@ private:
     int m_bitrateInMBits;
 
     bool m_hasQueryTimeout = false;
-    std::vector<uint8_t> m_outBuffer;
+    FramePacket m_framePacket = {nullptr, 0, 0};
     uint64_t m_targetTimestampNs;
 };
 

--- a/alvr/server/cpp/platform/linux/EncodePipelineAMF.h
+++ b/alvr/server/cpp/platform/linux/EncodePipelineAMF.h
@@ -96,7 +96,7 @@ private:
     int m_bitrateInMBits;
 
     bool m_hasQueryTimeout = false;
-    FramePacket m_framePacket = {nullptr, 0, 0};
+    amf::AMFBufferPtr m_frameBuffer;
     uint64_t m_targetTimestampNs;
 };
 

--- a/alvr/server/cpp/platform/linux/EncodePipelineAMF.h
+++ b/alvr/server/cpp/platform/linux/EncodePipelineAMF.h
@@ -70,7 +70,6 @@ public:
     void PushFrame(uint64_t targetTimestampNs, bool idr) override;
     bool GetEncoded(FramePacket &packet) override;
     void SetBitrate(int64_t bitrate) override;
-    void Free() override;
 
 private:
     amf::AMFComponentPtr MakeConverter(amf::AMF_SURFACE_FORMAT inputFormat, int width, int height, amf::AMF_SURFACE_FORMAT outputFormat);


### PR DESCRIPTION
Handle NAL filtering globally and remove video buffer copy caused by it from Linux code.