### PR TITLE
update pico sdk to 2.2.0

### DIFF
--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -251,7 +251,7 @@ fn get_android_openxr_loaders() {
     // Pico
     command::download_and_extract_zip(
         &sh,
-        "https://sdk.picovr.com/developer-platform/sdk/Pico_OpenXR_SDK_v210.zip",
+        "https://sdk.picovr.com/developer-platform/sdk/PICO_OpenXR_SDK_220.zip",
         &temp_dir,
     )
     .unwrap();


### PR DESCRIPTION
Allegedly includes bug fixes and optimizations. said improvements were not apparent to me while testing, but everything seems to work fine nonetheless.

This new SDK requires headset OS version 5.4.0, which has been out since early February.