### PR TITLE
fix: OpenGl warmstart crash 🐛

### DIFF
--- a/alvr/client_core/build.rs
+++ b/alvr/client_core/build.rs
@@ -53,5 +53,6 @@ fn main() {
         for path in cpp_paths {
             println!("cargo:rerun-if-changed={}", path.to_string_lossy());
         }
+        println!("cargo:rerun-if-changed={}", "cpp/bindings.h");
     }
 }

--- a/alvr/client_core/build.rs
+++ b/alvr/client_core/build.rs
@@ -53,6 +53,5 @@ fn main() {
         for path in cpp_paths {
             println!("cargo:rerun-if-changed={}", path.to_string_lossy());
         }
-        println!("cargo:rerun-if-changed={}", "cpp/bindings.h");
     }
 }

--- a/alvr/client_core/cpp/gl_render_utils/texture.cpp
+++ b/alvr/client_core/cpp/gl_render_utils/texture.cpp
@@ -44,13 +44,13 @@ Texture::Texture(bool external,
     GL(glTexParameteri(mTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     GL(glTexParameteri(mTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
     GL(glTexParameteri(mTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-    LOGD("New texture Created id#%d", mGLTexture);
+    LOGV("New texture Created id#%d", mGLTexture);
 }
 
 Texture::~Texture() {
     if (!mExternal) {
         GL(glDeleteTextures(1, &mGLTexture));
-        LOGD("texture id#%d deleted", mGLTexture);
+        LOGV("texture id#%d deleted", mGLTexture);
     }
 }
 } // namespace gl_render_utils

--- a/alvr/client_core/cpp/gl_render_utils/texture.cpp
+++ b/alvr/client_core/cpp/gl_render_utils/texture.cpp
@@ -17,6 +17,7 @@ Texture::Texture(bool external,
     mWidth = width;
     mHeight = height;
     mTarget = oes ? GL_TEXTURE_EXTERNAL_OES : GL_TEXTURE_2D;
+    mExternal = external;
 
     if (external) {
         mGLTexture = externalHandle;
@@ -43,11 +44,13 @@ Texture::Texture(bool external,
     GL(glTexParameteri(mTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     GL(glTexParameteri(mTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
     GL(glTexParameteri(mTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+    LOGD("New texture Created id#%d", mGLTexture);
 }
 
 Texture::~Texture() {
     if (!mExternal) {
         GL(glDeleteTextures(1, &mGLTexture));
+        LOGD("texture id#%d deleted", mGLTexture);
     }
 }
 } // namespace gl_render_utils

--- a/alvr/client_core/cpp/graphics.cpp
+++ b/alvr/client_core/cpp/graphics.cpp
@@ -747,10 +747,10 @@ void initGraphicsNative() {
 }
 
 void destroyGraphicsNative() {
-    LOGD("Resetting stream texture and hud texture %p, %p", g_ctx.streamTexture.get(), g_ctx.hudTexture.get());
+    LOGV("Resetting stream texture and hud texture %p, %p", g_ctx.streamTexture.get(), g_ctx.hudTexture.get());
     g_ctx.streamTexture.reset();
     g_ctx.hudTexture.reset();
-    LOGD("Resetted stream texture and hud texture to %p, %p", g_ctx.streamTexture.get(), g_ctx.hudTexture.get());
+    LOGV("Resetted stream texture and hud texture to %p, %p", g_ctx.streamTexture.get(), g_ctx.hudTexture.get());
 }
 
 // on resume

--- a/alvr/client_core/cpp/graphics.cpp
+++ b/alvr/client_core/cpp/graphics.cpp
@@ -747,8 +747,10 @@ void initGraphicsNative() {
 }
 
 void destroyGraphicsNative() {
+    LOGD("Resetting stream texture and hud texture %p, %p", g_ctx.streamTexture.get(), g_ctx.hudTexture.get());
     g_ctx.streamTexture.reset();
     g_ctx.hudTexture.reset();
+    LOGD("Resetted stream texture and hud texture to %p, %p", g_ctx.streamTexture.get(), g_ctx.hudTexture.get());
 }
 
 // on resume
@@ -834,8 +836,8 @@ void renderLobbyNative(const FfiViewInput eyeInputs[2]) {
         std::lock_guard<std::mutex> lock(g_ctx.hudTextureMutex);
 
         if (!g_ctx.hudTextureBitmap.empty()) {
-            glBindTexture(GL_TEXTURE_2D, g_ctx.hudTexture->GetGLTexture());
-            glTexSubImage2D(GL_TEXTURE_2D,
+            GL(glBindTexture(GL_TEXTURE_2D, g_ctx.hudTexture->GetGLTexture()));
+            GL(glTexSubImage2D(GL_TEXTURE_2D,
                             0,
                             0,
                             0,
@@ -843,7 +845,7 @@ void renderLobbyNative(const FfiViewInput eyeInputs[2]) {
                             HUD_TEXTURE_HEIGHT,
                             GL_RGBA,
                             GL_UNSIGNED_BYTE,
-                            &g_ctx.hudTextureBitmap[0]);
+                            &g_ctx.hudTextureBitmap[0]));
         }
         g_ctx.hudTextureBitmap.clear();
     }

--- a/alvr/client_core/cpp/utils.h
+++ b/alvr/client_core/cpp/utils.h
@@ -17,6 +17,10 @@
     do {                                                                                           \
         __android_log_print(ANDROID_LOG_DEBUG, "[ALVR Native]", __VA_ARGS__);                        \
     } while (false)
+#define LOGV(...)                                                                                  \
+    do {                                                                                           \
+        __android_log_print(ANDROID_LOG_VERBOSE, "[ALVR Native]", __VA_ARGS__);                        \
+    } while (false)
 
 static const char *GlErrorString(GLenum error) {
     switch (error) {


### PR DESCRIPTION
relates to: https://github.com/alvr-org/ALVR/issues/1610, https://github.com/alvr-org/ALVR/pull/1783, completely fixes https://github.com/PhoneVR-Developers/PhoneVR/issues/129

```java
19:55:21.203  I  Successfully compiled shader.
19:55:21.203  I  [ALVR NATIVE] ALVR Poll Event: HUD Message Update - ALVR v21.0.0-dev00
                 hostname: 3413.client.alvr
                 IP: 192.168.1.7
                 
                 Searching for streamer...
                 Open ALVR on your PC then click "Trust"
                 next to the client entry
19:55:21.386  D  update hud texture: 
19:55:21.386  E  GL error on cpp\graphics.cpp : 849: GL_INVALID_VALUE
```
Crashes on client on 3rd reopen : o, alvr_client -> Open -OK; close -> reOpen -OK; close -> reOpen !! Crash !!

Online https://github.com/alvr-org/ALVR/blob/6c8c0532ebe1c80b24f49d1146a30929d515a351/alvr/client_core/cpp/graphics.cpp#L838
