### PR TITLE
fix: alvr_client_core: Linking program failed: Attribute x aliases attribute y

### DIFF
--- a/alvr/client_core/cpp/graphics.cpp
+++ b/alvr/client_core/cpp/graphics.cpp
@@ -465,16 +465,25 @@ bool ovrProgram_Create(ovrProgram *program, const char *vertexSource, const char
         GL(glBindAttribLocation(program->streamProgram,
                                 ProgramVertexAttributes[i].location,
                                 ProgramVertexAttributes[i].name));
+        LOGI("Binding ProgramVertexAttributes[%d] %s to location %d", i, ProgramVertexAttributes[i].name, ProgramVertexAttributes[i].location);
     }
 
     GL(glLinkProgram(program->streamProgram));
+
+    GLint loc;
+    for (size_t i = 0; i < sizeof(ProgramVertexAttributes) / sizeof(ProgramVertexAttributes[0]);
+        i++) {
+        GL(loc = glGetAttribLocation(program->streamProgram, ProgramVertexAttributes[i].name));
+        LOGI("Bound ProgramVertexAttributes[%d] %s to location %d", i, ProgramVertexAttributes[i].name, loc);
+    }
+
     GL(glGetProgramiv(program->streamProgram, GL_LINK_STATUS, &r));
     if (r == GL_FALSE) {
         GLchar msg[4096];
         GL(glGetProgramInfoLog(program->streamProgram, sizeof(msg), 0, msg));
         LOGE("Linking program failed: %s (%s, %d)\n", msg, __FILE__, __LINE__);
-        LOGE("%s\n%s\n", vertexSource, msg);
-        LOGE("%s\n%s\n", fragmentSource, msg);
+        LOGE("vertexSource: %s\n", vertexSource);
+        LOGE("fragmentSource: %s\n", fragmentSource);
         return false;
     }
 

