### PR TITLE
Fixed:Headset-client-crashing-on-second-startup

### DIFF
--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -212,7 +212,7 @@ pub unsafe extern "C" fn alvr_initialize(
 }
 
 #[no_mangle]
-pub extern "C" fn alvr_destroy() {
+pub unsafe extern "C" fn alvr_destroy() {
     IS_ALIVE.set(false);
 
     if let Some(thread) = CONNECTION_THREAD.lock().take() {
@@ -221,6 +221,9 @@ pub extern "C" fn alvr_destroy() {
 
     #[cfg(target_os = "android")]
     platform::release_wifi_lock();
+
+    #[cfg(target_os = "android")]
+    ndk_context::release_android_context();
 }
 
 #[no_mangle]


### PR DESCRIPTION
Headset client crashing on startup #1610
If I restart my headset, it consistently crashes once, then opens successfully on the second attempt. If i quit the app (and by quit I mean press the oculus button, then press the quit button on the window that pops up), and open it again, it crashes. Open it right after the crash and it works. Quit, open and crash, open no crash, quit, open and crash, open no crash... And so on.