### PR TITLE
Linux: force bundled ffmpeg

### DIFF
--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -145,6 +145,9 @@ fn main() {
         } else {
             Profile::Debug
         };
+        #[cfg(target_os = "linux")]
+        let gpl = true;
+        #[cfg(not(target_os = "linux"))]
         let gpl = args.contains("--gpl");
         let experiments = args.contains("--experiments");
         let is_nightly = args.contains("--nightly");


### PR DESCRIPTION
This is to allow for custom patches to work around the ruff areas with ALVR and ffmpeg on Linux.