### PR TITLE
unlock mutex in OvrDirectModeComponent::Present when returning early

### DIFF
--- a/alvr/server/cpp/platform/win32/OvrDirectModeComponent.cpp
+++ b/alvr/server/cpp/platform/win32/OvrDirectModeComponent.cpp
@@ -194,6 +194,7 @@ void OvrDirectModeComponent::Present(vr::SharedTextureHandle_t syncTexture)
 	if (!pSyncTexture)
 	{
 		Warn("[VDispDvr] SyncTexture is NULL!\n");
+		m_presentMutex.unlock();
 		return;
 	}
 
@@ -209,6 +210,7 @@ void OvrDirectModeComponent::Present(vr::SharedTextureHandle_t syncTexture)
 			{
 				Debug("[VDispDvr] ACQUIRESYNC FAILED!!! hr=%d %p %ls\n", hr, hr, GetErrorStr(hr).c_str());
 				pKeyedMutex->Release();
+				m_presentMutex.unlock();
 				return;
 			}
 		}


### PR DESCRIPTION
Prevents the mutex added in 9d80f78 from getting stuck locked and causing a crash during a subsequent call of `OvrDirectModeComponent::SubmitLayer` by remembering to unlock the mutex in `OvrDirectModeComponent::Present` if it's returning early