### PR TITLE
Various refactoring

### DIFF
--- a/alvr/client_core/src/platform/android.rs
+++ b/alvr/client_core/src/platform/android.rs
@@ -480,9 +480,7 @@ pub fn video_decoder_split(
                             error!("Decoder dequeue error: {e}");
                         }
                     }
-                    MediaCodecResult::Info(MediaCodecInfo::TryAgainLater) => {
-                        thread::sleep(Duration::from_micros(500))
-                    }
+                    MediaCodecResult::Info(MediaCodecInfo::TryAgainLater) => thread::yield_now(),
                     MediaCodecResult::Info(i) => info!("Decoder dequeue event: {i:?}"),
                     MediaCodecResult::Err(e) => {
                         error!("Decoder dequeue error: {e}");

--- a/alvr/client_core/src/platform/android.rs
+++ b/alvr/client_core/src/platform/android.rs
@@ -333,8 +333,8 @@ impl VideoDecoderDequeuer {
                     .cast(),
             ))
         } else {
-            warn!("Video frame queue underflow!");
-
+            // TODO: add back when implementing proper phase sync
+            //warn!("Video frame queue underflow!");
             None
         }
     }

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -751,7 +751,7 @@ pub fn entry_point() {
 
                     display_time = timestamp;
                 } else {
-                    warn!("Timed out when waiting frame!");
+                    warn!("Timed out when waiting for frame!");
                     views = if let (Some(left_view), Some(right_view)) = (
                         last_swapchain_left_view.get(&left_swapchain_idx),
                         last_swapchain_right_view.get(&right_swapchain_idx),

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -751,6 +751,7 @@ pub fn entry_point() {
 
                     display_time = timestamp;
                 } else {
+                    warn!("Timed out when waiting frame!");
                     views = if let (Some(left_view), Some(right_view)) = (
                         last_swapchain_left_view.get(&left_swapchain_idx),
                         last_swapchain_right_view.get(&right_swapchain_idx),

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -720,7 +720,7 @@ pub fn entry_point() {
                 let mut frame_result = None;
                 while frame_result.is_none() && Instant::now() < frame_poll_deadline {
                     frame_result = alvr_client_core::get_frame();
-                    thread::sleep(Duration::from_millis(1));
+                    thread::yield_now();
                 }
 
                 if let Some((timestamp, hardware_buffer)) = frame_result {


### PR DESCRIPTION
1. Use `thread::yield_now()` instead of sleep in render loop. 1ms sleep introduces additional 1ms client compositor latency for little benefit, while with yield we give time to other threads (and we have plenty of threads). Better to be replaced with `Condvar` or MPSC channel.
2. Use `thread::yield_now()` in decoder thread. Same as above, this should help to avoid additional latency and give time for other threads. Unfortunately, there's no other way than poll and we probably want lower latency.
3. Remove "Video frame queue underflow!" when attempting to dequeue a frame and place "Timed out when waiting for frame!" warning when the frame dequeue function timed out. Queue polling triggers this warning lots of times under almost any condition and creates a huge log spam, but we can indicate low performance when poll times out.

For verification, CPU/GPU load with `sleep()`:
![image](https://user-images.githubusercontent.com/6103913/216842316-f8105dfb-cf7c-4896-9651-465b1868d60a.png)

CPU/GPU load with `yield_now()`:
![image](https://user-images.githubusercontent.com/6103913/216842153-b8638d39-5fb7-4aaa-9d4e-eb3c1110537c.png)