### PR TITLE
Socket fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_audio"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_core"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_audio",
  "alvr_common",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_mock"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_openxr"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_commands"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_common"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "backtrace",
  "glam",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_dashboard"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_commands",
  "alvr_common",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_events"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_filesystem"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "dirs 5.0.0",
  "once_cell",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alcro",
  "alvr_audio",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_data"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_common",
  "alvr_events",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_session"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_common",
  "bytemuck",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_sockets"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_common",
  "alvr_events",
@@ -404,14 +404,14 @@ dependencies = [
 
 [[package]]
 name = "alvr_vrcompositor_wrapper"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "exec",
 ]
 
 [[package]]
 name = "alvr_vulkan_layer"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_filesystem",
  "bindgen 0.65.1",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_xtask"
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 dependencies = [
  "alvr_filesystem",
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["alvr/*"]
 
 [workspace.package]
-version = "20.0.0-dev11"
+version = "20.0.0-dev12"
 edition = "2021"
 rust-version = "1.65"
 authors = ["alvr-org"]

--- a/alvr/server/cpp/alvr_server/NalParsing.cpp
+++ b/alvr/server/cpp/alvr_server/NalParsing.cpp
@@ -96,7 +96,8 @@ void processH265Nals(unsigned char *&buf, int &len) {
     }
 }
 
-void ParseFrameNals(int codec, unsigned char *buf, int len, unsigned long long targetTimestampNs) {
+void ParseFrameNals(
+    int codec, unsigned char *buf, int len, unsigned long long targetTimestampNs, bool isIdr) {
     // Report before the frame is packetized
     ReportEncoded(targetTimestampNs);
 
@@ -110,5 +111,5 @@ void ParseFrameNals(int codec, unsigned char *buf, int len, unsigned long long t
         processH265Nals(buf, len);
     }
 
-    VideoSend(targetTimestampNs, buf, len);
+    VideoSend(targetTimestampNs, buf, len, isIdr);
 }

--- a/alvr/server/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server/cpp/alvr_server/alvr_server.cpp
@@ -184,7 +184,7 @@ void (*LogDebug)(const char *stringPtr);
 void (*LogPeriodically)(const char *tag, const char *stringPtr);
 void (*DriverReadyIdle)(bool setDefaultChaprone);
 void (*InitializeDecoder)(const unsigned char *configBuffer, int len, int codec);
-void (*VideoSend)(unsigned long long targetTimestampNs, unsigned char *buf, int len);
+void (*VideoSend)(unsigned long long targetTimestampNs, unsigned char *buf, int len, bool isIdr);
 void (*HapticsSend)(unsigned long long path, float duration_s, float frequency, float amplitude);
 void (*ShutdownRuntime)();
 unsigned long long (*PathStringToHash)(const char *path);
@@ -226,9 +226,7 @@ void DeinitializeStreaming() {
     }
 }
 
-void SendVSync() {
-    vr::VRServerDriverHost()->VsyncEvent(0.0);
-}
+void SendVSync() { vr::VRServerDriverHost()->VsyncEvent(0.0); }
 
 void RequestIDR() {
     if (g_driver_provider.hmd && g_driver_provider.hmd->m_encoder) {

--- a/alvr/server/cpp/alvr_server/bindings.h
+++ b/alvr/server/cpp/alvr_server/bindings.h
@@ -107,7 +107,10 @@ extern "C" void (*LogDebug)(const char *stringPtr);
 extern "C" void (*LogPeriodically)(const char *tag, const char *stringPtr);
 extern "C" void (*DriverReadyIdle)(bool setDefaultChaprone);
 extern "C" void (*InitializeDecoder)(const unsigned char *configBuffer, int len, int codec);
-extern "C" void (*VideoSend)(unsigned long long targetTimestampNs, unsigned char *buf, int len);
+extern "C" void (*VideoSend)(unsigned long long targetTimestampNs,
+                             unsigned char *buf,
+                             int len,
+                             bool isIdr);
 extern "C" void (*HapticsSend)(unsigned long long path,
                                float duration_s,
                                float frequency,
@@ -145,4 +148,5 @@ extern "C" void SetButton(unsigned long long path, FfiButtonValue value);
 extern "C" void CaptureFrame();
 
 // NalParsing.cpp
-void ParseFrameNals(int codec, unsigned char *buf, int len, unsigned long long targetTimestampNs);
+void ParseFrameNals(
+    int codec, unsigned char *buf, int len, unsigned long long targetTimestampNs, bool isIdr);

--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -273,7 +273,8 @@ void CEncoder::Run() {
         ReportPresent(pose->targetTimestampNs, present_offset);
         ReportComposed(pose->targetTimestampNs, composed_offset);
 
-        ParseFrameNals(encode_pipeline->GetCodec(), packet.data, packet.size, packet.pts);
+        // todo: properly detect IDR
+        ParseFrameNals(encode_pipeline->GetCodec(), packet.data, packet.size, packet.pts, true);
       }
     }
     catch (std::exception &e) {

--- a/alvr/server/cpp/platform/win32/VideoEncoderNVENC.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderNVENC.cpp
@@ -118,7 +118,7 @@ void VideoEncoderNVENC::Transmit(ID3D11Texture2D *pTexture, uint64_t presentatio
 			fpOut.write(reinterpret_cast<char*>(packet.data()), packet.size());
 		}
 		
-		ParseFrameNals(m_codec, packet.data(), (int)packet.size(), targetTimestampNs);
+		ParseFrameNals(m_codec, packet.data(), (int)packet.size(), targetTimestampNs, insertIDR);
 	}
 }
 

--- a/alvr/server/cpp/platform/win32/VideoEncoderSW.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderSW.cpp
@@ -199,7 +199,8 @@ void VideoEncoderSW::Transmit(ID3D11Texture2D *pTexture, uint64_t presentationTi
 			break;
 		}
 		// Send encoded frame to client
-		ParseFrameNals(m_codec, packet->data, packet->size, packet->pts);
+		// todo: properly detect IDR
+		ParseFrameNals(m_codec, packet->data, packet->size, packet->pts, true);
 		//Debug("Sent encoded packet to client");
 		av_packet_free(&packet);
 	}

