### PR TITLE
Disable the back button in the setup wizard on the Welcome page

### DIFF
--- a/alvr/dashboard/src/dashboard/components/setup_wizard.rs
+++ b/alvr/dashboard/src/dashboard/components/setup_wizard.rs
@@ -171,7 +171,7 @@ This requires administrator rights!",
                     }
                 }
                 if ui
-                    .add_visible(self.page != Page::HardwareRequirements, Button::new("Back"))
+                    .add_visible(self.page != Page::Welcome, Button::new("Back"))
                     .clicked()
                 {
                     self.page = index_to_page(self.page as usize - 1);


### PR DESCRIPTION
The back button on the setup wizard was erroneously disabled on the Hardware Requirements page, which is not the first page of the setup wizard.

I assume this is a bug, and the intended behaviour is more likely to be a disabled back button on the first page of the setup wizard.