### PR TITLE
EncodePipelineVAAPI: Force VBR with adaptive bitrate

### DIFF
--- a/alvr/server/cpp/alvr_server/Settings.cpp
+++ b/alvr/server/cpp/alvr_server/Settings.cpp
@@ -108,6 +108,12 @@ void Settings::Load() {
         m_overrideGripThreshold = config.get("override_grip_threshold").get<bool>();
         m_gripThreshold = config.get("grip_threshold").get<double>();
 
+        m_constantBitrate = v.get("session_settings")
+                             .get("video")
+                             .get("bitrate")
+                             .get("mode")
+                             .get("variant").get<std::string>() == "ConstantMbps";
+
         Info("Render Target: %d %d\n", m_renderWidth, m_renderHeight);
         Info("Refresh Rate: %d\n", m_refreshRate);
         m_loaded = true;

--- a/alvr/server/cpp/alvr_server/Settings.h
+++ b/alvr/server/cpp/alvr_server/Settings.h
@@ -84,4 +84,6 @@ class Settings {
     float m_triggerThreshold;
     bool m_overrideGripThreshold;
     float m_gripThreshold;
+
+    bool m_constantBitrate;
 };


### PR DESCRIPTION
Change VBV buffer fullness to 100%.
Remove no longer needed HEVC dynamic framerate workaround.

Seems to work now.