--- a/alvr/client_core/cpp/graphics.cpp
+++ b/alvr/client_core/cpp/graphics.cpp
@@ -721,6 +721,16 @@ void initGraphicsNative() {
     g_ctx.streamTexture = std::make_unique<Texture>(false, 0, true);
     g_ctx.hudTexture = std::make_unique<Texture>(
         false, 0, false, 1280, 720, GL_RGBA8, GL_RGBA, std::vector<uint8_t>(1280 * 720 * 4, 0));
+    
+    const GLubyte *sVendor, *sRenderer, *sVersion, *sExts;
+
+    GL(sVendor = glGetString(GL_VENDOR));
+    GL(sRenderer = glGetString(GL_RENDERER));
+    GL(sVersion = glGetString(GL_VERSION));
+    GL(sExts = glGetString(GL_EXTENSIONS));
+
+    LOGI("glVendor : %s, glRenderer : %s, glVersion : %s", sVendor, sRenderer, sVersion);
+    LOGI("glExts : %s", sExts);
 }
 
 void destroyGraphicsNative() {

--- a/alvr/client_core/cpp/graphics.cpp
+++ b/alvr/client_core/cpp/graphics.cpp
@@ -472,7 +472,9 @@ bool ovrProgram_Create(ovrProgram *program, const char *vertexSource, const char
     if (r == GL_FALSE) {
         GLchar msg[4096];
         GL(glGetProgramInfoLog(program->streamProgram, sizeof(msg), 0, msg));
-        LOGE("Linking program failed: %s\n", msg);
+        LOGE("Linking program failed: %s (%s, %d)\n", msg, __FILE__, __LINE__);
+        LOGE("%s\n%s\n", vertexSource, msg);
+        LOGE("%s\n%s\n", fragmentSource, msg);
         return false;
     }
 

--- a/alvr/client_core/cpp/graphics.cpp
+++ b/alvr/client_core/cpp/graphics.cpp
@@ -456,8 +456,6 @@ bool ovrProgram_Create(ovrProgram *program, const char *vertexSource, const char
     }
 
     GL(program->streamProgram = glCreateProgram());
-    GL(glAttachShader(program->streamProgram, program->VertexShader));
-    GL(glAttachShader(program->streamProgram, program->FragmentShader));
 
     // Bind the vertex attribute locations.
     for (size_t i = 0; i < sizeof(ProgramVertexAttributes) / sizeof(ProgramVertexAttributes[0]);
@@ -468,6 +466,8 @@ bool ovrProgram_Create(ovrProgram *program, const char *vertexSource, const char
         LOGI("Binding ProgramVertexAttributes[%d] %s to location %d", i, ProgramVertexAttributes[i].name, ProgramVertexAttributes[i].location);
     }
 
+    GL(glAttachShader(program->streamProgram, program->VertexShader));
+    GL(glAttachShader(program->streamProgram, program->FragmentShader));
     GL(glLinkProgram(program->streamProgram));
 
     GLint loc;

--- a/alvr/client_core/cpp/utils.h
+++ b/alvr/client_core/cpp/utils.h
@@ -13,6 +13,10 @@
     do {                                                                                           \
         __android_log_print(ANDROID_LOG_ERROR, "[ALVR Native]", __VA_ARGS__);                        \
     } while (false)
+#define LOGD(...)                                                                                  \
+    do {                                                                                           \
+        __android_log_print(ANDROID_LOG_DEBUG, "[ALVR Native]", __VA_ARGS__);                        \
+    } while (false)
 
 static const char *GlErrorString(GLenum error) {
     switch (error) {
@@ -34,11 +38,14 @@ static const char *GlErrorString(GLenum error) {
 }
 
 [[maybe_unused]] static void GLCheckErrors(const char *file, int line) {
-    const GLenum error = glGetError();
+    GLenum error = glGetError();
     if (error == GL_NO_ERROR) {
         return;
     }
-    LOGE("GL error on %s : %d: %s", file, line, GlErrorString(error));
+    while (error != GL_NO_ERROR) {
+        LOGE("GL error on %s : %d: %s", file, line, GlErrorString(error));
+        error = glGetError();
+    }
     abort();
 }
 


### PR DESCRIPTION
```java
05-11 17:08:26.031  9082  9197 E [ALVR Native]: Linking program failed: Attribute 'vertexNormal' aliases attribute 'vertexTransform' at location 4
05-11 17:08:26.031  9082  9197 E [ALVR Native]:  (cpp/graphics.cpp, 475)
05-11 17:08:26.031  9082  9197 E [ALVR Native]: #ifndef DISABLE_MULTIVIEW
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     #define DISABLE_MULTIVIEW 0
05-11 17:08:26.031  9082  9197 E [ALVR Native]: #endif
05-11 17:08:26.031  9082  9197 E [ALVR Native]: #define NUM_VIEWS 2
05-11 17:08:26.031  9082  9197 E [ALVR Native]: #if defined( GL_OVR_multiview2 ) && ! DISABLE_MULTIVIEW
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     #extension GL_OVR_multiview2 : enable
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     layout(num_views=NUM_VIEWS) in;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     #define VIEW_ID gl_ViewID_OVR
05-11 17:08:26.031  9082  9197 E [ALVR Native]: #else
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     uniform lowp int ViewID;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     #define VIEW_ID ViewID
05-11 17:08:26.031  9082  9197 E [ALVR Native]: #endif
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in vec3 vertexPosition;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in vec4 vertexColor;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in mat4 vertexTransform;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in vec2 vertexUv;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in vec3 vertexNormal;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: uniform mat4 mvpMatrix[NUM_VIEWS];
05-11 17:08:26.031  9082  9197 E [ALVR Native]: uniform lowp vec4 Color;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: uniform mat4 mMatrix;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: out vec4 fragmentColor;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: out vec2 uv;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: out lowp float fragmentLight;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: out lowp vec3 lightPoint;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: out lowp vec3 normal;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: out lowp vec3 position;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: void main()
05-11 17:08:26.031  9082  9197 E [ALVR Native]: {
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     lowp vec4 position4 = mMatrix * vec4( vertexPosition, 1.0 );
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     gl_Position = mvpMatrix[VIEW_ID] * position4;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     uv = vertexUv;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     position = position4.xyz / position4.w;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     lowp vec4 lightPoint4 = mvpMatrix[VIEW_ID] * vec4(100.0, 10000.0, 100.0, 1.0);
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     lightPoint = lightPoint4.xyz / lightPoint4.w;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     normal = normalize((mvpMatrix[VIEW_ID] *
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in lowp vec2 uv;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in lowp vec4 fragmentColor;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in lowp float fragmentLight;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in lowp vec3 lightPoint;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in lowp vec3 normal;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: in lowp vec3 position;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: out lowp vec4 outColor;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: uniform sampler2D sTexture;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: uniform lowp int Mode;
05-11 17:08:26.031  9082  9197 E [ALVR Native]: void main()
05-11 17:08:26.031  9082  9197 E [ALVR Native]: {
05-11 17:08:26.031  9082  9197 E [ALVR Native]:     if(Mode == 0){                                      // ground
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         lowp vec3 groundCenter = vec3(1.0, 1.0, 1.0);
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         lowp vec3 groundHorizon = vec3(1.0, 1.0, 1.0);
05-11 17:08:26.031  9082  9197 E [ALVR Native]:
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         lowp float distance = length(position.xz);
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         // Pick a coordinate to visualize in a grid
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         lowp vec2 coord = position.xz / 2.0;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         // Compute anti-aliased world-space grid lines
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         lowp vec2 grid = abs(fract(coord - 0.5) - 0.5) / fwidth(coord);
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         lowp float line = min(grid.x, grid.y);
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         outColor.rgb = vec3(min(line, 1.0) * (1.0 - exp(-distance / 5.0 - 0.01) / 4.0)) * groundCenter;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         if(distance > 3.0){
05-11 17:08:26.031  9082  9197 E [ALVR Native]:             lowp float coef = 1.0 - 3.0 / distance;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:             outColor.rgb = (1.0 - coef) * outColor.rgb + coef * groundHorizon;
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         }
05-11 17:08:26.031  9082  9197 E [ALVR Native]:         outColor.a
```
on specifically
```java
05-11 17:08:23.957  9082  9197 I [ALVR Native]: glVendor : Google (Google Inc. (Google)), glRenderer : Android Emulator OpenGL ES Translator (ANGLE (Google, Vulkan 1.2.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver-5.0.0)), glVersion : OpenGL ES 3.0 (OpenGL ES 3.1.0 (ANGLE 2.1.2 git hash: 1f0534893540))

05-11 17:08:23.957  9082  9197 I [ALVR Native]: glExts : GL_EXT_debug_marker GL_EXT_robustness GL_OES_EGL_sync GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_depth24 GL_OES_depth32 GL_OES_element_index_uint GL_OES_texture_float GL_OES_texture_float_linear GL_OES_compressed_paletted_texture GL_OES_compressed_ETC1_RGB8_texture GL_OES_depth_texture GL_OES_texture_half_float GL_OES_texture_half_float_linear GL_OES_packed_depth_stencil GL_OES_vertex_half_float GL_OES_standard_derivatives GL_OES_texture_npot GL_OES_rgb8_rgba8 GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_EXT_texture_format_BGRA8888 GL_APPLE_texture_format_BGRA8888 ANDROID_EMU_CHECKSUM_HELPER_v1 ANDROID_EMU_native_sync_v2 ANDROID_EMU_dma_v1 ANDROID_EMU_direct_mem ANDROID_EMU_vulkan ANDROID_EMU_deferred_vulkan_commands ANDROID_EMU_vulkan_null_optional_strings ANDROID_EMU_vulkan_create_resources_with_requirements ANDROID_EMU_YUV_Cache ANDROID_EMU_vulkan_ignored_handles ANDROID_EMU_has_shared_slots_host_memory_allocator ANDROID_EMU_vulkan_free_memory_sync ANDROID_EMU_vulkan_shader_

```
related to lines,
https://github.com/alvr-org/ALVR/blob/0ca1fbc48d977f1df3adaac1c34978fc4184c699/alvr/client_core/cpp/graphics.cpp#L461-L478

<br/>

- Really seems like an chromium/ANGLE bug, lazy to report it. (https://chromium.googlesource.com/angle/angle/+/refs/heads/main/src/libANGLE/Program.cpp#3156)
- now only binds vertixAttributes in shader when they are actually being used
- Added LOGD (which should be auto removed when building in release mode)
- Properly implemented opengl error handling