### PR TITLE
fix: alvr_client_core stability issues on smartphone androids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4057,8 +4057,7 @@ dependencies = [
 [[package]]
 name = "socket2"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d283f86695ae989d1e18440a943880967156325ba025f05049946bff47bcc2b"
+source = "git+https://github.com/rust-lang/socket2.git#6713533ef29a6792f1553c44a8cf580f8cbbed68"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ alvr_sockets = { path = "alvr/sockets" }
 [profile.distribution]
 inherits = "release"
 lto = true
+
+[patch.crates-io]
+socket2 = { git = 'https://github.com/rust-lang/socket2.git' } # TODO: Remove patch once a new version is released (maybe in 1-2months)

--- a/alvr/client_core/src/platform/android.rs
+++ b/alvr/client_core/src/platform/android.rs
@@ -447,6 +447,8 @@ pub fn video_decoder_split(
             let decoder = Arc::new(FakeThreadSafe(
                 MediaCodec::from_decoder_type(&mime).unwrap(),
             ));
+
+            info!("Using AMediaCoded format:{} ", format);
             decoder
                 .configure(
                     &format,

--- a/alvr/client_core/src/platform/android.rs
+++ b/alvr/client_core/src/platform/android.rs
@@ -208,6 +208,8 @@ pub fn release_wifi_lock() {
 
         env.call_method(wifi_lock.as_obj(), "release", "()V", &[])
             .unwrap();
+        // TODO: all JVM.call_method sometimes result in JavaExceptions, unwrap will only report Error as 'JavaException', ideally before unwrapping
+        // need to call JVM.describe_error() which will actually check if there is an exception and print error to stderr/logcat. Then unwrap.
 
         // wifi_lock is dropped here
     }

--- a/alvr/session/Cargo.toml
+++ b/alvr/session/Cargo.toml
@@ -6,6 +6,10 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[features]
+defaults = ["enable-low-latency"] # Android smartphones crashes enabling this feature (https://github.com/PhoneVR-Developers/alvr-cardboard/issues/5)
+enable-low-latency = []
+
 [dependencies]
 alvr_common.workspace = true
 

--- a/alvr/session/Cargo.toml
+++ b/alvr/session/Cargo.toml
@@ -6,10 +6,6 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 
-[features]
-defaults = ["enable-low-latency"] # Android smartphones crashes enabling this feature (https://github.com/PhoneVR-Developers/alvr-cardboard/issues/5)
-enable-low-latency = []
-
 [dependencies]
 alvr_common.workspace = true
 

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -948,8 +948,7 @@ pub fn session_settings_default() -> SettingsDefault {
                         ("priority".into(), int32_default(0)),
                         // low-latency: only applicable on API level 30. Quest 1 and 2 might not be
                         // cabable, since they are on level 29.
-                        #[cfg(feature = "enable-low-latency")]
-                        ("low-latency".into(), int32_default(1)),
+                        // ("low-latency".into(), int32_default(1)), // Android smartphones crashes enabling this feature (https://github.com/PhoneVR-Developers/alvr-cardboard/issues/5)
                         (
                             "vendor.qti-ext-dec-low-latency.enable".into(),
                             int32_default(1),

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -948,7 +948,7 @@ pub fn session_settings_default() -> SettingsDefault {
                         ("priority".into(), int32_default(0)),
                         // low-latency: only applicable on API level 30. Quest 1 and 2 might not be
                         // cabable, since they are on level 29.
-                        ("low-latency".into(), int32_default(1)),
+                        // ("low-latency".into(), int32_default(1)),
                         (
                             "vendor.qti-ext-dec-low-latency.enable".into(),
                             int32_default(1),

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -948,7 +948,10 @@ pub fn session_settings_default() -> SettingsDefault {
                         ("priority".into(), int32_default(0)),
                         // low-latency: only applicable on API level 30. Quest 1 and 2 might not be
                         // cabable, since they are on level 29.
-                        // ("low-latency".into(), int32_default(1)),
+                        
+                        #[cfg(feature="enable-low-latency")]
+                        ("low-latency".into(), int32_default(1)),
+
                         (
                             "vendor.qti-ext-dec-low-latency.enable".into(),
                             int32_default(1),

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -948,10 +948,8 @@ pub fn session_settings_default() -> SettingsDefault {
                         ("priority".into(), int32_default(0)),
                         // low-latency: only applicable on API level 30. Quest 1 and 2 might not be
                         // cabable, since they are on level 29.
-                        
-                        #[cfg(feature="enable-low-latency")]
+                        #[cfg(feature = "enable-low-latency")]
                         ("low-latency".into(), int32_default(1)),
-
                         (
                             "vendor.qti-ext-dec-low-latency.enable".into(),
                             int32_default(1),

--- a/alvr/xtask/src/build.rs
+++ b/alvr/xtask/src/build.rs
@@ -200,7 +200,7 @@ pub fn build_client_lib(profile: Profile, link_stdcpp: bool) {
 
     cmd!(
         sh,
-        "cargo ndk -t arm64-v8a -p 26 -o {build_dir} build {flags_ref...}"
+        "cargo ndk -t arm64-v8a -t x86_64 -p 26 -o {build_dir} build {flags_ref...}"
     )
     .run()
     .unwrap();

--- a/alvr/xtask/src/build.rs
+++ b/alvr/xtask/src/build.rs
@@ -200,7 +200,7 @@ pub fn build_client_lib(profile: Profile, link_stdcpp: bool) {
 
     cmd!(
         sh,
-        "cargo ndk -t arm64-v8a -t x86_64 -p 26 -o {build_dir} build {flags_ref...}"
+        "cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 -p 26 -o {build_dir} build {flags_ref...}"
     )
     .run()
     .unwrap();

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -296,7 +296,7 @@ pub fn build_android_deps(skip_admin_priv: bool) {
         .unwrap();
     cmd!(sh, "rustup target add i686-linux-android")
         .run()
-        .unwrap();    
+        .unwrap();
     cmd!(sh, "cargo install cargo-apk cargo-ndk cbindgen")
         .run()
         .unwrap();

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -288,6 +288,16 @@ pub fn build_android_deps(skip_admin_priv: bool) {
     cmd!(sh, "rustup target add aarch64-linux-android")
         .run()
         .unwrap();
+    cmd!(sh, "rustup target add armv7-linux-androideabi")
+        .run()
+        .unwrap();
+    cmd!(sh, "rustup target add x86_64-linux-android")
+        .run()
+        .unwrap();
+    cmd!(sh, "rustup target add i686-linux-android")
+        .run()
+        .unwrap();
+    
     cmd!(sh, "cargo install cargo-apk cargo-ndk cbindgen")
         .run()
         .unwrap();

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -296,8 +296,7 @@ pub fn build_android_deps(skip_admin_priv: bool) {
         .unwrap();
     cmd!(sh, "rustup target add i686-linux-android")
         .run()
-        .unwrap();
-    
+        .unwrap();    
     cmd!(sh, "cargo install cargo-apk cargo-ndk cbindgen")
         .run()
         .unwrap();


### PR DESCRIPTION
- low-latency feature crashes on smartphone android, hence made it as a default-enabled feature https://github.com/PhoneVR-Developers/alvr-cardboard/issues/5

- Building for x86 arch enables faster AVD emulation, wider client_core compatibility
  - Android enforces only x86 emulator images to run on x86 hosts from API 28 - https://stackoverflow.com/a/74819011
    - we can actually stably build for other ABIs as well but waiting for confirmation from https://github.com/googlevr/cardboard/pull/400
    - and fixes from upstream module https://github.com/rust-lang/socket2/issues/433
- some useful logging

future todo: build for remaining two ABIs (ref: https://developer.android.com/ndk/guides/abis)