### PR TITLE
switch for soft-toggling controllers at runtime

### DIFF
--- a/alvr/server/cpp/alvr_server/Controller.cpp
+++ b/alvr/server/cpp/alvr_server/Controller.cpp
@@ -17,9 +17,9 @@ vr::ETrackedDeviceClass Controller::getControllerDeviceClass() {
 
 Controller::Controller(uint64_t deviceID) : TrackedDevice(deviceID) {
     m_pose = vr::DriverPose_t{};
-    m_pose.poseIsValid = true;
-    m_pose.result = vr::TrackingResult_Running_OK;
-    m_pose.deviceIsConnected = true;
+    m_pose.poseIsValid = false;
+    m_pose.deviceIsConnected = false;
+    m_pose.result = vr::TrackingResult_Uninitialized;
 
     m_pose.qDriverFromHeadRotation = HmdQuaternion_Init(1, 0, 0, 0);
     m_pose.qWorldFromDriverRotation = HmdQuaternion_Init(1, 0, 0, 0);
@@ -408,7 +408,8 @@ void Controller::SetButton(uint64_t id, FfiButtonValue value) {
 
 bool Controller::onPoseUpdate(float predictionS,
                               FfiDeviceMotion motion,
-                              const FfiHandSkeleton *handSkeleton) {
+                              const FfiHandSkeleton *handSkeleton,
+                              unsigned int controllersTracked) {
     if (this->object_id == vr::k_unTrackedDeviceIndexInvalid) {
         return false;
     }
@@ -416,10 +417,11 @@ bool Controller::onPoseUpdate(float predictionS,
     auto vr_driver_input = vr::VRDriverInput();
 
     auto pose = vr::DriverPose_t{};
-
-    pose.poseIsValid = true;
-    pose.result = vr::TrackingResult_Running_OK;
-    pose.deviceIsConnected = true;
+    pose.poseIsValid = controllersTracked;
+    pose.deviceIsConnected = controllersTracked;
+    pose.result = controllersTracked
+      ? vr::TrackingResult_Running_OK
+      : vr::TrackingResult_Uninitialized;
 
     pose.qDriverFromHeadRotation = HmdQuaternion_Init(1, 0, 0, 0);
     pose.qWorldFromDriverRotation = HmdQuaternion_Init(1, 0, 0, 0);

--- a/alvr/server/cpp/alvr_server/Controller.h
+++ b/alvr/server/cpp/alvr_server/Controller.h
@@ -35,7 +35,10 @@ class Controller : public TrackedDevice, public vr::ITrackedDeviceServerDriver {
 
     void SetButton(uint64_t id, FfiButtonValue value);
 
-    bool onPoseUpdate(float predictionS, FfiDeviceMotion motion, const FfiHandSkeleton *hand);
+    bool onPoseUpdate(float predictionS,
+                      FfiDeviceMotion motion,
+                      const FfiHandSkeleton *hand,
+                      unsigned int controllersTracked);
 
     void GetBoneTransform(bool withController,
                           bool isLeftHand,

--- a/alvr/server/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server/cpp/alvr_server/alvr_server.cpp
@@ -241,18 +241,19 @@ void SetTracking(unsigned long long targetTimestampNs,
                  const FfiDeviceMotion *deviceMotions,
                  int motionsCount,
                  const FfiHandSkeleton *leftHand,
-                 const FfiHandSkeleton *rightHand) {
+                 const FfiHandSkeleton *rightHand,
+                 unsigned int controllersTracked) {
     for (int i = 0; i < motionsCount; i++) {
         if (deviceMotions[i].deviceID == HEAD_ID && g_driver_provider.hmd) {
             g_driver_provider.hmd->OnPoseUpdated(targetTimestampNs, deviceMotions[i]);
         } else {
             if (g_driver_provider.left_controller && deviceMotions[i].deviceID == LEFT_HAND_ID) {
                 g_driver_provider.left_controller->onPoseUpdate(
-                    controllerPoseTimeOffsetS, deviceMotions[i], leftHand);
+                    controllerPoseTimeOffsetS, deviceMotions[i], leftHand, controllersTracked);
             } else if (g_driver_provider.right_controller &&
                        deviceMotions[i].deviceID == RIGHT_HAND_ID) {
                 g_driver_provider.right_controller->onPoseUpdate(
-                    controllerPoseTimeOffsetS, deviceMotions[i], rightHand);
+                    controllerPoseTimeOffsetS, deviceMotions[i], rightHand, controllersTracked);
             }
         }
     }

--- a/alvr/server/cpp/alvr_server/bindings.h
+++ b/alvr/server/cpp/alvr_server/bindings.h
@@ -131,7 +131,8 @@ extern "C" void SetTracking(unsigned long long targetTimestampNs,
                             const FfiDeviceMotion *deviceMotions,
                             int motionsCount,
                             const FfiHandSkeleton *leftHand,
-                            const FfiHandSkeleton *rightHand);
+                            const FfiHandSkeleton *rightHand,
+                            unsigned int controllersTracked);
 extern "C" void VideoErrorReportReceive();
 extern "C" void ShutdownSteamvr();
 

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -773,6 +773,11 @@ async fn connection_pipeline(
                 None
             };
 
+            let mut track_controllers = 0u32;
+            if let Switch::Enabled(config) = settings.headset.controllers {
+                track_controllers = config.tracked.into();
+            }
+
             loop {
                 let tracking = receiver.recv_header_only().await?;
 
@@ -858,6 +863,7 @@ async fn connection_pipeline(
                             } else {
                                 ptr::null()
                             },
+                            track_controllers,
                         )
                     };
                 }

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -573,6 +573,11 @@ pub struct HapticsConfig {
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 pub struct ControllersDesc {
+    #[schema(strings(
+        help = "Turning this off will make the controllers appear powered off. Reconnect HMD to apply."
+    ))]
+    pub tracked: bool,
+
     #[schema(flag = "steamvr-restart")]
     pub emulation_mode: ControllersEmulationMode,
 
@@ -1077,6 +1082,7 @@ pub fn session_settings_default() -> SettingsDefault {
                     emulation_mode: ControllersEmulationModeDefault {
                         variant: ControllersEmulationModeDefaultVariant::Quest2Touch,
                     },
+                    tracked: true,
                     extra_openvr_props: default_custom_openvr_props,
                     steamvr_pipeline_frames: 3.0,
                     linear_velocity_cutoff: 0.05,


### PR DESCRIPTION
This feature lets users switch the power state of ALVR emulated controllers at runtime, without the need for a SteamVR restart.

This is useful to those wishing to use different controllers, for example via OpenVR-SpaceCalibrator.
