### PR TITLE
Logger: Fix calling DriverLog

### DIFF
--- a/alvr/server/cpp/alvr_server/Logger.cpp
+++ b/alvr/server/cpp/alvr_server/Logger.cpp
@@ -20,7 +20,7 @@ void _log(const char *format, va_list args, void (*logFn)(const char *), bool dr
 #ifndef ALVR_DEBUG_LOG
 	if (driverLog)
 #endif
-		DriverLogVarArgs(format, args);
+		DriverLog(buf);
 }
 
 Exception MakeException(const char *format, ...)


### PR DESCRIPTION
va_list is undefined after passing it to vsnprintf.