### PR TITLE
Bitrate: Limit silliness 

### DIFF
--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -267,7 +267,7 @@ pub enum BitrateMode {
 
         #[schema(strings(display_name = "Minimum bitrate"))]
         #[schema(flag = "real-time")]
-        #[schema(gui(slider(min = 1, max = 1000, logarithmic)), suffix = "Mbps")]
+        #[schema(gui(slider(min = 1, max = 100, logarithmic)), suffix = "Mbps")]
         min_bitrate_mbps: Switch<u64>,
 
         #[schema(strings(display_name = "Maximum network latency"))]


### PR DESCRIPTION
Reason: Setting it to high can cause the encoder to take more than a frame to encode locking SteamVR's render thread