--- a/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderVCE.cpp
@@ -434,7 +434,8 @@ void VideoEncoderVCE::Receive(AMFDataPtr data)
 		fpOut.write(p, length);
 	}
 
-	ParseFrameNals(m_codec, reinterpret_cast<uint8_t *>(p), length, targetTimestampNs);
+	// todo: properly detect IDR
+	ParseFrameNals(m_codec, reinterpret_cast<uint8_t *>(p), length, targetTimestampNs, true);
 }
 
 void VideoEncoderVCE::ApplyFrameProperties(const amf::AMFSurfacePtr &surface, bool insertIDR) {

--- a/alvr/sockets/src/packets.rs
+++ b/alvr/sockets/src/packets.rs
@@ -97,6 +97,12 @@ pub struct FaceData {
     pub htc_lip_expression: Option<Vec<f32>>, // issue: Serialize does not support [f32; 37]
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct VideoPacketHeader {
+    pub timestamp: Duration,
+    pub is_idr: bool,
+}
+
 // Note: face_data does not respect target_timestamp.
 #[derive(Serialize, Deserialize, Default)]
 pub struct Tracking {

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -34,7 +34,7 @@ Vcs-Browser: https://github.com/alvr-org/ALVR
 Vcs-Git: https://github.com/alvr-org/ALVR.git
 Rules-Requires-Root: no
 Package: alvr
-Version: 20.0.0-dev11
+Version: 20.0.0-dev12
 Architecture: amd64
 Recommends: steam
 Description: Stream VR games from your PC to your headset via Wi-Fi

--- a/packaging/rpm/alvr.spec
+++ b/packaging/rpm/alvr.spec
@@ -1,9 +1,9 @@
 Name: alvr
 Version: 20.0.0
-Release: 0.0.1dev11
+Release: 0.0.1dev12
 Summary: Stream VR games from your PC to your headset via Wi-Fi
 License: MIT
-Source: https://github.com/alvr-org/ALVR/archive/refs/tags/v20.0.0-dev11.tar.gz
+Source: https://github.com/alvr-org/ALVR/archive/refs/tags/v20.0.0-dev12.tar.gz
 URL: https://github.com/alvr-org/ALVR/
 ExclusiveArch: x86_64
 BuildRequires: alsa-lib-devel cairo-gobject-devel cargo clang-devel ffmpeg-devel gcc gcc-c++ cmake ImageMagick (jack-audio-connection-kit-devel or pipewire-jack-audio-connection-kit-devel) libunwind-devel openssl-devel rpmdevtools rust rust-atk-sys-devel rust-cairo-sys-rs-devel rust-gdk-sys-devel rust-glib-sys-devel rust-pango-sys-devel selinux-policy-devel vulkan-headers vulkan-loader-devel


### PR DESCRIPTION
* Added option to drop frames on TCP. This fixes OOM crashes when using TCP and the client is sleeping.
* Add option to never show glitching. When a packet is dropped either on the server, client (because of stalled decoder) or network, wait for a IDR frame before feeding new frames to the decoder.
* Removed disconnection criteria options.
* The option to avoid glitching works only on Windows+Nvidia. Needs to detect when the encoder outputs a IDR frame.