### PR TITLE
Linux: Distrobox ALVR packaging implementation

### DIFF
--- a/packaging/distrobox/.gitignore
+++ b/packaging/distrobox/.gitignore
@@ -1,0 +1,2 @@
+installation/*
+*.log

--- a/packaging/distrobox/LICENSE
+++ b/packaging/distrobox/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Meister1593
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packaging/distrobox/audio-setup.sh
+++ b/packaging/distrobox/audio-setup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+function get_alvr_playback_sink_id() {
+  local last_node_name=''
+  local last_node_id=''
+  pactl list sink-inputs | while read -r line; do
+    node_id=$(echo "$line" | grep -oP 'Sink Input #\K.+' | sed -e 's/^[ \t]*//')
+    node_name=$(echo "$line" | grep -oP 'node.name = "\K[^"]+' | sed -e 's/^[ \t]*//')
+    if [[ "$node_id" != '' ]] && [[ "$last_node_id" != "$node_id" ]]; then
+      last_node_id="$node_id"
+    fi
+    if [[ -n "$node_name" ]] && [[ "$last_node_name" != "$node_name" ]]; then
+      last_node_name="$node_name"
+      if [[ "$last_node_name" == "alsa_playback.vrserver" ]]; then
+        echo "$last_node_id"
+        return
+      fi
+    fi
+  done
+}
+
+function get_alvr_sink_id() {
+  pactl list short sinks | grep ALVR-MIC-Sink | cut -d$'\t' -f1
+}
+
+function setup_mic() {
+  echo "Creating microphone sink & source and linking alvr playback to it"
+  local sink_mic_id
+  # This sink is required so that it persistently auto-connects to alvr playback later
+  sink_mic_id=$(pactl load-module module-null-sink sink_name=ALVR-MIC-Sink media.class=Audio/Sink)
+  local source_mic_id
+  # This source is required so that any app can use it as microphone
+  source_mic_id=$(pactl load-module module-null-sink sink_name=ALVR-MIC-Source media.class=Audio/Source/Virtual)
+  # We link them together
+  pw-link ALVR-MIC-Sink ALVR-MIC-Source
+  # And we assign playback of pipewire alsa playback to created alvr sink
+  pactl move-sink-input "$(get_alvr_playback_sink_id)" "$(get_alvr_sink_id)"
+  echo "$sink_mic_id|$source_mic_id" | tee "/tmp/alvr-mic-ids"
+}
+
+function unload_mic() {
+  echo "Unloading microphone sink & source"
+  local sink_mic_id
+  sink_mic_id="$(cut -d '|' -f1 /tmp/alvr-mic-ids)"
+  local source_mic_id
+  source_mic_id="$(cut -d '|' -f2 /tmp/alvr-mic-ids)"
+  pactl unload-module "$sink_mic_id"
+  pactl unload-module "$source_mic_id"
+}
+
+case $ACTION in
+	connect)
+		pactl set-sink-mute @DEFAULT_SINK@ 1
+		sleep 1
+		setup_mic
+		;;
+        disconnect)
+                pactl set-sink-mute @DEFAULT_SINK@ 0
+		unload_mic;;
+esac

--- a/packaging/distrobox/helper-functions.sh
+++ b/packaging/distrobox/helper-functions.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+function echog() {
+   echo -e "${RED}${STEP_INDEX}${NC} : ${GREEN}$1${NC}"
+   sleep 0.5
+}
+function echor() {
+   echo -e "${RED}${STEP_INDEX}${NC} : ${RED}$1${NC}"
+   sleep 0.5
+}
+function cleanup_alvr() {
+   echog "Cleaning up ALVR"
+   for vrp in vrdashboard vrcompositor vrserver vrmonitor vrwebhelper vrstartup alvr_dashboard SlimeVR-amd64* slimevr openvr-spacecalibrator; do
+      pkill -f $vrp
+   done
+   sleep 3
+   for vrp in vrdashboard vrcompositor vrserver vrmonitor vrwebhelper vrstartup alvr_dashboard SlimeVR-amd64* slimevr openvr-spacecalibrator; do
+      pkill -f -9 $vrp
+   done
+}
+
+function init_prefixed_installation() {
+   positional=()
+   if [[ "$#" -eq 0 ]]; then
+      echog "Using default installation with default name"
+      return
+   fi
+   before_prefix="$prefix"
+   before_container_name="$container_name"
+   while [[ "$#" -gt 0 ]]; do
+      case $1 in
+      -p | --prefix)
+         prefix="$(realpath "$2")"
+         shift
+         ;;
+      -c | --container-name)
+         container_name="$2"
+         shift
+         ;;
+      -*)
+         echor "Unknown parameter passed: $1"
+         exit 1
+         ;;
+      *)
+         positional+=("$1")
+         shift
+         ;;
+      esac
+      shift
+   done
+   if [[ "$before_prefix" == "$prefix" ]] || [[ "$before_container_name" == "$container_name" ]]; then
+      echor "You must choose both prefix and container name to use prefixed installation"
+      exit 1
+   fi
+   export prefix
+   export container_name
+}

--- a/packaging/distrobox/links.sh
+++ b/packaging/distrobox/links.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+ALVR_LINK='https://github.com/alvr-org/ALVR-nightly/releases/download/v20.0.0-dev13%2Bnightly.2023.05.21/ALVR-x86_64.AppImage' # todo: update after release
+ALVR_FILENAME='ALVR-x86_64.AppImage'
+ALVR_APK_LINK='https://github.com/alvr-org/ALVR-nightly/releases/download/v20.0.0-dev13%2Bnightly.2023.05.21/alvr_client_android.apk' # todo: update after release
+ALVR_APK_NAME='alvr_client_android.apk'
+WLXOVERLAY_LINK='https://github.com/galister/WlxOverlay/releases/download/v1.3.0/WlxOverlay-v1.3.0-x86_64.AppImage'
+WLXOVERLAY_FILENAME='WlxOverlay.AppImage'

