### PR TITLE
revert removal of pico rendering_thread workaround

### DIFF
--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -915,7 +915,14 @@ fn xr_runtime_now(xr_instance: &xr::Instance, platform: Platform) -> Option<Dura
 fn android_main(app: android_activity::AndroidApp) {
     use android_activity::{InputStatus, MainEvent, PollEvent};
 
-    let rendering_thread = thread::spawn(entry_point);
+    let rendering_thread = thread::spawn(|| {
+        // workaround for the Pico runtime
+        let context = ndk_context::android_context();
+        let vm = unsafe { jni::JavaVM::from_raw(context.vm().cast()) }.unwrap();
+        let _env = vm.attach_current_thread().unwrap();
+
+        entry_point();
+    });
 
     let mut should_quit = false;
     while !should_quit {


### PR DESCRIPTION
Pico 4 standard edition still needs this. hangs indefinitely otherwise.