### PR TITLE
Update references to alvr_vulkan_layer.so

### DIFF
--- a/alvr/filesystem/src/lib.rs
+++ b/alvr/filesystem/src/lib.rs
@@ -74,7 +74,7 @@ pub fn dashboard_fname() -> &'static str {
 pub struct Layout {
     // directory containing the dashboard executable
     pub executables_dir: PathBuf,
-    // (linux only) directory where alvr_vulkan_layer.so is saved
+    // (linux only) directory where libalvr_vulkan_layer.so is saved
     pub libraries_dir: PathBuf,
     // parent directory of resources like the dashboard and presets folders
     pub static_resources_dir: PathBuf,


### PR DESCRIPTION
Actual file is libalvr_vulkan_layer.so

(this is trivial, but I was encouraged to do it)