### PR TITLE
Fixed:Headset-client-crashing-on-second-startup

### DIFF
--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -158,8 +158,11 @@ pub unsafe extern "C" fn alvr_initialize(
 }
 
 #[no_mangle]
-pub extern "C" fn alvr_destroy() {
+pub unsafe extern "C" fn alvr_destroy() {
     crate::destroy();
+
+    #[cfg(target_os = "android")]
+    ndk_context::release_android_context();
 }
 
 #[no_mangle]


### PR DESCRIPTION
Headset client crashing on startup https://github.com/alvr-org/ALVR/issues/1610
If I restart my headset, it consistently crashes once, then opens successfully on the second attempt. If i quit the app (and by quit I mean press the oculus button, then press the quit button on the window that pops up), and open it again, it crashes. Open it right after the crash and it works. Quit, open and crash, open no crash, quit, open and crash, open no crash... And so on.