### PR TITLE
Fix setup wizard session settings

### DIFF
--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -210,9 +210,7 @@ impl eframe::App for Dashboard {
                 if let Some(SetupWizardRequest::Close { finished }) = self.setup_wizard.ui(ui) {
                     if finished {
                         requests.push(DashboardRequest::SetValues(vec![PathValuePair {
-                            path: alvr_sockets::parse_path(
-                                "session_settings.extra.open_setup_wizard",
-                            ),
+                            path: alvr_sockets::parse_path("session_settings.open_setup_wizard"),
                             value: serde_json::Value::Bool(false),
                         }]))
                     }

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -211,7 +211,7 @@ impl eframe::App for Dashboard {
                     if finished {
                         requests.push(DashboardRequest::SetValues(vec![PathValuePair {
                             path: alvr_sockets::parse_path(
-                                "session_settings.extra.open_setup_wizard",
+                                "session_settings.open_setup_wizard",
                             ),
                             value: serde_json::Value::Bool(false),
                         }]))

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -211,7 +211,7 @@ impl eframe::App for Dashboard {
                     if finished {
                         requests.push(DashboardRequest::SetValues(vec![PathValuePair {
                             path: alvr_sockets::parse_path(
-                                "session_settings.open_setup_wizard",
+                                "session_settings.extra.open_setup_wizard",
                             ),
                             value: serde_json::Value::Bool(false),
                         }]))


### PR DESCRIPTION
Commit 4fa46ce restructured the settings schema, which broke the setup wizard's auto open setting as it was using an old path that had not been updated.