### PR TITLE
Draft: Pico hand tracking fixes, basic hand tracking controller gestures

### DIFF
--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -489,16 +489,20 @@ pub fn get_hand_motion(
             linear_velocity: to_vec3(velocity.linear_velocity),
             angular_velocity: to_vec3(velocity.angular_velocity),
         };
-
-        return (Some(hand_motion), None);
+        if velocity.linear_velocity.x != 0.0
+            && velocity.linear_velocity.y != 0.0
+            && velocity.linear_velocity.z != 0.0
+        {
+            return (Some(hand_motion), None);
+        }
     }
 
     let Some(tracker) = &hand_source.skeleton_tracker else {
         return (None, None);
     };
 
-    let Some((joint_locations, jont_velocities)) = reference_space
-            .relate_hand_joints(tracker, time)
+    let Some(joint_locations) = reference_space
+            .locate_hand_joints(tracker, time)
             .ok().flatten()
         else {
             return (None, None);
@@ -506,8 +510,16 @@ pub fn get_hand_motion(
 
     let root_motion = DeviceMotion {
         pose: to_pose(joint_locations[0].pose),
-        linear_velocity: to_vec3(jont_velocities[0].linear_velocity),
-        angular_velocity: to_vec3(jont_velocities[0].angular_velocity),
+        linear_velocity: Vec3 {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        },
+        angular_velocity: Vec3 {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        },
     };
 
     let joints = joint_locations

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -510,16 +510,8 @@ pub fn get_hand_motion(
 
     let root_motion = DeviceMotion {
         pose: to_pose(joint_locations[0].pose),
-        linear_velocity: Vec3 {
-            x: 0.0,
-            y: 0.0,
-            z: 0.0,
-        },
-        angular_velocity: Vec3 {
-            x: 0.0,
-            y: 0.0,
-            z: 0.0,
-        },
+        linear_velocity: Vec3::ZERO,
+        angular_velocity: Vec3::ZERO,
     };
 
     let joints = joint_locations


### PR DESCRIPTION
Fixes issue that Pico's runtime doesn't work with relate_hand_joints, and instead uses locate_hand_joints. Velocities were zeroed as they aren't useful anyway even on other headsets. This change should affect all openxr based versions on Pico, but it will just work incorrectly on versions bellow 5.7 (needs testing on how it looks on pre-5.7)

Also adds (WIP) basic gesture recognition to emulate pinches and grab using hand tracking, which was removed after switching to openxr client.