--- a/packaging/distrobox/patch_bindings_spam.sh
+++ b/packaging/distrobox/patch_bindings_spam.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+echo "Latest known working version for patching: 1.25.7"
+
+if [[ -z "$1" ]]; then
+	echo 'Enter path to SteamVR (for example, ~/.local/share/Steam/steamapps/common/SteamVR'
+	read STEAMVR_PATH
+else
+	STEAMVR_PATH="$1"
+fi
+PATH_TO_PATCHING_FILE="$STEAMVR_PATH/resources/webinterface/dashboard/vrwebui_shared.js"
+
+if [[ ! -f "$PATH_TO_PATCHING_FILE" ]]; then
+	echo "Couldn't find required file for patch, aborting"
+	exit 1
+fi
+
+echo 'In case of failed patching, please re-validate SteamVR files to make sure they stay unchanged'
+
+echo Deleting SteamVR html cache
+rm -r ~/.cache/SteamVR
+
+CHANGED_OUT=$(sed -i 's/m=n(9670),g=n(3947);/m=n(9670),g=n(3947),refresh_counter=0,refresh_counter_max=25;/g w /dev/stdout' "$PATH_TO_PATCHING_FILE")
+if [[ -z "$CHANGED_OUT" ]]; then
+	echo "Couldn't patch, exiting"
+	exit 1
+fi
+CHANGED_OUT=$(sed -i 's/case"action_bindings_reloaded":this.OnActionBindingsReloaded(n);break;/case"action_bindings_reloaded":if(refresh_counter%refresh_counter_max==0){this.OnActionBindingsReloaded(n);}refresh_counter++;break;/g w /dev/stdout' "$PATH_TO_PATCHING_FILE")
+if [[ -z "$CHANGED_OUT" ]]; then
+	echo "Couldn't patch, exiting"
+	exit 1
+fi
+CHANGED_OUT=$(sed -i 's/l=n(3868),c=n(6321);/l=n(3868),c=n(6321),refresh_counter_v2=0,refresh_counter_max_v2=25;/g w /dev/stdout' "$PATH_TO_PATCHING_FILE")
+if [[ -z "$CHANGED_OUT" ]]; then
+	echo "Couldn't patch, exiting"
+	exit 1
+fi
+CHANGED_OUT=$(sed -i 's/OnActionBindingsReloaded(){this.GetInputState()}/OnActionBindingsReloaded(){if(refresh_counter_v2%refresh_counter_max_v2==0){this.GetInputState();}refresh_counter_v2++;}/g w /dev/stdout' "$PATH_TO_PATCHING_FILE")
+if [[ -z "$CHANGED_OUT" ]]; then
+	echo "Couldn't patch, exiting"
+	exit 1
+fi
+echo Successfully patched file. Please restart SteamVR if it was running

--- a/packaging/distrobox/setup-dev-env.sh
+++ b/packaging/distrobox/setup-dev-env.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source ./helper-functions.sh
+
+# Required on xorg setups
+if [[ -z "$WAYLAND_DISPLAY" ]]; then
+    xhost "+si:localuser:$USER"
+    if [ $? -ne 0 ]; then
+        echor "Couldn't use xhost, please install it and re-run installation"
+        exit 1
+    fi
+fi
+
+prefix="$(realpath "$1")"
+export prefix
+
+if which podman && which distrobox; then
+    echog "Using system podman and distrobox"
+    return
+fi
+
+export CONTAINERS_CONF="$prefix/.config/containers/containers.conf"
+export CONTAINERS_REGISTRIES_CONF="$prefix/.config/containers/registries.conf"
+export CONTAINERS_STORAGE_CONF="$prefix/.config/containers/storage.conf"
+export PATH="$prefix/podman/bin:$prefix/distrobox/bin:$PATH"

--- a/packaging/distrobox/setup-env.sh
+++ b/packaging/distrobox/setup-env.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source ./helper-functions.sh
+
+# Required on xorg setups
+if [[ -z "$WAYLAND_DISPLAY" ]]; then
+    xhost "+si:localuser:$USER"
+    if [ $? -ne 0 ]; then
+        echor "Couldn't use xhost, please install it and re-run installation"
+        exit 1
+    fi
+fi
+
+prefix="installation"
+
+if [[ -n "$(which podman)" ]] && [[ -n "$(which distrobox)" ]]; then
+    echog "Using system podman and distrobox"
+    return
+fi
+
+init_prefixed_installation "$@"
+
+export CONTAINERS_CONF="$prefix/.config/containers/containers.conf"
+export CONTAINERS_REGISTRIES_CONF="$prefix/.config/containers/registries.conf"
+export CONTAINERS_STORAGE_CONF="$prefix/.config/containers/storage.conf"
+export PATH="$prefix/podman/bin:$prefix/distrobox/bin:$PATH"

