### PR TITLE
Linux NVENC: make quality preset set a preset

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -75,14 +75,14 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(Renderer *render,
 
     switch (settings.m_encoderQualityPreset) {
     case ALVR_QUALITY:
-        av_opt_set(encoder_ctx->priv_data, "preset", "p7", 0);
+        av_opt_set(encoder_ctx->priv_data, "preset", "llhq", 0);
         break;
     case ALVR_BALANCED:
-        av_opt_set(encoder_ctx->priv_data, "preset", "p4", 0);
+        av_opt_set(encoder_ctx->priv_data, "preset", "ll", 0);
         break;
     case ALVR_SPEED:
     default:
-        av_opt_set(encoder_ctx->priv_data, "preset", "p1", 0);
+        av_opt_set(encoder_ctx->priv_data, "preset", "llhp", 0);
         break;
     }
 


### PR DESCRIPTION
There are no p1..p7 profiles for FFmpeg like there are for NvEncodeAPI. Prior to the commit that introduced these, the encoder quality setting was ignored and set to "llhq". Therefore "llhq", "ll" and "llhp" were the obvious choices.

This will also stop the error popups complaining about stuff like:
```
... Encoder: Undefined constant or missing '(' in 'p1'"}}}
... Encoder: Unable to parse option value "p1""}}}
... Encoder: failed to reconfigure nvenc: invalid param (8): Invalid Level."}}}
```

Note: there exists a compatibility layer in FFmpeg for NVEncodeAPI, see https://ffmpeg.org/doxygen/trunk/nvEncodeAPI_8h.html#details
