### PR TITLE
Khronos-defined color correction algorithm

### DIFF
--- a/alvr/client_core/cpp/gamma_pass.cpp
+++ b/alvr/client_core/cpp/gamma_pass.cpp
@@ -17,10 +17,23 @@ const string PASSTHROUGH_FRAGMENT_SHADER = R"glsl(#version 300 es
         uniform samplerExternalOES tex0;
         in vec2 uv;
         out vec4 color;
+
+        const float div12 = 1. / 12.92;
+        const float div1 = 1. / 1.055;
+        
+        float srgbToLinear(float val)
+        {
+          return val < 0.04045
+          ? val * div12
+          : pow((val + 0.055) * div1, 2.4);
+        }
+
         void main()
         {
             color = texture(tex0, uv);
-            color.rgb = pow(color.rgb, vec3(2.2));
+            color.r = srgbToLinear(color.r);
+            color.g = srgbToLinear(color.g);
+            color.b = srgbToLinear(color.b);
         }
     )glsl";
 }


### PR DESCRIPTION
The `pow(cl, 2.2)` method is an approximation and breaks down in dark scenes, which is especially bad in VR.

I stumbled across the formula that's being used by `SRGB_FRAMEBUFFER` on the desktop editions of OpenGL:

https://registry.khronos.org/OpenGL/extensions/ARB/ARB_framebuffer_sRGB.txt

I've replaced the divisions with multiplications for performance reasons.