### PR TITLE
fix(client): lynx r1 hand tracking

### DIFF
--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -61,6 +61,8 @@ name = "android.permission.ACCESS_WIFI_STATE"
 [[package.metadata.android.uses_permission]]
 name = "android.permission.INTERNET"
 [[package.metadata.android.uses_permission]]
+name = "android.permission.ACCESS_NETWORK_STATE"
+[[package.metadata.android.uses_permission]]
 name = "android.permission.RECORD_AUDIO"
 [[package.metadata.android.uses_permission]]
 name = "android.permission.WAKE_LOCK"


### PR DESCRIPTION
since ultraleap's service uses a TCP loopback socket you need this additional permission. Now hand tracking works!
