### PR TITLE
Linux Intel encoder fixes

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipeline.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipeline.cpp
@@ -35,13 +35,15 @@ std::unique_ptr<alvr::EncodePipeline> alvr::EncodePipeline::Create(Renderer *ren
         Info("failed to create NvEnc encoder: %s", e.what());
       }
     } else {
-      try {
-        auto amf = std::make_unique<alvr::EncodePipelineAMF>(render, width, height);
-        Info("using AMF encoder");
-        return amf;
-      } catch (std::exception &e)
-      {
-        Info("failed to create AMF encoder: %s", e.what());
+      if (vk_ctx.amd) {
+        try {
+          auto amf = std::make_unique<alvr::EncodePipelineAMF>(render, width, height);
+          Info("using AMF encoder");
+          return amf;
+        } catch (std::exception &e)
+        {
+          Info("failed to create AMF encoder: %s", e.what());
+        }
       }
       try {
         auto vaapi = std::make_unique<alvr::EncodePipelineVAAPI>(render, vk_ctx, input_frame, width, height);

--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
@@ -204,17 +204,23 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(Renderer *render, VkContext &vk_c
   switch (settings.m_encoderQualityPreset)
   {
     case ALVR_QUALITY:
-      quality.preset_mode = PRESET_MODE_QUALITY;
-      encoder_ctx->compression_level = quality.quality; // (QUALITY preset, no pre-encoding, vbaq)
+      if (vk_ctx.amd) {
+        quality.preset_mode = PRESET_MODE_QUALITY;
+        encoder_ctx->compression_level = quality.quality; // (QUALITY preset, no pre-encoding, vbaq)
+      }
     break;
     case ALVR_BALANCED:
-      quality.preset_mode = PRESET_MODE_BALANCE;
-      encoder_ctx->compression_level = quality.quality; // (BALANCE preset, no pre-encoding, vbaq)
+      if (vk_ctx.amd) {
+        quality.preset_mode = PRESET_MODE_BALANCE;
+        encoder_ctx->compression_level = quality.quality; // (BALANCE preset, no pre-encoding, vbaq)
+      }
     break;
     case ALVR_SPEED:
       default:
-       quality.preset_mode = PRESET_MODE_SPEED;
-       encoder_ctx->compression_level = quality.quality; // (speed preset, no pre-encoding, vbaq)
+       if (vk_ctx.amd) {
+         quality.preset_mode = PRESET_MODE_SPEED;
+         encoder_ctx->compression_level = quality.quality; // (speed preset, no pre-encoding, vbaq)
+       }
     break;
   }
 

--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.cpp
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.cpp
@@ -116,6 +116,8 @@ alvr::VkContext::VkContext(const char *deviceName, const std::vector<const char*
   deviceProps.pNext = &drmProps;
   vkGetPhysicalDeviceProperties2(physicalDevice, &deviceProps);
 
+  amd = deviceProps.properties.vendorID == 0x1002;
+  intel = deviceProps.properties.vendorID == 0x8086;
   nvidia = deviceProps.properties.vendorID == 0x10de;
   Info("Using Vulkan device %s", deviceProps.properties.deviceName);
 

--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.h
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.h
@@ -57,6 +57,8 @@ public:
   uint32_t queueFamilyIndex;
   std::vector<const char*> instanceExtensions;
   std::vector<const char*> deviceExtensions;
+  bool amd = false;
+  bool intel = false;
   bool nvidia = false;
   std::string devicePath;
 };


### PR DESCRIPTION
Don't try AMF on Intel cards.
Also don't set VAAPI quality as it has different meaning on Intel drivers.