### PR TITLE
Fix negated hand tracking skeleton toggle

### DIFF
--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -810,7 +810,7 @@ fn try_connect(mut client_ips: HashMap<IpAddr, String>) -> ConResult {
                 }
 
                 if controllers_config
-                    .map(|c| c.hand_tracking.enable_skeleton)
+                    .map(|c| !c.hand_tracking.enable_skeleton)
                     .unwrap_or(false)
                 {
                     ffi_left_hand_skeleton = None;


### PR DESCRIPTION
adds back a `!` that was lost in 096ec85296e4024f8615a16953ba07a785249ba0