### PR TITLE
Add 'Finish' and 'Cancel' buttons to the setup wizard

### DIFF
--- a/alvr/dashboard/src/dashboard/components/setup_wizard.rs
+++ b/alvr/dashboard/src/dashboard/components/setup_wizard.rs
@@ -70,6 +70,14 @@ impl SetupWizard {
     pub fn ui(&mut self, ui: &mut Ui) -> Option<SetupWizardRequest> {
         let mut response = None;
 
+        macro_rules! close_setup_wizard {
+            () => {
+                response = Some(SetupWizardRequest::Close {
+                    finished: self.finished,
+                });
+            };
+        }
+
         ui.horizontal(|ui| {
             ui.add_space(60.0);
             ui.vertical(|ui| {
@@ -80,9 +88,7 @@ impl SetupWizard {
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                 ui.add_space(15.0);
                 if ui.button("❌").clicked() {
-                    response = Some(SetupWizardRequest::Close {
-                        finished: self.finished,
-                    });
+                    close_setup_wizard!();
                 }
             })
         });
@@ -161,20 +167,33 @@ This requires administrator rights!",
             ui.add_space(30.0);
             ui.horizontal(|ui| {
                 ui.add_space(15.0);
-                if ui
-                    .add_visible(self.page != Page::Finished, Button::new("Next"))
-                    .clicked()
-                {
-                    self.page = index_to_page(self.page as usize + 1);
+                let mut next_txt = "Next";
+                if self.page == Page::Finished {
+                    next_txt = "Finish";
+                }
+                let next_btn = ui.add(Button::new(next_txt));
+                if next_btn.clicked() {
                     if self.page == Page::Finished {
                         self.finished = true;
+                        close_setup_wizard!();
+                    }
+                    else {
+                        self.page = index_to_page(self.page as usize + 1);
                     }
                 }
-                if ui
-                    .add_visible(self.page != Page::Welcome, Button::new("Back"))
-                    .clicked()
-                {
-                    self.page = index_to_page(self.page as usize - 1);
+
+                let mut back_txt = "Back";
+                if self.page == Page::Welcome {
+                    back_txt = "Cancel";
+                }
+                let back_btn = ui.add(Button::new(back_txt));
+                if back_btn.clicked() {
+                    if self.page == Page::Welcome {
+                        close_setup_wizard!();
+                    }
+                    else {
+                        self.page = index_to_page(self.page as usize - 1);
+                    }
                 }
             });
             ui.separator();

--- a/alvr/dashboard/src/dashboard/components/setup_wizard.rs
+++ b/alvr/dashboard/src/dashboard/components/setup_wizard.rs
@@ -176,8 +176,7 @@ This requires administrator rights!",
                     if self.page == Page::Finished {
                         self.finished = true;
                         close_setup_wizard!();
-                    }
-                    else {
+                    } else {
                         self.page = index_to_page(self.page as usize + 1);
                     }
                 }
@@ -190,8 +189,7 @@ This requires administrator rights!",
                 if back_btn.clicked() {
                     if self.page == Page::Welcome {
                         close_setup_wizard!();
-                    }
-                    else {
+                    } else {
                         self.page = index_to_page(self.page as usize - 1);
                     }
                 }

--- a/alvr/dashboard/src/dashboard/components/setup_wizard.rs
+++ b/alvr/dashboard/src/dashboard/components/setup_wizard.rs
@@ -161,18 +161,15 @@ This requires administrator rights!",
             ui.add_space(30.0);
             ui.horizontal(|ui| {
                 ui.add_space(15.0);
-                let mut next_txt = "Next";
                 if self.page == Page::Finished {
-                    next_txt = "Finish";
-                }
-                let next_btn = ui.add(Button::new(next_txt));
-                if next_btn.clicked() {
-                    if self.page == Page::Finished {
+                    if ui.button("Finish").clicked() {
                         self.finished = true;
                         response = Some(SetupWizardRequest::Close {
                             finished: self.finished,
                         });
-                    } else {
+                    }
+                } else {
+                    if ui.button("Next").clicked() {
                         self.page = index_to_page(self.page as usize + 1);
                     }
                 }

--- a/alvr/dashboard/src/dashboard/components/setup_wizard.rs
+++ b/alvr/dashboard/src/dashboard/components/setup_wizard.rs
@@ -70,14 +70,6 @@ impl SetupWizard {
     pub fn ui(&mut self, ui: &mut Ui) -> Option<SetupWizardRequest> {
         let mut response = None;
 
-        macro_rules! close_setup_wizard {
-            () => {
-                response = Some(SetupWizardRequest::Close {
-                    finished: self.finished,
-                });
-            };
-        }
-
         ui.horizontal(|ui| {
             ui.add_space(60.0);
             ui.vertical(|ui| {
@@ -88,7 +80,9 @@ impl SetupWizard {
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                 ui.add_space(15.0);
                 if ui.button("❌").clicked() {
-                    close_setup_wizard!();
+                    response = Some(SetupWizardRequest::Close {
+                        finished: self.finished,
+                    });
                 }
             })
         });
@@ -175,23 +169,18 @@ This requires administrator rights!",
                 if next_btn.clicked() {
                     if self.page == Page::Finished {
                         self.finished = true;
-                        close_setup_wizard!();
+                        response = Some(SetupWizardRequest::Close {
+                            finished: self.finished,
+                        });
                     } else {
                         self.page = index_to_page(self.page as usize + 1);
                     }
                 }
-
-                let mut back_txt = "Back";
-                if self.page == Page::Welcome {
-                    back_txt = "Cancel";
-                }
-                let back_btn = ui.add(Button::new(back_txt));
-                if back_btn.clicked() {
-                    if self.page == Page::Welcome {
-                        close_setup_wizard!();
-                    } else {
-                        self.page = index_to_page(self.page as usize - 1);
-                    }
+                if ui
+                    .add_visible(self.page != Page::Welcome, Button::new("Back"))
+                    .clicked()
+                {
+                    self.page = index_to_page(self.page as usize - 1);
                 }
             });
             ui.separator();


### PR DESCRIPTION
It seems a little odd that when the setup wizard finishes, there's no 'Finish' button that the user can click. This pull request fixes this by changing the 'Next' button's text to 'Finish' and action to close the setup wizard, only appearing on the last setup page. For consistency, a similar 'Cancel' button is added to the first setup page.

I'm not sure of the code style/requirements for Rust in this project, so please suggest improvements if needed!
Notably, some things to review:
- The code that closes the setup wizard is now a macro (`close_setup_wizard!()`) (I couldn't find a way of doing this with a regular function, suggestions for a more Rust-like pattern are appreciated!)
- Creating the buttons for the setup wizard that operate in a similar fashion (in one state that closes the wizard when a condition is met, and in another state that doesn't in all other instances) seems repetitive, maybe this could be refactored into its own component?
- Maybe we should have variables for the first and last pages of the setup wizard? Although _very unlikely_, it's possible that the first and last pages could be changed or moved around, and it's currently a pain to update all references to `Page::Welcome` and `Page::Finished`.