### PR TITLE
Include missing header for Fedora 38.

### DIFF
--- a/alvr/vulkan_layer/layer/settings.h
+++ b/alvr/vulkan_layer/layer/settings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 class Settings
 {


### PR DESCRIPTION
I tried building ALVR on Fedora 38 and it did not work because this header was missing, after adding it works as expected.