### PR TITLE
Refactor session.json loading

### DIFF
--- a/alvr/server_data/src/lib.rs
+++ b/alvr/server_data/src/lib.rs
@@ -65,7 +65,11 @@ impl ServerDataManager {
 
         let session_desc = match fs::read_to_string(session_path) {
             Ok(session_string) => {
-                let json_value = json::from_str::<json::Value>(&session_string).unwrap();
+                let json_value = if let Ok(val) = json::from_str::<json::Value>(&session_string) {
+                    val
+                } else {
+                    json::to_value(SessionDesc::default()).unwrap()
+                };
                 match json::from_value(json_value.clone()) {
                     Ok(session_desc) => session_desc,
                     Err(_) => {

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -238,16 +238,11 @@ impl SessionDesc {
         let session_settings_json = json::to_value(&self.session_settings).unwrap();
         let schema = settings::settings_schema(settings::session_settings_default());
 
-        if let Err(e) = json::from_value::<Settings>(json_session_settings_to_settings(
-            &session_settings_json,
-            &schema,
-        )) {
-            dbg!(e);
-        }
-        json::from_value(json_session_settings_to_settings(
+        json::from_value::<Settings>(json_session_settings_to_settings(
             &session_settings_json,
             &schema,
         ))
+        .map_err(|e| dbg!(e))
         .unwrap()
     }
 }


### PR DESCRIPTION
This avoids panic (and SteamVR crash as the result) in case `session.json` was somehow corrupted or became invalid due to manual edit.