### PR TITLE
Change steam to xdg-open on non-Windows systems

### DIFF
--- a/alvr/dashboard/src/steamvr_launcher.rs
+++ b/alvr/dashboard/src/steamvr_launcher.rs
@@ -155,7 +155,7 @@ impl Launcher {
             }
             #[cfg(not(windows))]
             {
-                Command::new("steam")
+                Command::new("xdg-open")
                     .args(["steam://rungameid/250820"])
                     .spawn()
                     .ok();


### PR DESCRIPTION
I am attempting to create an ALVR Flatpak, and this is the only barrier to a nearly-similar experience as with the AppImage. I don't imagine it impacts many users, since Steam should likely be already registered as the URL handler for `steam://`.