### PR TITLE
Linux: remove Vulkan async flag change reprojection flag

### DIFF
--- a/alvr/server/cpp/alvr_server/HMD.cpp
+++ b/alvr/server/cpp/alvr_server/HMD.cpp
@@ -114,10 +114,7 @@ vr::EVRInitError Hmd::Activate(vr::TrackedDeviceIndex_t unObjectId) {
 // Also Disable async reprojection on vulkan
 #ifndef _WIN32
     vr::VRSettings()->SetBool(
-        vr::k_pch_SteamVR_Section, vr::k_pch_SteamVR_DisableAsyncReprojection_Bool, true);
-    vr::VRSettings()->SetBool(vr::k_pch_SteamVR_Section,
-                              vr::k_pch_SteamVR_EnableLinuxVulkanAsync_Bool,
-                              Settings::Instance().m_enableLinuxVulkanAsync);
+        vr::k_pch_SteamVR_Section, vr::k_pch_SteamVR_DisableAsyncReprojection_Bool, !Settings::Instance().m_enableLinuxAsyncReprojection);
 #endif
 
     if (!m_baseComponentsInitialized) {

--- a/alvr/server/cpp/alvr_server/Settings.cpp
+++ b/alvr/server/cpp/alvr_server/Settings.cpp
@@ -99,7 +99,7 @@ void Settings::Load() {
 
         m_enableViveTrackerProxy = config.get("enable_vive_tracker_proxy").get<bool>();
         m_TrackingRefOnly = config.get("tracking_ref_only").get<bool>();
-        m_enableLinuxVulkanAsync = config.get("linux_async_reprojection").get<bool>();
+        m_enableLinuxAsyncReprojection = config.get("linux_async_reprojection").get<bool>();
 
         m_enableControllers = config.get("controllers_enabled").get<bool>();
         m_controllerMode = (int32_t)config.get("controllers_mode_idx").get<int64_t>();

--- a/alvr/server/cpp/alvr_server/Settings.h
+++ b/alvr/server/cpp/alvr_server/Settings.h
@@ -76,7 +76,7 @@ class Settings {
 
     bool m_enableViveTrackerProxy = false;
     bool m_TrackingRefOnly = false;
-    bool m_enableLinuxVulkanAsync;
+    bool m_enableLinuxAsyncReprojection;
 
     bool m_enableControllers;
     int m_controllerMode = 0;


### PR DESCRIPTION
vulkan setting bit was removed in the latest beta and did affect anything(dead setting), and per other user's reports in the Linux Gaming discord async reprojection is fixed keep it disabled by default or the setting true until testing in ALVR 