### PR TITLE
Vulkan: Fix Renderer/FrameConverter destructor crash when init fails

### DIFF
--- a/alvr/server/cpp/platform/linux/FormatConverter.h
+++ b/alvr/server/cpp/platform/linux/FormatConverter.h
@@ -6,7 +6,7 @@ class FormatConverter
 {
 public:
     struct Output {
-        VkSemaphore semaphore;
+        VkSemaphore semaphore = VK_NULL_HANDLE;
     };
 
     virtual ~FormatConverter();
@@ -21,30 +21,30 @@ public:
 
 protected:
     struct OutputImage {
-        VkImage image;
-        VkDeviceMemory memory;
-        VkImageView view;
-        VkSemaphore semaphore;
-        VkDeviceSize linesize;
-        uint8_t *mapped;
+        VkImage image = VK_NULL_HANDLE;
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+        VkImageView view = VK_NULL_HANDLE;
+        VkSemaphore semaphore = VK_NULL_HANDLE;
+        VkDeviceSize linesize = 0;
+        uint8_t *mapped = nullptr;
     };
 
     explicit FormatConverter(Renderer *render);
     void init(VkImage image, VkImageCreateInfo imageCreateInfo, VkSemaphore semaphore, int count, const unsigned char *shaderData, unsigned shaderLen);
 
     Renderer *r;
-    VkSampler m_sampler;
-    VkQueryPool m_queryPool;
-    VkCommandBuffer m_commandBuffer;
-    VkDescriptorSet m_descriptor;
-    VkDescriptorSetLayout m_descriptorLayout;
-    VkImageView m_view;
-    VkSemaphore m_semaphore;
-    VkShaderModule m_shader;
-    VkPipelineLayout m_pipelineLayout;
-    VkPipeline m_pipeline;
-    uint32_t m_groupCountX;
-    uint32_t m_groupCountY;
+    VkSampler m_sampler = VK_NULL_HANDLE;
+    VkQueryPool m_queryPool = VK_NULL_HANDLE;
+    VkCommandBuffer m_commandBuffer = VK_NULL_HANDLE;
+    VkDescriptorSet m_descriptor = VK_NULL_HANDLE;
+    VkDescriptorSetLayout m_descriptorLayout = VK_NULL_HANDLE;
+    VkImageView m_view = VK_NULL_HANDLE;
+    VkSemaphore m_semaphore = VK_NULL_HANDLE;
+    VkShaderModule m_shader = VK_NULL_HANDLE;
+    VkPipelineLayout m_pipelineLayout = VK_NULL_HANDLE;
+    VkPipeline m_pipeline = VK_NULL_HANDLE;
+    uint32_t m_groupCountX = 0;
+    uint32_t m_groupCountY = 0;
     std::vector<OutputImage> m_images;
     Output m_output;
 };