--- a/packaging/distrobox/setup-env.sh
+++ b/packaging/distrobox/setup-env.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd $(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 
 source ./helper-functions.sh
 

--- a/packaging/distrobox/setup-phase-3.sh
+++ b/packaging/distrobox/setup-phase-3.sh
@@ -18,7 +18,7 @@ echo "[multilib]" | sudo tee -a /etc/pacman.conf
 echo "Include = /etc/pacman.d/mirrorlist" | sudo tee -a /etc/pacman.conf
 echog "Setting up locales"
 echo "en_US.UTF-8 UTF-8" | sudo tee -a /etc/locale.gen
-sudo pacman -q --noprogressbar -Syu glibc lib32-glibc --noconfirm
+sudo pacman -q --noprogressbar -Syu glibc lib32-glibc xdg-utils --noconfirm
 echo "LANG=en_US.UTF-8" | sudo tee /etc/locale.conf
 echo "LC_ALL=en_US.UTF-8" | sudo tee /etc/locale.conf
 echo "export LANG=en_US.UTF-8 #alvr-distrobox" | tee -a ~/.bashrc

--- a/packaging/distrobox/setup-phase-3.sh
+++ b/packaging/distrobox/setup-phase-3.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+source ./links.sh
+source ./helper-functions.sh
+
+if [[ -z "$prefix" ]]; then
+   echor "No prefix found inside distrobox, aborting"
+   exit 1
+fi
+
+echor "Phase 3"
+
+cd "$prefix" || echor "Couldn't go into installation folder, aborting."
+
+# Setting up arch
+echog "Setting up repositories"
+echo "[multilib]" | sudo tee -a /etc/pacman.conf
+echo "Include = /etc/pacman.d/mirrorlist" | sudo tee -a /etc/pacman.conf
+echog "Setting up locales"
+echo "en_US.UTF-8 UTF-8" | sudo tee -a /etc/locale.gen
+sudo pacman -q --noprogressbar -Syu glibc lib32-glibc --noconfirm
+echo "LANG=en_US.UTF-8" | sudo tee /etc/locale.conf
+echo "LC_ALL=en_US.UTF-8" | sudo tee /etc/locale.conf
+echo "export LANG=en_US.UTF-8 #alvr-distrobox" | tee -a ~/.bashrc
+echo "export LC_ALL=en_US.UTF-8 #alvr-distrobox" | tee -a ~/.bashrc
+
+cd ..
+
+exit 0

--- a/packaging/distrobox/setup-phase-4.sh
+++ b/packaging/distrobox/setup-phase-4.sh
@@ -60,7 +60,7 @@ sleep 2
 
 # installing alvr
 echog "Installing alvr"
-echog "This installation script assumes that you will register alvr as a driver further, so it needs to extract appimage."
+echog "This installation script will download apk client for the headset later, but you shouldn't connect it to alvr during this script installation, leave it to post install."
 wget -q --show-progress "$ALVR_LINK"
 chmod +x "$ALVR_FILENAME"
 ./"$ALVR_FILENAME" --appimage-extract &>/dev/null
@@ -131,4 +131,4 @@ echog "To close vr, press ctrl+c in terminal where start-alvr.sh script is runni
 echor "Very important: to prevent game from looking like it's severily lagging, please turn on legacy reprojection in per-app video settings in steamvr. This improves experience drastically."
 echog "Don't forget to enable Steam Play for all supported titles with latest (non-experimental) proton to make all games visible as playable in Steam."
 echog "Tip: to prevent double-restart due to how client resets it's settings, you can change settings and then put headset to sleep, and power back. This restarts client and server, and prevents double restart."
-echog "Thank you for using the script! Continue with Post-installation notes to configure ALVR and SteamVR"
+echog "Thank you for using the script! Continue with installing alvr apk to headset and with Post-installation notes to configure ALVR and SteamVR"

--- a/packaging/distrobox/setup-phase-4.sh
+++ b/packaging/distrobox/setup-phase-4.sh
@@ -46,10 +46,14 @@ sleep 2
 # Ask user for installing steamvr
 echog "Installed base packages and Steam. Opening steam. Please install SteamVR from it."
 steam &>/dev/null &
+echog "Enabling ctrl+c prevention."
+trap 'echog Oops you have pressed ctrl+c which almost stopped this setup, dont worry, i prevented it from doing that in this moment' 2
 echog "After installing SteamVR, copy (ctrl + shift + c from terminal) and launch command bellow from your host terminal shell (outside this container) and press enter to continue there. This prevents annoying popup (yes/no with asking for superuser) that prevents steamvr from launching automatically."
 echog "sudo setcap CAP_SYS_NICE+ep '$HOME/.steam/steam/steamapps/common/SteamVR/bin/linux64/vrcompositor-launcher'"
 echog "After you execute that command on host, press enter to continue."
 read
+echog "Disabling ctrl+c prevention, be careful."
+trap 2
 echog "Now launch SteamVR once and close it."
 echog "At this point you can safely add your external library from the host system ('/home/$USER' is same from inside the script container as from outside)"
 echog "When ready for next step, press enter to continue."

--- a/packaging/distrobox/setup-phase-4.sh
+++ b/packaging/distrobox/setup-phase-4.sh
@@ -48,7 +48,9 @@ echog "Installed base packages and Steam. Opening steam. Please install SteamVR 
 steam &>/dev/null &
 echog "Enabling ctrl+c prevention."
 trap 'echog Oops you have pressed ctrl+c which almost stopped this setup, dont worry, i prevented it from doing that in this moment' 2
-echog "After installing SteamVR, copy (ctrl + shift + c from terminal) and launch command bellow from your host terminal shell (outside this container) and press enter to continue there. This prevents annoying popup (yes/no with asking for superuser) that prevents steamvr from launching automatically."
+echog "Install SteamVR from Steam and press enter here"
+read
+echog "Copy (ctrl + shift + c from terminal) and launch command bellow from your host terminal shell (outside this shell, container) and press enter to continue there. This prevents annoying popup (yes/no with asking for superuser) that prevents steamvr from launching automatically."
 echog "sudo setcap CAP_SYS_NICE+ep '$HOME/.steam/steam/steamapps/common/SteamVR/bin/linux64/vrcompositor-launcher'"
 echog "After you execute that command on host, press enter to continue."
 read

--- a/packaging/distrobox/setup-phase-4.sh
+++ b/packaging/distrobox/setup-phase-4.sh
@@ -20,7 +20,7 @@ fi
 AUDIO_SYSTEM="$(head <specs.conf -2 | tail -1)"
 
 echog "Installing packages for base functionality."
-sudo pacman -q --noprogressbar -Syu git vim base-devel noto-fonts xdg-user-dirs fuse libx264 sdl2 libva-utils --noconfirm || exit 1
+sudo pacman -q --noprogressbar -Syu git vim base-devel noto-fonts xdg-user-dirs fuse libx264 sdl2 libva-utils xorg-server --noconfirm || exit 1
 echog "Installing steam, audio and driver packages."
 if [[ "$GPU" == "amd" ]]; then
    sudo pacman -q --noprogressbar -Syu libva-mesa-driver vulkan-radeon lib32-vulkan-radeon lib32-libva-mesa-driver --noconfirm || exit 1

--- a/packaging/distrobox/setup-phase-4.sh
+++ b/packaging/distrobox/setup-phase-4.sh
@@ -93,7 +93,7 @@ echog "SteamVR overlay is partially broken on Linux (it also doesn't open games,
 wget -q --show-progress -O "$WLXOVERLAY_FILENAME" "$WLXOVERLAY_LINK"
 chmod +x "$WLXOVERLAY_FILENAME"
 if [[ "$WAYLAND_DISPLAY" != "" ]]; then
-   echog "If you're not (on wlroots-based compositor like Sway), it will ask for display to choose. Choose displays if you have more than 1."
+   echog "If you're not (on wlroots-based compositor like Sway), it will ask for display to choose. Choose the one display that contains every other (usually first in list)."
 fi
 ./"$WLXOVERLAY_FILENAME" &>/dev/null &
 if [[ "$WAYLAND_DISPLAY" != "" ]]; then

--- a/packaging/distrobox/setup-phase-4.sh
+++ b/packaging/distrobox/setup-phase-4.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+source ./links.sh
+source ./helper-functions.sh
+
+if [[ -z "$prefix" ]]; then
+   echor "No prefix found inside distrobox, aborting"
+   exit 1
+fi
+
+echor "Phase 4"
+export STEP_INDEX=1
+cd "$prefix" || echor "Couldn't go into installation folder, aborting."
+
+# Get current gpu (and version in case if it's nvidia from configuration)
+GPU="$(head <specs.conf -1 | tail -2)"
+if [[ "$GPU" == nvidia* ]]; then
+   GPU=$(echo "$GPU" | cut -d' ' -f1)
+fi
+AUDIO_SYSTEM="$(head <specs.conf -2 | tail -1)"
+
+echog "Installing packages for base functionality."
+sudo pacman -q --noprogressbar -Syu git vim base-devel noto-fonts xdg-user-dirs fuse libx264 sdl2 libva-utils --noconfirm || exit 1
+echog "Installing steam, audio and driver packages."
+if [[ "$GPU" == "amd" ]]; then
+   sudo pacman -q --noprogressbar -Syu libva-mesa-driver vulkan-radeon lib32-vulkan-radeon lib32-libva-mesa-driver --noconfirm || exit 1
+elif [[ "$GPU" == "nvidia" ]]; then
+   echog "Using host system driver mounts, not installing anything inside for nvidia drivers."
+else
+   echor "Couldn't determine gpu with name: $GPU, exiting!"
+   exit 1
+fi
+if [[ "$AUDIO_SYSTEM" == "pipewire" ]]; then
+   sudo pacman -q --noprogressbar -Syu lib32-pipewire pipewire pipewire-pulse pipewire-alsa pipewire-jack wireplumber --noconfirm || exit 1
+elif [[ "$AUDIO_SYSTEM" == "pulseaudio" ]]; then
+   sudo pacman -q --noprogressbar -Syu pulseaudio pusleaudio-alsa --noconfirm || exit 1
+else
+   echor "Couldn't determine audio system: $AUDIO_SYSTEM, you may have issues with audio!"
+fi
+
+sudo pacman -q --noprogressbar -Syu steam --noconfirm
+
+export STEP_INDEX=2
+sleep 2
+
+# Ask user for installing steamvr
+echog "Installed base packages and Steam. Opening steam. Please install SteamVR from it."
+steam &>/dev/null &
+echog "After installing SteamVR, copy (ctrl + shift + c from terminal) and launch command bellow from your host terminal shell (outside this container) and press enter to continue there. This prevents annoying popup (yes/no with asking for superuser) that prevents steamvr from launching automatically."
+echog "sudo setcap CAP_SYS_NICE+ep '$HOME/.steam/steam/steamapps/common/SteamVR/bin/linux64/vrcompositor-launcher'"
+echog "After you execute that command on host, press enter to continue."
+read
+echog "Now launch SteamVR once and close it."
+echog "At this point you can safely add your external library from the host system ('/home/$USER' is same from inside the script container as from outside)"
+echog "When ready for next step, press enter to continue."
+read
+
+export STEP_INDEX=3
+sleep 2
+
+# installing alvr
+echog "Installing alvr"
+echog "This installation script assumes that you will register alvr as a driver further, so it needs to extract appimage."
+wget -q --show-progress "$ALVR_LINK"
+chmod +x "$ALVR_FILENAME"
+./"$ALVR_FILENAME" --appimage-extract &>/dev/null
+mv squashfs-root alvr
+./alvr/usr/bin/alvr_dashboard &>/dev/null &
+echog "ALVR and dashboard now launch and when it does that, skip setup (X button on right up corner)."
+echog "After that, launch SteamVR using button on left lower corner and after starting steamvr, you should see one headset showing up in steamvr menu and 'Streamer: Connected' in ALVR dashboard."
+echog "In ALVR Dashboard settings at left side, in the beginning set 'Game Audio' and 'Game Microphone' to pipewire (if possible)."
+echog "Scroll all the way down and find 'Driver launch action', set it to 'No action' to prevent alvr from unregistering itself after startup."
+echog "Find 'On connect script' and 'On disconnect script' as well and put $(realpath "$PWD"/../audio-setup.sh) (confirm each of them with enter on text box) into both of them. This is for automatic microphone that will load/unload based on connection to the headset"
+echog "Next time you connect headset, set 'ALVR-MIC-Source' as your default microphone, it will automatically switch to it whenever it shows up."
+echog "Tick 'Open setup wizard' too to prevent popup on dashboard startup."
+echog "After you have done with this, press enter here."
+read
+cleanup_alvr
+./alvr/usr/bin/alvr_dashboard &>/dev/null &
+echor "Go to 'Installation' tab at left and press 'Register ALVR driver'"
+echog "After that, press press 'Launch SteamVR' at left corner and hit enter here to continue."
+read
+echog "Downloading ALVR apk, you can install it now from the installation folder into your headset using either ADB or Sidequest on host."
+wget -q --show-progress "$ALVR_APK_LINK"
+echog "From this point on, alvr will automatically start with SteamVR. But it's still quite broken mechanism so we need to use additional script for auto-restart to work."
+echog "Don't close ALVR."
+
+STEP_INDEX=4
+sleep 2
+
+# installing wlxoverlay
+echog "SteamVR overlay is partially broken on Linux (it also doesn't open games, only allows to interact with already opened games) and for replacement we will use WlxOverlay, which works with both X11 and Wayland and has ability to control whole desktop from inside VR."
+wget -q --show-progress -O "$WLXOVERLAY_FILENAME" "$WLXOVERLAY_LINK"
+chmod +x "$WLXOVERLAY_FILENAME"
+if [[ "$WAYLAND_DISPLAY" != "" ]]; then
+   echog "If you're not (on wlroots-based compositor like Sway), it will ask for display to choose. Choose displays if you have more than 1."
+fi
+./"$WLXOVERLAY_FILENAME" &>/dev/null &
+if [[ "$WAYLAND_DISPLAY" != "" ]]; then
+   echog "If everything went well, you might see little icon on your desktop that indicates that screenshare is happening (by WlxOverlay) created by xdg portal."
+fi
+echog "WlxOverlay adds itself to auto-startup so you don't need to do anything with it to make it autostart."
+echog "Press enter to continue."
+read
+
+STEP_INDEX=5
+sleep 2
+
+# patching steamvr
+echog "To prevent issues with SteamVR spamming with messages into it's own web interface, i created patcher that can prevent this spam. Without this, you will have issues with opening Video Setttings per app, bindings, etc."
+echog "If you're okay with patching (and have compatible SteamVR version), you can type y and press enter to patch SteamVR. Otherwise just press enter to skip"
+read -r DO_PATCH
+if [[ "$DO_PATCH" == "y" ]]; then
+   ../patch_bindings_spam.sh "$HOME/.steam/steam/steamapps/common/SteamVR"
+fi
+
+cleanup_alvr
+cd ..
+
+STEP_INDEX=6
+sleep 2
+
+# Added color to pacman for user convenience later
+echo "Color" | sudo tee -a /etc/pacman.conf
+
+# post messages
+echog "From that point on, ALVR should be installed and WlxOverlay should be working. Please refer to https://github.com/galister/WlxOverlay/wiki/Getting-Started to familiarise with controls."
+echor "To start alvr now you need to use start-alvr.sh script from this repository. It will also open Steam for you."
+echog "In case you want to enter into container, do 'source setup-env.sh && distrobox-enter arch-alvr'"
+echog "To close vr, press ctrl+c in terminal where start-alvr.sh script is running. It will automatically close alvr and steamvr."
+echor "Very important: to prevent game from looking like it's severily lagging, please turn on legacy reprojection in per-app video settings in steamvr. This improves experience drastically."
+echog "Don't forget to enable Steam Play for all supported titles with latest (non-experimental) proton to make all games visible as playable in Steam."
+echog "Tip: to prevent double-restart due to how client resets it's settings, you can change settings and then put headset to sleep, and power back. This restarts client and server, and prevents double restart."
+echog "Thank you for using the script! Continue with Post-installation notes to configure ALVR and SteamVR"

--- a/packaging/distrobox/setup-phase-4.sh
+++ b/packaging/distrobox/setup-phase-4.sh
@@ -73,7 +73,7 @@ echog "Scroll all the way down and find 'Driver launch action', set it to 'No ac
 echog "Find 'On connect script' and 'On disconnect script' as well and put $(realpath "$PWD"/../audio-setup.sh) (confirm each of them with enter on text box) into both of them. This is for automatic microphone that will load/unload based on connection to the headset"
 echog "Next time you connect headset, set 'ALVR-MIC-Source' as your default microphone, it will automatically switch to it whenever it shows up."
 echog "Tick 'Open setup wizard' too to prevent popup on dashboard startup."
-echog "After you have done with this, press enter here."
+echor "After you have done with this, press enter here, and don't close alvr dashboard manually."
 read
 cleanup_alvr
 ./alvr/usr/bin/alvr_dashboard &>/dev/null &

--- a/packaging/distrobox/setup-process.sh
+++ b/packaging/distrobox/setup-process.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+source ./helper-functions.sh
+
+prefix="installation"
+container_name="arch-alvr"
+system_podman_install=1
+system_distrobox_install=1
+
+function detect_gpu() {
+   local gpu
+   gpu=$(lspci | grep -i vga | tr '[:upper:]' '[:lower:]')
+   if [[ $gpu == *"amd"* ]]; then
+      echo 'amd'
+      return
+   elif [[ $gpu == *"nvidia"* ]]; then
+      echo 'nvidia'
+      return
+   else
+      echo 'intel'
+      return
+   fi
+}
+
+function detect_audio() {
+   if [[ -n "$(pgrep pipewire)" ]]; then
+      echo 'pipewire'
+   elif [[ -n "$(pgrep pulseaudio)" ]]; then
+      echo 'pulse'
+   else
+      echo 'none'
+   fi
+}
+
+function phase1_distrobox_podman_install() {
+   echor "Phase 1"
+   mkdir "$prefix"
+   cd "$prefix" || exit
+
+   if ! which podman; then
+      system_podman_install=0
+      echog "Installing rootless podman"
+      mkdir podman
+      curl -s https://raw.githubusercontent.com/Meister1593/distrobox/main/extras/install-podman | sh -s -- --prefix "$PWD" --prefix-name "$container_name" # TODO temporary linked to own repository until MR passes
+   fi
+
+   if ! which distrobox; then
+      system_distrobox_install=0
+      echog "Installing distrobox"
+      # Installing distrobox from git because it is much newer
+      mkdir distrobox
+      git clone https://github.com/89luca89/distrobox.git distrobox-git
+
+      cd distrobox-git || exit
+      ./install --prefix ../distrobox
+      cd ..
+
+      rm -rf distrobox-git
+   fi
+   cd ..
+}
+
+function phase2_distrobox_container_creation() {
+   echor "Phase 2"
+   GPU=$(detect_gpu)
+   AUDIO_SYSTEM=$(detect_audio)
+
+   source ./setup-dev-env.sh "$prefix"
+
+   if [[ "$system_podman_install" == 0 ]]; then
+      if [[ "$(which podman)" != "$prefix/podman/bin/podman" ]]; then
+         echor "Failed to install podman properly"
+         exit 1
+      fi
+   fi
+   if [[ "$system_distrobox_install" == 0 ]]; then
+      if [[ "$(which distrobox)" != "$prefix/distrobox/bin/distrobox" ]]; then
+         echor "Failed to install distrobox properly"
+         exit 1
+      fi
+   else
+      if [[ "$GPU" == "nvidia" ]]; then
+         echog "This script requires latest git version of distrobox, which has ability to integrate with host using --nvidia flag."
+         echog "If you have that version, then write y and press enter to continue."
+         read -r HAS_NVIDIA_FLAG
+         if [[ "$HAS_NVIDIA_FLAG" != "y" ]]; then
+            echor "Aborting installation as per user request."
+            echor "Please visit https://github.com/89luca89/distrobox/blob/main/docs/posts/install_rootless.md for installing rootless podman and make sure to run it from git repository instead from curl."
+            exit 1
+         fi
+      fi
+   fi
+
+   echo "$GPU" | tee -a "$prefix/specs.conf"
+   if [[ "$GPU" == "amd" ]]; then
+      distrobox create --pull --image docker.io/library/archlinux:latest \
+         --name "$container_name" \
+         --home "$prefix/$container_name"
+      if [ $? -ne 0 ]; then
+         echor "Couldn't create distrobox container, please report it to maintainer."
+         echor "GPU: $GPU; AUDIO SYSTEM: $AUDIO_SYSTEM"
+         exit 1
+      fi
+   elif [[ "$GPU" == nvidia* ]]; then
+      CUDA_LIBS="$(find /usr/lib* -iname "libcuda*.so*")"
+      if [[ -z "$CUDA_LIBS" ]]; then
+         echor "Couldn't find CUDA on host, please install it as it's required for NVENC encoder support."
+         exit 1
+      fi
+      distrobox create --pull --image docker.io/library/archlinux:latest \
+         --name "$container_name" \
+         --nvidia \
+         --home "$prefix/$container_name"
+      if [ $? -ne 0 ]; then
+         echor "Couldn't create distrobox container, please report it to maintainer."
+         echor "GPU: $GPU; AUDIO SYSTEM: $AUDIO_SYSTEM"
+         exit 1
+      fi
+   else
+      echor "Intel is not supported yet."
+      exit 1
+   fi
+
+   if [[ "$AUDIO_SYSTEM" == "pipewire" ]]; then
+      echo "$AUDIO_SYSTEM" | tee -a "$prefix/specs.conf"
+   elif [[ "$AUDIO_SYSTEM" == "pulse" ]]; then
+      echo "$AUDIO_SYSTEM" | tee -a "$prefix/specs.conf"
+      echor "Do note that pulseaudio doesn't work well with ALVR and automatic microphone routing won't work."
+   else
+      echor "Unsupported audio system ($AUDIO_SYSTEM). Please report this issue."
+      exit 1
+   fi
+
+   distrobox enter --name "$container_name" --additional-flags "--env prefix='$prefix' --env container_name='$container_name'" -- ./setup-phase-3.sh
+   if [ $? -ne 0 ]; then
+      echor "Couldn't install distrobox container first time at phase 3, please report it as an issue with attached setup.log from the directory."
+      # envs are required! otherwise first time install won't have those env vars, despite them being even in bashrc, locale conf, profiles, etc
+      exit 1
+   fi
+   distrobox stop --name "$container_name" --yes
+   distrobox enter --name "$container_name" --additional-flags "--env prefix='$prefix' --env container_name='$container_name' --env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8" -- ./setup-phase-4.sh
+   if [ $? -ne 0 ]; then
+      echor "Couldn't install distrobox container first time at phase 4, please report it as an issue with attached setup.log from the directory."
+      # envs are required! otherwise first time install won't have those env vars, despite them being even in bashrc, locale conf, profiles, etc
+      exit 1
+   fi
+}
+
+init_prefixed_installation "$@"
+if [[ "$prefix" =~ \  ]]; then
+   echor "File path to container can't contains spaces as SteamVR will fail to launch if path to it contains spaces."
+   echor "Please clone or unpack repository into another directory that doesn't contain spaces."
+   exit 1
+fi
+phase1_distrobox_podman_install
+phase2_distrobox_container_creation

--- a/packaging/distrobox/setup-process.sh
+++ b/packaging/distrobox/setup-process.sh
@@ -152,5 +152,9 @@ if [[ "$prefix" =~ \  ]]; then
    echor "Please clone or unpack repository into another directory that doesn't contain spaces."
    exit 1
 fi
+
+# Prevent host steam to be used during install, forcefully kill it
+pkill -f steam
+
 phase1_distrobox_podman_install
 phase2_distrobox_container_creation

--- a/packaging/distrobox/setup.sh
+++ b/packaging/distrobox/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd $(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 
 ./setup-process.sh "$@" 2>&1 | tee setup.log || true
 cp setup.log /tmp/alvr-setup.log

--- a/packaging/distrobox/setup.sh
+++ b/packaging/distrobox/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./setup-process.sh "$@" 2>&1 | tee setup.log || true
+cp setup.log /tmp/alvr-setup.log
+sed < /tmp/alvr-setup.log $'s/\033[[][^A-Za-z]*m//g' > setup.log

--- a/packaging/distrobox/start-alvr.sh
+++ b/packaging/distrobox/start-alvr.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+prefix="installation"
+container_name="arch-alvr"
+
+source ./helper-functions.sh
+init_prefixed_installation "$@"
+source ./setup-dev-env.sh "$prefix"
+
+echog "Starting up Steam"
+distrobox enter --name "$container_name" --additional-flags "--env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8" -- steam &>/dev/null &
+echog "Starting up ALVR"
+distrobox enter --name "$container_name" --additional-flags "--env LANG=en_US.UTF-8 --env LC_ALL=en_US.UTF-8" -- ./start-vr.sh

--- a/packaging/distrobox/start-alvr.sh
+++ b/packaging/distrobox/start-alvr.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd $(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 
 prefix="installation"
 container_name="arch-alvr"

--- a/packaging/distrobox/start-vr.sh
+++ b/packaging/distrobox/start-vr.sh
@@ -15,7 +15,7 @@ run_additional_stuff() {
   ./alvr/usr/bin/alvr_dashboard &
   # WIP:
   #./SlimeVR-amd64.appimage &
-  ./arch-alvr/oscalibrator-fork/OpenVR-SpaceCalibrator/openvr-spacecalibrator &
+  #./arch-alvr/oscalibrator-fork/OpenVR-SpaceCalibrator/openvr-spacecalibrator &
 }
 
 run_vrstartup() {

--- a/packaging/distrobox/start-vr.sh
+++ b/packaging/distrobox/start-vr.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# credits to original script go to galister#4182
+
+source ./helper-functions.sh
+
+# go to installation folder in case we aren't already there
+cd installation || echog "Already at needed folder"
+
+STEAMVR_PATH="$HOME/.local/share/Steam/steamapps/common/SteamVR"
+
+# add your tools here
+run_additional_stuff() {
+  echog Starting additional software
+  ./alvr/usr/bin/alvr_dashboard &
+  # WIP:
+  #./SlimeVR-amd64.appimage &
+  ./arch-alvr/oscalibrator-fork/OpenVR-SpaceCalibrator/openvr-spacecalibrator &
+}
+
+run_vrstartup() {
+  "$STEAMVR_PATH/bin/vrstartup.sh" >/dev/null 2>&1 &
+}
+
+if pidof vrmonitor >/dev/null; then
+  # we're started with vr already running so just start the extras
+  run_additional_stuff
+fi
+
+trap 'echo SIGINT!; cleanup_alvr; exit 0' INT
+trap 'echo SIGTERM!; cleanup_alvr; exit 0' TERM
+
+while true; do
+
+  if ! pidof vrmonitor >/dev/null; then
+    cleanup_alvr
+
+    run_vrstartup
+    sleep 12
+    run_additional_stuff
+  fi
+
+  sleep 1
+done

--- a/packaging/distrobox/uninstall.sh
+++ b/packaging/distrobox/uninstall.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source ./helper-functions.sh
+
+prefix="installation"
+container_name="arch-alvr"
+
+init_prefixed_installation "$@"
+source ./setup-dev-env.sh "$prefix"
+
+echog "If you're using something else than 'sudo', please write it as-is now, otherwise just press enter to confirm deletion of $prefix folder with $container_name container."
+read -r ROOT_PERMS_COMMAND
+if [[ -z "$ROOT_PERMS_COMMAND" ]]; then
+   ROOT_PERMS_COMMAND="sudo"
+fi
+
+podman stop "$container_name" 2>/dev/null
+
+"$ROOT_PERMS_COMMAND" rm -rf "$prefix"
+DBX_SUDO_PROGRAM="$ROOT_PERMS_COMMAND" distrobox-rm --rm-home "$container_name" 2>/dev/null
+
+echog "Uninstall completed."

--- a/packaging/distrobox/uninstall.sh
+++ b/packaging/distrobox/uninstall.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd $(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 
 source ./helper-functions.sh
 

--- a/packaging/distrobox/update-vr-apps.sh
+++ b/packaging/distrobox/update-vr-apps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+prefix="installation"
+
+source ./links.sh
+source ./helper-functions.sh
+
+init_prefixed_installation "$@"
+source ./setup-dev-env.sh "$prefix"
+
+echog "Reinstalling alvr"
+rm -r $prefix/alvr "${prefix:?}/${ALVR_FILENAME:?}" "${prefix:?}/${ALVR_APK_NAME:?}"
+wget -q --show-progress -P $prefix/ "$ALVR_LINK"
+chmod +x "$prefix/$ALVR_FILENAME"
+"$prefix"/./"$ALVR_FILENAME" --appimage-extract
+mv squashfs-root $prefix/alvr
+echog "Downloading alvr apk"
+wget -q --show-progress -P $prefix/ "$ALVR_APK_LINK"
+
+echog "Reinstalling wlxoverlay"
+rm "$prefix"/"$WLXOVERLAY_FILENAME"
+wget -O "$prefix/$WLXOVERLAY_FILENAME" -q --show-progress "$WLXOVERLAY_LINK"
+chmod +x "$prefix/$WLXOVERLAY_FILENAME"
+
+echog "Installation finished."

--- a/packaging/distrobox/update-vr-apps.sh
+++ b/packaging/distrobox/update-vr-apps.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd $(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 
 prefix="installation"
 

--- a/wiki/ALVR-in-distrobox.md
+++ b/wiki/ALVR-in-distrobox.md
@@ -28,6 +28,7 @@ For installing you only really need couple of dependencies on host:
 4. `pipewire` for fully automatic microphone, `pulseaudio` for basic audio support (automatic microphone is unsupported with it)
 5. For nvidia - `CUDA` (distrobox passes through it and driver as well into the container and CUDA contains NVENC encoder for streaming)
 6. If you don't have `newgidmap` command available, you need to install `shadow-utils`. (packages - ubuntu-like: `newuidmap`, arch-like: `shadow`)
+
 After you have installed required dependencies for your installation from above, open terminal in this repository folder and do:
 
 1. `./setup.sh`

--- a/wiki/ALVR-in-distrobox.md
+++ b/wiki/ALVR-in-distrobox.md
@@ -27,7 +27,7 @@ For installing you only really need couple of dependencies on host:
 3. `sed` (for removing color in logs)
 4. `pipewire` for fully automatic microphone, `pulseaudio` for basic audio support (automatic microphone is unsupported with it)
 5. For nvidia - `CUDA` (distrobox passes through it and driver as well into the container and CUDA contains NVENC encoder for streaming)
-6. If you don't have `newgidmap` command available, you need to install `shadow-utils`. (packages - ubuntu-like: `newuidmap`, arch-like: `shadow`)
+6. If you don't have `newgidmap` command available, you need to install `shadow-utils`. (packages ubuntu-like: `newuidmap`, arch-like: `shadow`, mint: `uidmap`)
 
 After you have installed required dependencies for your installation from above, open terminal in this repository folder and do:
 

--- a/wiki/ALVR-in-distrobox.md
+++ b/wiki/ALVR-in-distrobox.md
@@ -27,7 +27,7 @@ For installing you only really need couple of dependencies on host:
 3. `sed` (for removing color in logs)
 4. `pipewire` for fully automatic microphone, `pulseaudio` for basic audio support (automatic microphone is unsupported with it)
 5. For nvidia - `CUDA` (distrobox passes through it and driver as well into the container and CUDA contains NVENC encoder for streaming)
-
+6. If you don't have `newgidmap` command available, you need to install `shadow-utils`. (packages - ubuntu-like: `newuidmap`, arch-like: `shadow`)
 After you have installed required dependencies for your installation from above, open terminal in this repository folder and do:
 
 1. `./setup.sh`

--- a/wiki/ALVR-in-distrobox.md
+++ b/wiki/ALVR-in-distrobox.md
@@ -1,0 +1,124 @@
+## Installing ALVR and using SteamVR on Linux through Distrobox
+
+## Disclaimer
+
+1. This is just an attempt to make things easier for Linux users to use ALVR, SteamVR. By no means it's a comprehensive, fully featured and 100% working guide. Please open new issues and pull requests to correct this guide, scripts, etc etc.
+
+2. This guide is not adjusted for Intel gpu owners yet. Only NVIDIA and AMDGPU (Low priority TODO).
+
+3. Slimevr, OpenVRAS, Open Space Calibrator are all possible to launch and use on Linux, but this guide/script is not adjusted yet (Medium priority TODO).
+
+4. Firewall configuration is skipped entirely and setup firewall configuration is broken, so it might not work in case you have strict firewall (alvr docs should have info about that) (Low priority TODO).
+
+5. Don't use SteamVR Beta (1.26+) version, it contains a lot of breaking changes that are yet to be tested to work with.
+
+6. Some nvidia users might experience 307 steamvr crash - seemingly related to 530 driver, update or downgrade, should resolve the issue.
+
+7. At the moment, most of the podman portability issues were fixed, but it's not done, so if you happen to have any kind of issues while running both this and other distroboxes from your system, please report them. I created some issues at podman side ([documentation issue](https://github.com/containers/podman/issues/18375), [storage configuration issue, which prevents complete isolation from runtime containers at the moment](https://github.com/containers/storage/issues/1587)) and [created PR](https://github.com/89luca89/distrobox/pull/718) for distrobox (WIP) to upstream the changes.
+
+8. This script unlikely to work on external disks.
+
+## Installing alvr distrobox
+
+For installing you only really need couple of dependencies on host:
+
+1. `wget` + `curl` (to download podman/distrobox/alvr/etc)
+2. `xhost` (on X11 to allow rootless podman to work with graphical applications)
+3. `sed` (for removing color in logs)
+4. `pipewire` for fully automatic microphone, `pulseaudio` for basic audio support (automatic microphone is unsupported with it)
+5. For nvidia - `CUDA` (distrobox passes through it and driver as well into the container and CUDA contains NVENC encoder for streaming)
+
+After you have installed required dependencies for your installation from above, open terminal in this repository folder and do:
+
+1. `./setup.sh`
+   
+   That's it. **Follow all green and especially red text carefully from the scripts.**
+   
+   In case if have errors during installation, please report the full log as-is (remove private info if you happen to have some) as an Issue.
+   
+   But if you are just reinstalling it, please run `./uninstall.sh` first before trying to install again.
+   
+   After full installation, you can use `./start-alvr.sh` to launch alvr automatically.
+   
+   Script also downloads related apk file to install to headset into `installation` folder for you. Use Sidequest or ADB to install it.
+   
+   **Experimental:** Prefixed installation is now available, which allows you to specify where to install relative to this folder. Use --prefix and --container-name to specify folder name and container name (you should specify both for this to work)
+
+## Post-install ALVR & SteamVR Configuration
+
+After installing ALVR you may want to configure it and steamvr to run at best quality for your given hardware/gpu. Open up ALVR using `./start-alvr.sh` script and do the following (each field with input value needs enter to confirm):
+
+### Common configuration:
+
+1. **Resolution:** If you have 6600 XT level GPU you can select Low, and in case you don't mind lower FPS - Medium
+
+2. **Preferred framerate:** If you know that you will have lower fps than usual (for instance, VRChat), run at lower fps. This is because when reprojection (this is what allows for smooth view despite being at low fps) goes lower than twice the amount of specified framerate - it fails to reproject and will look worse. So for example, you can run at 72hz if you know you're expecting low framerate, and 120hz if you are going to play something like Beat Saber, which is unlikely to run at low fps.
+
+3. **Encoder preset:** Quality
+
+4. **Game Audio & Microphone:** Set to pipewire as has been said in installation. ALVR uses default audio sink for audio, and doesn't care about volume (it's controlled only onboard audio on headset), and automatic audio scripts mutes default audio by default to prevent mirroring. As for microphone, every time ALVR is connected on headset, on connect script creates audio source named **ALVR-MIC-Source**, which can be used in game as default microphone, if you set it at least once. No need to un-set it back to default. And when headset disconnects it automatically clears audio source and restores back to previous microphone.
+
+5. **Bitrate:** Adaptive, maximum bitrate: 150 mbps, minimum bitrate: 100 mbps.
+
+6. **Foveated rendering:** This highly depends on given headset, but generally default settings should be OK for Quest 2. For **pico neo 3** i would recommend setting center region width to 0.8 and height to 0.75, shifts to 0 and edge ratios can be set at 6-7, and for the same **pico neo 3** disable oculus foveation level and dynamic oculus foveation.
+
+7. **Color correction:** Set sharpening to 1and if you like oversaturated image, bump saturation to 0.6.
+
+8. For **pico neo 3** left controller offsets (from top to bottom): Position -0.06, -0.03, -0.1; Rotation: 0, 3, 17.
+
+9. **Connection -> Stream Protocol:** TCP. This ensures that there would be no heavy artifacts if packet loss happens (until it's too severe), only slowdowns.
+
+10. **Linux async reprojection:** keep it off, it's not needed anymore and client does reprojection better
+
+### AMD-specific configuration:
+
+1. Preferred codec: HEVC, h264 looked choppy and has visual "blocking".
+
+2. Reduce color banding: turn on, makes image smoother.
+
+### Nvidia-specific configuration (needs feedback):
+
+1. Preferred codec: h264
+
+After that, restart your headset using power button and it will automatically restart steamvr once, applying all changes.
+
+### SteamVR configuration:
+
+Inside SteamVR you also may need to change settings to improve experience. Open settings by clicking on triple stripe on SteamVR window and expand Advanced Settings (Hide -> Show)
+
+1. **Disable SteamVR Home.** It can be laggy, crashes often and generally not working nice on linux, so it is recommend disabling it altogether.
+
+2. **Render Resolution:** - Custom and keep it at 100%. This is to ensure that SteamVR won't try to supersample resolution given by ALVR
+
+3. **Video tab: Fade To Grid** on app hang - this will lock your view to last frame when app hangs instead of dropping you into steamvr void, completely optional but you may prefer that.
+
+4. **Video tab: Disable Advanced Supersample Filtering** 
+
+5. **Video tab: Per-application video settings** - Use Legacy Reprojection Mode for specific game. This can drastically change experience from being very uncomfortable, rubber-banding, to straight up perfect. This essentially disables reprojection on SteamVR side and leaves it to the client. Make sure to enable it for each game you will play. If you don't see that button, it is possible that  you didn't apply patch from installation script, which means that opening each game video settings will take a while and may not even catch up at all after multiple minutes. If you want to apply that patch, get into the container (read bellow in the end how to do that) and run the `./patch_bindings_spam.sh` with absolute path to your steamvr inside container directory (relative to scripts folder, `installation/arch-alvr/.local/share/Steam/steamapps/SteamVR`).
+
+6. **Developer tab: Set steamvr as openxr runtime** - this ensures that games using openxr (such as Bonelab, or Beat Saber) will use SteamVR.
+
+### Distrobox note:
+
+* To enter container (for updating archlinux, installing additional software, and other reasons) you need to do the following:
+1. `source ./setup-env.sh`
+
+2. `distrobox-enter arch-alvr`
+
+        This enters the container. Do note that `sudo` inside container doesn't have privliges to do anything as `root`, but that container has almost exactly the same rights as regular user, so deleting user files from that container **is** possible.
+
+* You can add your steam library from outside the container after alvr installation as for container, `/home/user` folder is the same as on your host, so you can add it from inside distrobox steam.
+
+* Do note though, there has been mentioned some issues with mounted devices, symlinks and containers, so in case you have them, please report them to discover if it's the case.
+
+## Updating ALVR & WlxOverlay
+
+In case there was an update for ALVR or WlxOverlay in the repository, you can run `./update-vr-apps.sh` with or without prefix. In case you want to manually update ALVR or WlxOverlay versions, you can change `links.sh` file accordingly and run the same script.
+
+## Uninstalling
+
+To uninstall this, simply run `./uninstall.sh` and it will automatically remove everything related to locally installed distrobox, it's containers, podman and everything inside in `installation` or prefixed folder.
+
+## Additional info
+
+Highly recommend using CoreCtrl (install it using your distribution package management) and setting settings to VR profile for **AMD** gpus, as well as cpu to performance profile (if it's a Ryzen cpu). Without setting those gpu profiles, it's highly likely you will have serious shutters/wobbles/possibly crashes (sway users) at random point while playing ([[PERF] Subpar GPU performance due to wrong power profile mode · Issue #469 · ValveSoftware/SteamVR-for-Linux · GitHub](https://github.com/ValveSoftware/SteamVR-for-Linux/issues/469)).

--- a/wiki/Installation-guide.md
+++ b/wiki/Installation-guide.md
@@ -26,6 +26,7 @@ For any problem visit the [Troubleshooting page](https://github.com/alvr-org/ALV
 ## Advanced installation
 
 ### Portable version
+
 There is also a portable version for the PC that requires more manual steps to make it work.
 
 * Install SteamVR and launch it once.
@@ -61,8 +62,8 @@ You can skip the ALVR Dashboard and open ALVR automatically together with SteamV
 ALVR requires a Chromium based browser to correctly display the dashboard. Chrome and Edge work out of the box, but Edge has a few bugs that make ALVR behave weirdly. If you want to use other Chromium based browsers like Brave or Vivaldi you have to add an environment variable `ALCRO_BROWSER_PATH` pointing to the path of the browser executable (for example `C:\Program Files\Vivaldi\Application\vivaldi.exe`). Unfortunately Firefox is not supported.
 
 ### Connect headset and PC via a USB Cable
-Check out the guide [here](https://github.com/alvr-org/ALVR/wiki/Using-ALVR-through-a-USB-connection).
 
+Check out the guide [here](https://github.com/alvr-org/ALVR/wiki/Using-ALVR-through-a-USB-connection).
 
 ## Linux
 
@@ -74,6 +75,24 @@ Unless you are using a nightly version, make sure all audio streaming options ar
 * Install [alvr](https://aur.archlinux.org/packages/alvr)<sup>AUR</sup> (recommended), or [alvr-git](https://aur.archlinux.org/packages/alvr-git)<sup>AUR</sup>
 * Install SteamVR, **launch it once** then close it.
 * Run `alvr_launcher` or ALVR from your DE's application launcher.
+
+### Semi-automatic arch distrobox guidance
+
+Some notes:
+
+* This is generally recommended way to install ALVR if you're not on arch linux, and can practically work on any distribution. You can of course use it in case you have issues installing it on Arch Linux.
+
+* Guide also contains fixes, tweaks, additional software like desktop overlay to help you run with steamvr better and workaround it's issues.
+
+* It didn't have a big feedback history yet, so if you happen to have issues, please report them into this repository.
+
+For installation:
+
+1. `git clone https://github.com/alvr-org/ALVR.git`
+
+2. `cd ALVR/packaging/distrobox`
+
+3. Follow the [guide](https://github.com/alvr-org/ALVR/wiki/ALVR-in-distrobox).
 
 ### Other
 
@@ -92,13 +111,18 @@ If you do not install the correct version of FFmpeg systemwide, a common problem
 ### Game Audio
 
 * Must be on v19+
-* Enable Game Audio in ALVR dashboard.
-* Select `pipewire` or `pulse` as the device.
-* Connect with headset and wait until streaming starts.
-* In `pavucontrol` set the device ALVR is recording from to "Monitor of \<your audio output\>". You might have to set "Show:" to "All Streams" for it to show up.
-* Any audio should now be played on the headset. To automatically mute your PC speakers when the headset is streaming, you can use the following script:
 
-  ~~~
+* Enable Game Audio in ALVR dashboard.
+
+* Select `pipewire` or `pulse` as the device.
+
+* Connect with headset and wait until streaming starts.
+
+* In `pavucontrol` set the device ALVR is recording from to "Monitor of \<your audio output\>". You might have to set "Show:" to "All Streams" for it to show up.
+
+* Any audio should now be played on the headset. To automatically mute your PC speakers when the headset is streaming, you can use the following script:
+  
+  ```
   #!/bin/sh
   case $ACTION in
           connect)
@@ -106,8 +130,8 @@ If you do not install the correct version of FFmpeg systemwide, a common problem
           disconnect)
                   pactl set-sink-mute @DEFAULT_SINK@ 0;;
   esac
-  ~~~
-
+  ```
+  
   Save this text to a file, make it executable (`chmod +x ...`) then put the
   file name in "on connect script" and "on disconnect script" settings
   (Connection tab with advanced options shown).
@@ -117,8 +141,8 @@ If you do not install the correct version of FFmpeg systemwide, a common problem
 * Run: `pactl load-module module-null-sink sink_name=VirtMain` or, for a
   permanent setup, add the following to the `context.modules` array in your
   `~/.config/pipewire/pipewire.conf`:
-
-  ~~~
+  
+  ```
   {   name = libpipewire-module-loopback
       args = {
           node.name = "VirtMain" node.description = "VirtMain" media.name = "VirtMain"
@@ -129,9 +153,12 @@ If you do not install the correct version of FFmpeg systemwide, a common problem
           }
       }
   }
-  ~~~
+  ```
 
 * Enable microphone streaming in ALVR dashboard.
+
 * Connect with headset and wait until streaming starts.
+
 * In `pavucontrol` set ALVR Playback to "VirtMain"
+
 * Set "Monitor of VirtMain" as your microphone.


### PR DESCRIPTION
This PR prepares new packaging method for ALVR in the form of using containers through distrobox.

It was chosen because it is designed to be as close to desktop as possible, flexible enough for installing vr or any other software on top of it and was fairly well maintained and supported for such use case.

This method of installing alvr should make it much easier to have pretty much the same environment across the distributions, and make using alvr, steamvr a lot less painful on linux.