### PR TITLE
Remove duplicate c++std library

### DIFF
--- a/alvr/client_core/Cargo.toml
+++ b/alvr/client_core/Cargo.toml
@@ -48,3 +48,6 @@ local-ip-address = "0.5"
 bindgen = "0.64"
 cc = { version = "1", features = ["parallel"] }
 walkdir = "2"
+
+[features]
+link-stdcpp-shared = []

--- a/alvr/client_core/build.rs
+++ b/alvr/client_core/build.rs
@@ -38,6 +38,9 @@ fn main() {
         println!("cargo:rustc-link-lib=GLESv3");
         println!("cargo:rustc-link-lib=android");
 
+        #[cfg(feature = "link-stdcpp-shared")]
+        println!("cargo:rustc-link-lib=c++_shared");
+
         bindgen::builder()
             .clang_arg("-xc++")
             .header("cpp/bindings.h")

--- a/alvr/client_core/build.rs
+++ b/alvr/client_core/build.rs
@@ -37,7 +37,6 @@ fn main() {
         println!("cargo:rustc-link-lib=EGL");
         println!("cargo:rustc-link-lib=GLESv3");
         println!("cargo:rustc-link-lib=android");
-        println!("cargo:rustc-link-lib=c++_shared");
 
         bindgen::builder()
             .clang_arg("-xc++")


### PR DESCRIPTION
- Fixes https://github.com/alvr-org/alvr-cardboard/issues/3 
- Static c++stdlib is included already here, no need for linking shared c++stdlib again - https://github.com/alvr-org/ALVR/blob/528fe67df4a8f7ff980da0a8ebe728a627069d29/alvr/client_core/build.rs#L25-L34