### PR TITLE
Remove sockets2 patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
- "socket2 0.5.2",
+ "socket2 0.5.3",
  "tokio",
  "tokio-util",
 ]
@@ -4056,8 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.2"
-source = "git+https://github.com/rust-lang/socket2.git#488441a418d7fb591357c5dfc20d0bf8cbcdfb25"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,3 @@ alvr_sockets = { path = "alvr/sockets" }
 [profile.distribution]
 inherits = "release"
 lto = true
-
-[patch.crates-io]
-socket2 = { git = 'https://github.com/rust-lang/socket2.git' } # TODO: Remove patch once a new version is released (maybe in 1-2months)


### PR DESCRIPTION
- very quick upstream release: https://github.com/rust-lang/socket2/pull/434 (https://github.com/alvr-org/ALVR/pull/1586)
- seems like there are no CI checks for build-client-lib, tested locally