### PR TITLE
replace bools w/ ints in FFI structs

### DIFF
--- a/alvr/client_core/cpp/bindings.h
+++ b/alvr/client_core/cpp/bindings.h
@@ -15,7 +15,7 @@ struct FfiStreamConfig {
     unsigned int viewHeight;
     const unsigned int *swapchainTextures[2];
     unsigned int swapchainLength;
-    bool enableFoveation;
+    unsigned int enableFoveation;
     float foveationCenterSizeX;
     float foveationCenterSizeY;
     float foveationCenterShiftX;

--- a/alvr/client_core/cpp/graphics.cpp
+++ b/alvr/client_core/cpp/graphics.cpp
@@ -783,7 +783,7 @@ void streamStartNative(FfiStreamConfig config) {
                        g_ctx.streamTexture.get(),
                        g_ctx.hudTexture->GetGLTexture(),
                        g_ctx.streamSwapchainTextures,
-                       {config.enableFoveation,
+                       {(bool)config.enableFoveation,
                         config.viewWidth,
                         config.viewHeight,
                         config.foveationCenterSizeX,

--- a/alvr/client_core/src/opengl.rs
+++ b/alvr/client_core/src/opengl.rs
@@ -83,7 +83,7 @@ pub fn start_stream(
                 swapchain_textures[1].as_ptr(),
             ],
             swapchainLength: swapchain_textures[0].len() as _,
-            enableFoveation: foveated_rendering.is_some(),
+            enableFoveation: foveated_rendering.is_some().into(),
             foveationCenterSizeX: foveated_rendering
                 .as_ref()
                 .map(|f| f.center_size_x)

--- a/alvr/client_mock/src/main.rs
+++ b/alvr/client_mock/src/main.rs
@@ -243,7 +243,7 @@ fn client_thread(
                     window_output.fps = fps;
                     window_output.connected = true;
                     window_output.resolution = view_resolution;
-                    window_output.foveated_rendering = foveated_rendering.is_some();
+                    window_output.foveated_rendering = foveated_rendering.is_some().into();
 
                     let streaming = Arc::clone(&streaming);
                     let input = Arc::clone(&window_input);

--- a/alvr/server/cpp/alvr_server/bindings.h
+++ b/alvr/server/cpp/alvr_server/bindings.h
@@ -38,7 +38,7 @@ enum FfiOpenvrPropertyType {
 };
 
 union FfiOpenvrPropertyValue {
-    bool bool_;
+    unsigned int bool_;
     float float_;
     int int32;
     unsigned long long uint64;
@@ -66,13 +66,13 @@ enum FfiButtonType {
 struct FfiButtonValue {
     FfiButtonType type;
     union {
-        bool binary;
+        unsigned int binary;
         float scalar;
     };
 };
 
 struct FfiDynamicEncoderParams {
-    bool updated;
+    unsigned int updated;
     unsigned long long bitrate_bps;
     float framerate;
 };

--- a/alvr/server/src/bitrate.rs
+++ b/alvr/server/src/bitrate.rs
@@ -118,7 +118,7 @@ impl BitrateManager {
             self.last_update_instant = now;
         } else {
             return FfiDynamicEncoderParams {
-                updated: false,
+                updated: 0,
                 bitrate_bps: 0,
                 framerate: 0.0,
             };
@@ -160,7 +160,7 @@ impl BitrateManager {
                 .min(1.0);
 
         FfiDynamicEncoderParams {
-            updated: true,
+            updated: 1,
             bitrate_bps: bitrate_bps as u64,
             framerate,
         }

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -981,7 +981,9 @@ async fn connection_pipeline(
                     let value = match value {
                         ButtonValue::Binary(value) => FfiButtonValue {
                             type_: crate::FfiButtonType_BUTTON_TYPE_BINARY,
-                            __bindgen_anon_1: crate::FfiButtonValue__bindgen_ty_1 { binary: value },
+                            __bindgen_anon_1: crate::FfiButtonValue__bindgen_ty_1 {
+                                binary: value.into(),
+                            },
                         },
 
                         ButtonValue::Scalar(value) => FfiButtonValue {

--- a/alvr/server/src/lib.rs
+++ b/alvr/server/src/lib.rs
@@ -136,7 +136,9 @@ pub fn to_ffi_openvr_prop(key: OpenvrPropertyKey, value: OpenvrPropValue) -> Ffi
     };
 
     let value = match value {
-        OpenvrPropValue::Bool(bool_) => FfiOpenvrPropertyValue { bool_ },
+        OpenvrPropValue::Bool(bool_) => FfiOpenvrPropertyValue {
+            bool_: bool_.into(),
+        },
         OpenvrPropValue::Float(float_) => FfiOpenvrPropertyValue { float_ },
         OpenvrPropValue::Int32(int32) => FfiOpenvrPropertyValue { int32 },
         OpenvrPropValue::Uint64(uint64) => FfiOpenvrPropertyValue { uint64 },


### PR DESCRIPTION
Fixes struct alignment issue between C++ and Rust on Linux systems