### PR TITLE
Refactor video decoder split

### DIFF
--- a/alvr/client_core/src/platform/android.rs
+++ b/alvr/client_core/src/platform/android.rs
@@ -458,10 +458,10 @@ pub fn video_decoder_split(
                 match decoder.dequeue_output_buffer(Duration::from_millis(1)) {
                     MediaCodecResult::Ok(buffer) => {
                         // The buffer timestamp is actually nanoseconds
-                        let presentation_time_us = buffer.presentation_time_us();
+                        let presentation_time_ns = buffer.presentation_time_us();
 
                         if let Err(e) =
-                            decoder.release_output_buffer_at_time(buffer, presentation_time_us)
+                            decoder.release_output_buffer_at_time(buffer, presentation_time_ns)
                         {
                             error!("Decoder dequeue error: {e}");
                         }

--- a/alvr/client_core/src/platform/android.rs
+++ b/alvr/client_core/src/platform/android.rs
@@ -396,7 +396,7 @@ pub fn video_decoder_split(
 
                         if image_queue_lock.len() > available_buffering_frames {
                             warn!("Video frame queue overflow!");
-                            image_queue_lock.clear();
+                            image_queue_lock.pop_front();
                         }
 
                         match &mut image_reader.acquire_next_image() {

--- a/alvr/client_core/src/platform/android.rs
+++ b/alvr/client_core/src/platform/android.rs
@@ -379,9 +379,6 @@ pub fn video_decoder_split(
                 }
             }
 
-            let acquired_image = Arc::new(Mutex::new(Ok(None)));
-            let image_acquired_notifier = Arc::new(Condvar::new());
-
             let mut image_reader = ImageReader::new_with_usage(
                 1,
                 1,
@@ -393,12 +390,39 @@ pub fn video_decoder_split(
 
             image_reader
                 .set_image_listener(Box::new({
-                    let acquired_image = Arc::clone(&acquired_image);
-                    let image_acquired_notifier = Arc::clone(&image_acquired_notifier);
+                    let image_queue = Arc::clone(&image_queue);
                     move |image_reader| {
-                        let mut acquired_image_lock = acquired_image.lock();
-                        *acquired_image_lock = image_reader.acquire_next_image();
-                        image_acquired_notifier.notify_one();
+                        let mut image_queue_lock = image_queue.lock();
+
+                        if image_queue_lock.len() > available_buffering_frames {
+                            warn!("Video frame queue overflow!");
+                            image_queue_lock.clear();
+                        }
+
+                        match &mut image_reader.acquire_next_image() {
+                            Ok(image @ Some(_)) => {
+                                let image = image.take().unwrap();
+                                let timestamp = Duration::from_nanos(image.get_timestamp().unwrap() as u64);
+
+                                dequeued_frame_callback(timestamp);
+
+                                image_queue_lock.push_back(QueuedImage {
+                                    timestamp,
+                                    image,
+                                    in_use: false,
+                                });
+                            }
+                            Ok(None) => {
+                                error!("ImageReader error: No buffer available");
+
+                                image_queue_lock.clear();
+                            }
+                            Err(e) => {
+                                error!("ImageReader error: {e}");
+
+                                image_queue_lock.clear();
+                            }
+                        }
                     }
                 }))
                 .unwrap();
@@ -430,54 +454,13 @@ pub fn video_decoder_split(
             }
 
             while running.value() {
-                if image_queue.lock().len() > available_buffering_frames {
-                    warn!("Video frame queue overflow!");
-
-                    image_queue.lock().clear();
-
-                    continue;
-                }
-
-                let mut acquired_image_ref = acquired_image.lock();
-
                 match decoder.dequeue_output_buffer(Duration::from_millis(1)) {
                     MediaCodecResult::Ok(buffer) => {
                         // The buffer timestamp is actually nanoseconds
-                        let timestamp = Duration::from_nanos(buffer.presentation_time_us() as _);
+                        let presentation_time_us = buffer.presentation_time_us();
 
-                        if let Err(e) = decoder.release_output_buffer(buffer, true) {
+                        if let Err(e) = decoder.release_output_buffer_at_time(buffer, presentation_time_us) {
                             error!("Decoder dequeue error: {e}");
-
-                            continue;
-                        }
-
-                        dequeued_frame_callback(timestamp);
-
-                        // Note: parking_lot::Condvar has no spurious wakeups
-                        image_acquired_notifier.wait(&mut acquired_image_ref);
-
-                        match &mut *acquired_image_ref {
-                            Ok(image @ Some(_)) => {
-                                image_queue.lock().push_back(QueuedImage {
-                                    timestamp,
-                                    image: image.take().unwrap(),
-                                    in_use: false,
-                                });
-                            }
-                            Ok(None) => {
-                                error!("ImageReader error: No buffer available");
-
-                                image_queue.lock().clear();
-
-                                continue;
-                            }
-                            Err(e) => {
-                                error!("ImageReader error: {e}");
-
-                                image_queue.lock().clear();
-
-                                continue;
-                            }
                         }
                     }
                     MediaCodecResult::Info(MediaCodecInfo::TryAgainLater) => (),

--- a/alvr/client_core/src/platform/android.rs
+++ b/alvr/client_core/src/platform/android.rs
@@ -463,7 +463,7 @@ pub fn video_decoder_split(
                             error!("Decoder dequeue error: {e}");
                         }
                     }
-                    MediaCodecResult::Info(MediaCodecInfo::TryAgainLater) => (),
+                    MediaCodecResult::Info(MediaCodecInfo::TryAgainLater) => thread::sleep(Duration::from_micros(500)),
                     MediaCodecResult::Info(i) => info!("Decoder dequeue event: {i:?}"),
                     MediaCodecResult::Err(e) => {
                         error!("Decoder dequeue error: {e}");

--- a/alvr/client_core/src/platform/android.rs
+++ b/alvr/client_core/src/platform/android.rs
@@ -402,7 +402,8 @@ pub fn video_decoder_split(
                         match &mut image_reader.acquire_next_image() {
                             Ok(image @ Some(_)) => {
                                 let image = image.take().unwrap();
-                                let timestamp = Duration::from_nanos(image.get_timestamp().unwrap() as u64);
+                                let timestamp =
+                                    Duration::from_nanos(image.get_timestamp().unwrap() as u64);
 
                                 dequeued_frame_callback(timestamp);
 
@@ -459,11 +460,15 @@ pub fn video_decoder_split(
                         // The buffer timestamp is actually nanoseconds
                         let presentation_time_us = buffer.presentation_time_us();
 
-                        if let Err(e) = decoder.release_output_buffer_at_time(buffer, presentation_time_us) {
+                        if let Err(e) =
+                            decoder.release_output_buffer_at_time(buffer, presentation_time_us)
+                        {
                             error!("Decoder dequeue error: {e}");
                         }
                     }
-                    MediaCodecResult::Info(MediaCodecInfo::TryAgainLater) => thread::sleep(Duration::from_micros(500)),
+                    MediaCodecResult::Info(MediaCodecInfo::TryAgainLater) => {
+                        thread::sleep(Duration::from_micros(500))
+                    }
                     MediaCodecResult::Info(i) => info!("Decoder dequeue event: {i:?}"),
                     MediaCodecResult::Err(e) => {
                         error!("Decoder dequeue error: {e}");


### PR DESCRIPTION
1. Avoid additional synchronization and write to image queue directly from callback.
2. Don't skip frame when decoder buffer overflow happens.
3. Use `release_output_buffer_at_time()` to have the same image timestamp as the buffer.
4. Report decoded frame when the image was acquired instead of buffer.
5. Sleep when no output buffer is available yet.