### PR TITLE
Vulkan: Use deviceUUID to match compositor and server devices

### DIFF
--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -211,7 +211,7 @@ void CEncoder::Run() {
           deviceExtensions = alvr::AMFContext::get()->requiredDeviceExtensions();
       }
 
-      alvr::VkContext vk_ctx(init.device_name.data(), deviceExtensions);
+      alvr::VkContext vk_ctx(init.device_uuid.data(), deviceExtensions);
 
       FrameRender render(vk_ctx, init, m_fds);
       auto output = render.CreateOutput();

--- a/alvr/server/cpp/platform/linux/ffmpeg_helper.h
+++ b/alvr/server/cpp/platform/linux/ffmpeg_helper.h
@@ -41,7 +41,7 @@ private:
 class VkContext
 {
 public:
-  VkContext(const char* device, const std::vector<const char*> &requiredDeviceExtensions);
+  VkContext(const uint8_t* deviceUUID, const std::vector<const char*> &requiredDeviceExtensions);
   ~VkContext();
   VkDevice get_vk_device() const { return device;}
   VkInstance get_vk_instance() const { return instance;}

--- a/alvr/server/cpp/platform/linux/protocol.h
+++ b/alvr/server/cpp/platform/linux/protocol.h
@@ -17,7 +17,7 @@ struct present_packet {
 
 struct init_packet {
     uint32_t num_images;
-    std::array<char, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE> device_name;
+    std::array<uint8_t, VK_UUID_SIZE> device_uuid;
     VkImageCreateInfo image_create_info;
     size_t mem_index;
     pid_t source_pid;

--- a/alvr/vulkan_layer/layer/private_data.hpp
+++ b/alvr/vulkan_layer/layer/private_data.hpp
@@ -50,6 +50,7 @@ namespace layer {
     REQUIRED(GetInstanceProcAddr)                                                                  \
     REQUIRED(DestroyInstance)                                                                      \
     REQUIRED(GetPhysicalDeviceProperties)                                                          \
+    REQUIRED(GetPhysicalDeviceProperties2)                                                          \
     REQUIRED(GetPhysicalDeviceMemoryProperties)                                                    \
     REQUIRED(GetPhysicalDeviceImageFormatProperties)                                               \
     REQUIRED(EnumerateDeviceExtensionProperties)                                                   \

--- a/alvr/vulkan_layer/wsi/headless/swapchain.cpp
+++ b/alvr/vulkan_layer/wsi/headless/swapchain.cpp
@@ -268,16 +268,21 @@ bool swapchain::try_connect() {
         return false; // we will try again next frame
     }
 
-    VkPhysicalDeviceProperties prop;
-    m_device_data.instance_data.disp.GetPhysicalDeviceProperties(m_device_data.physical_device,
-                                                                 &prop);
+    VkPhysicalDeviceVulkan11Properties props11 = {};
+    props11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES;
+
+    VkPhysicalDeviceProperties2 props = {};
+    props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+    props.pNext = &props11;
+    m_device_data.instance_data.disp.GetPhysicalDeviceProperties2(m_device_data.physical_device,
+                                                                  &props);
 
     init_packet init{.num_images = uint32_t(m_swapchain_images.size()),
-      .device_name = {},
+      .device_uuid = {},
       .image_create_info = m_create_info,
       .mem_index = m_mem_index,
       .source_pid = getpid()};
-    memcpy(init.device_name.data(), prop.deviceName, sizeof(prop.deviceName));
+    memcpy(init.device_uuid.data(), props11.deviceUUID, VK_UUID_SIZE);
     ret = write(m_socket, &init, sizeof(init));
     if (ret == -1) {
         perror("write");


### PR DESCRIPTION
Using deviceUUID instead of deviceName to match device will work correctly when multiple GPUs of the same model are present or even across different drivers (eg. happens with AMF).

Keep the first device fallback, but show warning when we hit it.