--- a/alvr/server/cpp/platform/linux/Renderer.cpp
+++ b/alvr/server/cpp/platform/linux/Renderer.cpp
@@ -47,6 +47,10 @@ Renderer::Renderer(const VkInstance &inst, const VkDevice &dev, const VkPhysical
     d.haveDmaBuf = checkExtension(VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME);
     d.haveDrmModifiers = checkExtension(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
 
+    if (!checkExtension(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME)) {
+        throw std::runtime_error("Vulkan: Required extension " VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME " not available");
+    }
+
 #define VK_LOAD_PFN(name) d.name = (PFN_##name) vkGetInstanceProcAddr(m_inst, #name)
     VK_LOAD_PFN(vkImportSemaphoreFdKHR);
     VK_LOAD_PFN(vkGetMemoryFdKHR);

--- a/alvr/server/cpp/platform/linux/Renderer.h
+++ b/alvr/server/cpp/platform/linux/Renderer.h
@@ -30,14 +30,14 @@ class Renderer
 {
 public:
     struct Output {
-        VkImage image;
+        VkImage image = VK_NULL_HANDLE;
         VkImageCreateInfo imageInfo;
-        VkDeviceSize size;
-        VkDeviceMemory memory;
-        VkSemaphore semaphore;
+        VkDeviceSize size = 0;
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+        VkSemaphore semaphore = VK_NULL_HANDLE;
         // ---
-        VkImageView view;
-        VkFramebuffer framebuffer;
+        VkImageView view = VK_NULL_HANDLE;
+        VkFramebuffer framebuffer = VK_NULL_HANDLE;
         // ---
         DrmImage drm;
     };
@@ -73,19 +73,19 @@ public:
 
 // private:
     struct InputImage {
-        VkImage image;
-        VkDeviceMemory memory;
-        VkSemaphore semaphore;
-        VkImageView view;
-        VkDescriptorSet descriptor;
+        VkImage image = VK_NULL_HANDLE;
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+        VkSemaphore semaphore = VK_NULL_HANDLE;
+        VkImageView view = VK_NULL_HANDLE;
+        VkDescriptorSet descriptor = VK_NULL_HANDLE;
     };
 
     struct StagingImage {
-        VkImage image;
-        VkDeviceMemory memory;
-        VkImageView view;
-        VkFramebuffer framebuffer;
-        VkDescriptorSet descriptor;
+        VkImage image = VK_NULL_HANDLE;
+        VkDeviceMemory memory = VK_NULL_HANDLE;
+        VkImageView view = VK_NULL_HANDLE;
+        VkFramebuffer framebuffer = VK_NULL_HANDLE;
+        VkDescriptorSet descriptor = VK_NULL_HANDLE;
     };
 
     void commandBufferBegin();
@@ -95,10 +95,10 @@ public:
     uint32_t memoryTypeIndex(VkMemoryPropertyFlags properties, uint32_t typeBits) const;
 
     struct {
-        PFN_vkImportSemaphoreFdKHR vkImportSemaphoreFdKHR;
-        PFN_vkGetMemoryFdKHR vkGetMemoryFdKHR;
-        PFN_vkGetImageDrmFormatModifierPropertiesEXT vkGetImageDrmFormatModifierPropertiesEXT;
-        PFN_vkGetCalibratedTimestampsEXT vkGetCalibratedTimestampsEXT;
+        PFN_vkImportSemaphoreFdKHR vkImportSemaphoreFdKHR = nullptr;
+        PFN_vkGetMemoryFdKHR vkGetMemoryFdKHR = nullptr;
+        PFN_vkGetImageDrmFormatModifierPropertiesEXT vkGetImageDrmFormatModifierPropertiesEXT = nullptr;
+        PFN_vkGetCalibratedTimestampsEXT vkGetCalibratedTimestampsEXT = nullptr;
         bool haveDmaBuf = false;
         bool haveDrmModifiers = false;
     } d;
@@ -108,24 +108,24 @@ public:
     std::vector<StagingImage> m_stagingImages;
     std::vector<RenderPipeline*> m_pipelines;
 
-    VkInstance m_inst;
-    VkDevice m_dev;
-    VkPhysicalDevice m_physDev;
-    VkQueue m_queue;
-    uint32_t m_queueFamilyIndex;
-    VkFormat m_format;
-    VkExtent2D m_imageSize;
-    VkQueryPool m_queryPool;
-    VkCommandPool m_commandPool;
-    VkSampler m_sampler;
-    VkBuffer m_vertexBuffer;
-    VkDeviceMemory m_vertexMemory;
-    VkRenderPass m_renderPass;
-    VkDescriptorPool m_descriptorPool;
-    VkDescriptorSetLayout m_descriptorLayout;
-    VkCommandBuffer m_commandBuffer;
-    VkFence m_fence;
-    double m_timestampPeriod;
+    VkInstance m_inst = VK_NULL_HANDLE;
+    VkDevice m_dev = VK_NULL_HANDLE;
+    VkPhysicalDevice m_physDev = VK_NULL_HANDLE;
+    VkQueue m_queue = VK_NULL_HANDLE;
+    uint32_t m_queueFamilyIndex = 0;
+    VkFormat m_format = VK_FORMAT_UNDEFINED;
+    VkExtent2D m_imageSize = {0, 0};
+    VkQueryPool m_queryPool = VK_NULL_HANDLE;
+    VkCommandPool m_commandPool = VK_NULL_HANDLE;
+    VkSampler m_sampler = VK_NULL_HANDLE;
+    VkBuffer m_vertexBuffer = VK_NULL_HANDLE;
+    VkDeviceMemory m_vertexMemory = VK_NULL_HANDLE;
+    VkRenderPass m_renderPass = VK_NULL_HANDLE;
+    VkDescriptorPool m_descriptorPool = VK_NULL_HANDLE;
+    VkDescriptorSetLayout m_descriptorLayout = VK_NULL_HANDLE;
+    VkCommandBuffer m_commandBuffer = VK_NULL_HANDLE;
+    VkFence m_fence = VK_NULL_HANDLE;
+    double m_timestampPeriod = 0;
 
     std::string m_inputImageCapture;
     std::string m_outputImageCapture;


### PR DESCRIPTION
Make sure things don't crash when Renderer/FrameConverter init fails.
Also check for required extensions.