### PR TITLE
CEncoder AV log level verbose -> info

### DIFF
--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -87,7 +87,7 @@ void av_logfn(void*, int level, const char* data, va_list va)
 #ifdef DEBUG
           AV_LOG_DEBUG)
 #else
-          AV_LOG_VERBOSE)
+          AV_LOG_INFO)
 #endif
     return;
 


### PR DESCRIPTION
With CEncoder, the logs tab is pretty much useless because libavcodec spams 3 lines each frame about how the stream params were adjusted.

Let's lower the log level, so that more meaningful messages are easier to spot.

For when there is a need for these messages, a debug build can be used.

This PR was brought to you by the Make Logs Readable Again movement.