### PR TITLE
Linux: Ignore framerate with x264 and vaapi-hevc encoders

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.h
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.h
@@ -30,6 +30,7 @@ public:
   EncodePipelineVAAPI(Renderer *render, VkContext &vk_ctx, VkFrame &input_frame, uint32_t width, uint32_t height);
 
   void PushFrame(uint64_t targetTimestampNs, bool idr) override;
+  void SetParams(FfiDynamicEncoderParams params) override;
 
 private:
   Renderer *r = nullptr;


### PR DESCRIPTION
These encoders just doesn't work with adaptive bitrate. This way they can still be used with constant bitrate.

VAAPI H264 and AMF H264/265 can handle adaptive bitrate/framerate well.