### PR TITLE
Fix 'StreamVR' typo (-> 'SteamVR')

### DIFF
--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -194,7 +194,7 @@ impl eframe::App for Dashboard {
                 // todo: find a way to center both vertically and horizontally
                 ui.vertical_centered(|ui| {
                     ui.add_space(100.0);
-                    ui.heading(RichText::new("StreamVR is restarting").size(30.0));
+                    ui.heading(RichText::new("SteamVR is restarting").size(30.0));
                 });
             });
 

--- a/alvr/server/cpp/platform/win32/FrameRender.cpp
+++ b/alvr/server/cpp/platform/win32/FrameRender.cpp
@@ -225,7 +225,7 @@ bool FrameRender::Startup()
 	//
 
 	// BlendState for first layer.
-	// Some VR apps (like StreamVR Home beta) submit the texture that alpha is zero on all pixels.
+	// Some VR apps (like SteamVR Home beta) submit the texture that alpha is zero on all pixels.
 	// So we need to ignore alpha of first layer.
 	D3D11_BLEND_DESC BlendDesc;
 	ZeroMemory(&BlendDesc, sizeof(BlendDesc));

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -91,7 +91,7 @@ pub struct NvencOverrides {
     #[schema(strings(
         help = "P1 is the fastest preset and P7 is the preset that produces better quality. P6 and P7 are too slow to be usable."
     ))]
-    #[schema(flag = "streamvr-restart")]
+    #[schema(flag = "steamvr-restart")]
     pub nvenc_quality_preset: EncoderQualityPresetNvidia,
 
     pub tuning_preset: NvencTuningPreset,
@@ -138,7 +138,7 @@ Temporal: Helps improve overall encoding quality, very small trade-off in speed.
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 pub struct AmfControls {
-    #[schema(flag = "streamvr-restart")]
+    #[schema(flag = "steamvr-restart")]
     pub amd_encoder_quality_preset: EncoderQualityPresetAmd,
     #[schema(flag = "steamvr-restart")]
     pub enable_vbaq: bool,
@@ -163,10 +163,10 @@ pub enum MediacodecDataType {
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 
 pub struct AdvancedCodecOptions {
-    #[schema(flag = "streamvr-restart")]
+    #[schema(flag = "steamvr-restart")]
     pub nvenc_overrides: NvencOverrides,
 
-    #[schema(flag = "streamvr-restart")]
+    #[schema(flag = "steamvr-restart")]
     pub amf_controls: AmfControls,
 
     pub mediacodec_extra_options: Vec<(String, MediacodecDataType)>,


### PR DESCRIPTION
This fixes a small typo with various instances of 'StreamVR' instead of 'SteamVR' :)

Most notably, it fixes the dashboard's "SteamVR is restarting" screen