### PR TITLE
EncodePipelineVAAPI: Don't allocate extra VA surface

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
@@ -76,7 +76,8 @@ AVFrame *map_frame(AVBufferRef *hw_device_ctx, AVBufferRef *drm_device_ctx, alvr
   }
 
   AVFrame * mapped_frame = av_frame_alloc();
-  av_hwframe_get_buffer(hw_frames_ref, mapped_frame, 0);
+  mapped_frame->format = AV_PIX_FMT_VAAPI;
+  mapped_frame->hw_frames_ctx = av_buffer_ref(hw_frames_ref);
 
   AVBufferRef *drm_frames_ref = NULL;
   if (!(drm_frames_ref = av_hwframe_ctx_alloc(drm_device_ctx))) {


### PR DESCRIPTION
This doesn't really matter all that much since it's only one extra surface, but it would be shame if someone took inspiration here and copied this bad code somewhere else (as I did).