### PR TITLE
Linux: Nvenc set in to encode one surface at a time

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -89,7 +89,8 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(Renderer *render,
 
     av_opt_set_int(encoder_ctx->priv_data, "tune", settings.m_nvencTuningPreset, 0);
     av_opt_set_int(encoder_ctx->priv_data, "zerolatency", 1, 0);
-    av_opt_set_int(encoder_ctx->priv_data, "delay", 0, 0);
+    // Delay isn't actually a delay instead its how many surfaces to encode at a time
+    av_opt_set_int(encoder_ctx->priv_data, "delay", 1, 0);
     av_opt_set_int(encoder_ctx->priv_data, "forced-idr", 1, 0);
 
     /**


### PR DESCRIPTION
the name isn't actually descriptive on what it actually does, it actually means how many surfaces to encode at a time