### PR TITLE
docs: add audio setup for Flatpak release

### DIFF
--- a/alvr/xtask/flatpak/audio-flatpak-setup.sh
+++ b/alvr/xtask/flatpak/audio-flatpak-setup.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+function get_alvr_playback_source_id() {
+  local last_node_name=''
+  local last_node_id=''
+  pactl list $1 | while read -r line; do
+    node_id=$(echo "$line" | grep -oP "$2 #\K.+" | sed -e 's/^[ \t]*//')
+    node_name=$(echo "$line" | grep -oP 'node.name = "\K[^"]+' | sed -e 's/^[ \t]*//')
+    if [[ "$node_id" != '' ]] && [[ "$last_node_id" != "$node_id" ]]; then
+      last_node_id="$node_id"
+    fi
+    if [[ -n "$node_name" ]] && [[ "$last_node_name" != "$node_name" ]]; then
+      last_node_name="$node_name"
+      if [[ "$last_node_name" == "$3" ]]; then
+        echo "$last_node_id"
+        return
+      fi
+    fi
+  done
+}
+
+function get_sink_id() {
+  local sink_name
+  sink_name=$1
+  pactl list short sinks | grep "$sink_name" | cut -d$'\t' -f1
+}
+
+function setup_mic() {
+  echo "Creating microphone sink & source and linking alvr playback to it"
+  # This sink is required so that it persistently auto-connects to alvr playback later
+  pactl load-module module-null-sink sink_name=ALVR-MIC-Sink media.class=Audio/Sink
+  # This source is required so that any app can use it as microphone
+  pactl load-module module-null-sink sink_name=ALVR-MIC-Source media.class=Audio/Source/Virtual
+  # We link them together
+  pw-link ALVR-MIC-Sink ALVR-MIC-Source
+  # And we assign playback of pipewire alsa playback to created alvr sink
+  pactl move-sink-input "$(get_alvr_playback_source_id sink-inputs 'Sink Input' 'ALSA plug-in [vrserver]')" "$(get_sink_id ALVR-MIC-Sink)"
+}
+
+function setup_audio() {
+  echo "Setting up audio"
+  pactl load-module module-null-sink sink_name=ALVR-AUDIO-Sink media.class=Audio/Sink
+  pactl set-default-sink ALVR-AUDIO-Sink
+  pactl move-source-output "$(get_alvr_playback_source_id source-outputs 'Source Output' 'ALSA plug-in [vrserver]')" "$(get_sink_id ALVR-AUDIO-Sink)"
+}
+
+function unload_mic() {
+  echo "Unloading microphone sink & source"
+  pw-cli destroy ALVR-MIC-Sink
+  pw-cli destroy ALVR-MIC-Source
+}
+
+function unload_sink() {
+  echo "Unloading audio sink"
+  pw-cli destroy ALVR-AUDIO-Sink
+}
+
+case $ACTION in
+connect)
+  unload_sink
+  unload_mic
+  sleep 1
+  setup_mic
+  setup_audio
+  ;;
+disconnect)
+  unload_mic
+  unload_sink
+  ;;
+esac

--- a/wiki/Flatpak.md
+++ b/wiki/Flatpak.md
@@ -110,6 +110,18 @@ flatpak run --command=alvr_dashboard com.valvesoftware.Steam
 
 A desktop file named `com.valvesoftware.Steam.Utility.alvr.desktop` is supplied within the `alvr/xtask/flatpak` directory. Move this to where other desktop files are located on your system in order to run the dashboard without the terminal.
 
+### Automatic Audio & Microphone setup
+
+Currently the game audio and microphone to and from the headset isn't routed automatically. The setup of this script will therefore run every time the headset connects or disconnects to the ALVR dashboard. This is based on [the steps](Installation-guide.md#automatic-audio--microphone-setup) in the installation guide, modified for the Flatpak.
+
+1. In the ALVR Dashboard under All Settings (Advanced) > Audio, enable Game Audio and Microphone.
+
+2. In the same place under Microphone, click Expand and set Devices to custom. Enter `default` for the name for both Sink and Source.
+
+2. Download the [audio-flatpak-setup.sh](../alvr/xtask/flatpak/audio-flatpak-setup.sh) script and place it into the Flatpak app data directory located at `~/.var/app/com.valvesoftware.Steam/`. Make sure it has execute permissions (e.g. `chmod +x audio-flatpak-setup.sh`).
+
+3. In the ALVR Dashboard, under All Settings (Advanced) > Connection, set the On connect script and On disconnect script to the absolute path of the script (relative to the Flatpak environment), e.g. `/var/home/$USERNAME/audio-flatpak-setup.sh`.
+
 ### Other Applications
 
 The support for other applications that are not launched via Steam is non-existent due to the Flatpak sandbox.

--- a/wiki/Flatpak.md
+++ b/wiki/Flatpak.md
@@ -118,9 +118,9 @@ Currently the game audio and microphone to and from the headset isn't routed aut
 
 2. In the same place under Microphone, click Expand and set Devices to custom. Enter `default` for the name for both Sink and Source.
 
-2. Download the [audio-flatpak-setup.sh](../alvr/xtask/flatpak/audio-flatpak-setup.sh) script and place it into the Flatpak app data directory located at `~/.var/app/com.valvesoftware.Steam/`. Make sure it has execute permissions (e.g. `chmod +x audio-flatpak-setup.sh`).
+3. Download the [audio-flatpak-setup.sh](../alvr/xtask/flatpak/audio-flatpak-setup.sh) script and place it into the Flatpak app data directory located at `~/.var/app/com.valvesoftware.Steam/`. Make sure it has execute permissions (e.g. `chmod +x audio-flatpak-setup.sh`).
 
-3. In the ALVR Dashboard, under All Settings (Advanced) > Connection, set the On connect script and On disconnect script to the absolute path of the script (relative to the Flatpak environment), e.g. `/var/home/$USERNAME/audio-flatpak-setup.sh`.
+4. In the ALVR Dashboard, under All Settings (Advanced) > Connection, set the On connect script and On disconnect script to the absolute path of the script (relative to the Flatpak environment), e.g. `/var/home/$USERNAME/audio-flatpak-setup.sh`.
 
 ### Other Applications
 


### PR DESCRIPTION
I think it would be helpful to have this on GitHub rather than just on Discord, as it took me a little longer than I liked to piece this together (partly my fault 😅). Wasn't sure where to put the audio setup script, so I put it into the path with the other Flatpak files.