### PR TITLE
Added basic toggle - cabled mode for devices

### DIFF
--- a/alvr/dashboard/src/dashboard/components/connections.rs
+++ b/alvr/dashboard/src/dashboard/components/connections.rs
@@ -1,4 +1,4 @@
-use crate::dashboard::ServerRequest;
+use crate::dashboard::{ServerRequest, basic_components};
 use alvr_gui_common::theme::{self, log_colors};
 use alvr_packets::ClientListAction;
 use alvr_session::{ClientConnectionConfig, ConnectionState, SessionConfig};
@@ -106,7 +106,7 @@ impl ConnectionsTab {
 
             ui.add_space(10.0);
 
-            if let Some(clients) = &self.trusted_clients {
+            if let Some(clients) = &mut self.trusted_clients {
                 Frame::group(ui.style())
                     .fill(theme::SECTION_BG)
                     .show(ui, |ui| {
@@ -117,7 +117,6 @@ impl ConnectionsTab {
 
                         ui.vertical(|ui| {
                             for (hostname,data) in clients {
-                                let copied_data = data.clone();
                                 Frame::group(ui.style())
                                 .fill(theme::DARKER_BG)
                                 .show(ui, |ui| {
@@ -151,7 +150,7 @@ impl ConnectionsTab {
                                     ui.horizontal(|ui| {
                                         ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
                                             ui.add_space(10.0);
-                                            if crate::dashboard::basic_components::switch(ui, &mut data.cabled).changed() { // issue is there, can't mutate state
+                                            if basic_components::switch(ui, &mut data.cabled).changed() {
                                                 requests.push(ServerRequest::UpdateClientList {
                                                     hostname: hostname.clone(),
                                                     action: ClientListAction::SetCabled(false),

--- a/alvr/dashboard/src/dashboard/components/connections.rs
+++ b/alvr/dashboard/src/dashboard/components/connections.rs
@@ -1,13 +1,20 @@
 use crate::dashboard::ServerRequest;
 use alvr_gui_common::theme::{self, log_colors};
-use alvr_packets::ClientListAction;
-use alvr_session::{ClientConnectionConfig, ConnectionState, SessionConfig};
+use alvr_packets::{ClientListAction, PathValuePair};
+use alvr_session::{
+    ClientConnectionConfig, ConnectionState, SessionConfig, SocketProtocol, SocketProtocolDefault,
+};
 use eframe::{
     egui::{Frame, Grid, Layout, RichText, TextEdit, Ui, Window},
     emath::{Align, Align2},
     epaint::Color32,
 };
-use std::net::{IpAddr, Ipv4Addr};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    str::FromStr,
+};
+
+use super::settings;
 
 struct EditPopupState {
     new_client: bool,
@@ -161,6 +168,14 @@ impl ConnectionsTab {
                                                 .collect::<Vec<String>>(),
                                         });
                                     }
+                                    let mut cabled_toggle : bool = data.cabled; // todo: moves slider back-forth before setting, how to fix?
+                                    if crate::dashboard::basic_components::switch(ui, &mut cabled_toggle).changed() {
+                                        requests.push(ServerRequest::UpdateClientList {
+                                            hostname: hostname.clone(),
+                                            action: ClientListAction::ToggleCabled,
+                                        });
+                                    }
+                                    ui.hyperlink_to("Cabled:", "https://github.com/alvr-org/ALVR/wiki/ALVR-wired-setup-(ALVR-over-USB)");
                                 });
                                 ui.end_row();
                             }

--- a/alvr/dashboard/src/dashboard/components/connections.rs
+++ b/alvr/dashboard/src/dashboard/components/connections.rs
@@ -168,7 +168,7 @@ impl ConnectionsTab {
                                             action: ClientListAction::ToggleCabled,
                                         });
                                     }
-                                    ui.hyperlink_to("Cabled:", "https://github.com/alvr-org/ALVR/wiki/ALVR-wired-setup-(ALVR-over-USB)#letting-your-pc-communicate-with-your-hmd");
+                                    ui.hyperlink_to("Use Cable:", "https://github.com/alvr-org/ALVR/wiki/ALVR-wired-setup-(ALVR-over-USB)#letting-your-pc-communicate-with-your-hmd");
                                 });
                                 ui.end_row();
                             }

--- a/alvr/dashboard/src/dashboard/components/connections.rs
+++ b/alvr/dashboard/src/dashboard/components/connections.rs
@@ -1,9 +1,9 @@
-use crate::dashboard::{ServerRequest, basic_components};
+use crate::dashboard::{basic_components, ServerRequest};
 use alvr_gui_common::theme::{self, log_colors};
 use alvr_packets::ClientListAction;
 use alvr_session::{ClientConnectionConfig, ConnectionState, SessionConfig};
 use eframe::{
-    egui::{Frame, Grid, Layout, RichText, TextEdit, Ui, Window},
+    egui::{Frame, Grid, Layout, Margin, RichText, TextEdit, Ui, Window, Button, TextStyle},
     emath::{Align, Align2},
     epaint::Color32,
 };
@@ -120,14 +120,12 @@ impl ConnectionsTab {
                                 Frame::group(ui.style())
                                 .fill(theme::DARKER_BG)
                                 .show(ui, |ui| {
-                                    let current_ip = data.current_ip
-                                    .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
-                                    let display_name = data.display_name.clone();
-                                    let manual_ips = data.manual_ips.clone();
+                                    ui.add_space(10.0);
                                     ui.horizontal(|ui| {
                                         ui.add_space(10.0);
-                                        ui.label(format!("{hostname}: {} ({})",current_ip,display_name));
+                                        ui.label(format!("{hostname}: {} ({})", data.current_ip.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)), data.display_name));
                                         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                            ui.add_space(10.0);
                                             match data.connection_state {
                                                 ConnectionState::Disconnected => {
                                                     ui.colored_label(Color32::GRAY, "Disconnected")
@@ -145,21 +143,21 @@ impl ConnectionsTab {
                                                     "Disconnecting",
                                                 ),
                                             }
-                                        })
+                                        });
                                     });
-                                    ui.horizontal(|ui| {
-                                        ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
+                                    Grid::new(&hostname).num_columns(2).show(ui, |ui| {
+                                        ui.horizontal(|ui| {
                                             ui.add_space(10.0);
+                                            ui.hyperlink_to("Use Cable:", "https://github.com/alvr-org/ALVR/wiki/ALVR-wired-setup-(ALVR-over-USB)#letting-your-pc-communicate-with-your-hmd");
                                             if basic_components::switch(ui, &mut data.cabled).changed() {
                                                 requests.push(ServerRequest::UpdateClientList {
                                                     hostname: hostname.clone(),
-                                                    action: ClientListAction::SetCabled(false),
+                                                    action: ClientListAction::SetCabled(data.cabled),
                                                 });
                                             }
-                                            ui.hyperlink_to("Use Cable:", "https://github.com/alvr-org/ALVR/wiki/ALVR-wired-setup-(ALVR-over-USB)#letting-your-pc-communicate-with-your-hmd");
                                         });
-
                                         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                            ui.add_space(10.0);
                                             if ui.button("Remove").clicked() {
                                                 requests.push(ServerRequest::UpdateClientList {
                                                     hostname: hostname.clone(),
@@ -170,13 +168,13 @@ impl ConnectionsTab {
                                                 self.edit_popup_state = Some(EditPopupState {
                                                     new_client: false,
                                                     hostname: hostname.to_owned(),
-                                                    ips: manual_ips
+                                                    ips: data.manual_ips
                                                         .iter()
                                                         .map(|addr| addr.to_string())
                                                         .collect::<Vec<String>>(),
                                                 });
                                             }
-                                        })
+                                        });
                                     });
                                 });
                             }

--- a/alvr/dashboard/src/dashboard/components/connections.rs
+++ b/alvr/dashboard/src/dashboard/components/connections.rs
@@ -83,24 +83,27 @@ impl ConnectionsTab {
                             ui.add_space(5.0);
                             ui.heading("New clients");
                         });
-
-                        Grid::new(1).num_columns(2).show(ui, |ui| {
-                            for (hostname, _) in clients {
-                                ui.horizontal(|ui| {
-                                    ui.add_space(10.0);
-                                    ui.label(hostname);
+                        for (hostname, _) in clients {
+                            Frame::group(ui.style())
+                            .fill(theme::DARKER_BG)
+                            .show(ui, |ui| {
+                                Grid::new(format!("{}-new-clients", hostname)).num_columns(2).show(ui, |ui| {
+                                    ui.horizontal(|ui| {
+                                        ui.add_space(10.0);
+                                        ui.label(hostname);
+                                    });
+                                    ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                        if ui.button("Trust").clicked() {
+                                            requests.push(ServerRequest::UpdateClientList {
+                                                hostname: hostname.clone(),
+                                                action: ClientListAction::Trust,
+                                            });
+                                        };
+                                    });
+                                    ui.end_row();
                                 });
-                                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                    if ui.button("Trust").clicked() {
-                                        requests.push(ServerRequest::UpdateClientList {
-                                            hostname: hostname.clone(),
-                                            action: ClientListAction::Trust,
-                                        });
-                                    };
-                                });
-                                ui.end_row();
-                            }
-                        })
+                            });
+                        }
                     });
             }
 
@@ -145,7 +148,7 @@ impl ConnectionsTab {
                                             }
                                         });
                                     });
-                                    Grid::new(&hostname).num_columns(2).show(ui, |ui| {
+                                    Grid::new(format!("{}-clients", hostname)).num_columns(2).show(ui, |ui| {
                                         ui.horizontal(|ui| {
                                             ui.add_space(10.0);
                                             ui.hyperlink_to("Use Cable:", "https://github.com/alvr-org/ALVR/wiki/ALVR-wired-setup-(ALVR-over-USB)#letting-your-pc-communicate-with-your-hmd");

--- a/alvr/dashboard/src/dashboard/components/connections.rs
+++ b/alvr/dashboard/src/dashboard/components/connections.rs
@@ -1,16 +1,13 @@
 use crate::dashboard::ServerRequest;
 use alvr_gui_common::theme::{self, log_colors};
 use alvr_packets::ClientListAction;
-use alvr_session::{
-    ClientConnectionConfig, ConnectionState, SessionConfig,
-};
+use alvr_session::{ClientConnectionConfig, ConnectionState, SessionConfig};
 use eframe::{
     egui::{Frame, Grid, Layout, RichText, TextEdit, Ui, Window},
     emath::{Align, Align2},
     epaint::Color32,
 };
 use std::net::{IpAddr, Ipv4Addr};
-
 
 struct EditPopupState {
     new_client: bool,

--- a/alvr/dashboard/src/dashboard/components/connections.rs
+++ b/alvr/dashboard/src/dashboard/components/connections.rs
@@ -3,7 +3,7 @@ use alvr_gui_common::theme::{self, log_colors};
 use alvr_packets::ClientListAction;
 use alvr_session::{ClientConnectionConfig, ConnectionState, SessionConfig};
 use eframe::{
-    egui::{Frame, Grid, Layout, Margin, RichText, TextEdit, Ui, Window, Button, TextStyle},
+    egui::{Frame, Grid, Layout, RichText, TextEdit, Ui, Window},
     emath::{Align, Align2},
     epaint::Color32,
 };

--- a/alvr/dashboard/src/dashboard/components/connections.rs
+++ b/alvr/dashboard/src/dashboard/components/connections.rs
@@ -1,20 +1,16 @@
 use crate::dashboard::ServerRequest;
 use alvr_gui_common::theme::{self, log_colors};
-use alvr_packets::{ClientListAction, PathValuePair};
+use alvr_packets::ClientListAction;
 use alvr_session::{
-    ClientConnectionConfig, ConnectionState, SessionConfig, SocketProtocol, SocketProtocolDefault,
+    ClientConnectionConfig, ConnectionState, SessionConfig,
 };
 use eframe::{
     egui::{Frame, Grid, Layout, RichText, TextEdit, Ui, Window},
     emath::{Align, Align2},
     epaint::Color32,
 };
-use std::{
-    net::{IpAddr, Ipv4Addr},
-    str::FromStr,
-};
+use std::net::{IpAddr, Ipv4Addr};
 
-use super::settings;
 
 struct EditPopupState {
     new_client: bool,
@@ -175,7 +171,7 @@ impl ConnectionsTab {
                                             action: ClientListAction::ToggleCabled,
                                         });
                                     }
-                                    ui.hyperlink_to("Cabled:", "https://github.com/alvr-org/ALVR/wiki/ALVR-wired-setup-(ALVR-over-USB)");
+                                    ui.hyperlink_to("Cabled:", "https://github.com/alvr-org/ALVR/wiki/ALVR-wired-setup-(ALVR-over-USB)#letting-your-pc-communicate-with-your-hmd");
                                 });
                                 ui.end_row();
                             }

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -188,6 +188,7 @@ pub enum ClientListAction {
     RemoveEntry,
     UpdateCurrentIp(Option<IpAddr>),
     SetConnectionState(ConnectionState),
+    ToggleCabled,
 }
 
 #[derive(Serialize, Deserialize, Default, Clone)]

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -188,7 +188,7 @@ pub enum ClientListAction {
     RemoveEntry,
     UpdateCurrentIp(Option<IpAddr>),
     SetConnectionState(ConnectionState),
-    ToggleCabled,
+    SetCabled(bool),
 }
 
 #[derive(Serialize, Deserialize, Default, Clone)]

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -28,15 +28,15 @@ use alvr_packets::{
     ServerControlPacket, StreamConfigPacket, Tracking, VideoPacketHeader, AUDIO, HAPTICS,
     STATISTICS, TRACKING, VIDEO,
 };
-use alvr_session::{CodecType, ConnectionState, ControllersEmulationMode, FrameSize, OpenvrConfig};
+use alvr_session::{CodecType, ConnectionState, ControllersEmulationMode, FrameSize, OpenvrConfig, SocketProtocol, SocketProtocolDefault, SocketProtocolDefaultVariant};
 use alvr_sockets::{
     PeerType, ProtoControlSocket, StreamSender, StreamSocketBuilder, KEEPALIVE_INTERVAL,
-    KEEPALIVE_TIMEOUT,
+    KEEPALIVE_TIMEOUT, LOCAL_IP,
 };
 use std::{
     collections::HashMap,
     io::Write,
-    net::IpAddr,
+    net::{IpAddr, Ipv4Addr},
     process::Command,
     ptr,
     sync::{

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -28,15 +28,15 @@ use alvr_packets::{
     ServerControlPacket, StreamConfigPacket, Tracking, VideoPacketHeader, AUDIO, HAPTICS,
     STATISTICS, TRACKING, VIDEO,
 };
-use alvr_session::{CodecType, ConnectionState, ControllersEmulationMode, FrameSize, OpenvrConfig, SocketProtocol, SocketProtocolDefault, SocketProtocolDefaultVariant};
+use alvr_session::{CodecType, ConnectionState, ControllersEmulationMode, FrameSize, OpenvrConfig};
 use alvr_sockets::{
     PeerType, ProtoControlSocket, StreamSender, StreamSocketBuilder, KEEPALIVE_INTERVAL,
-    KEEPALIVE_TIMEOUT, LOCAL_IP,
+    KEEPALIVE_TIMEOUT,
 };
 use std::{
     collections::HashMap,
     io::Write,
-    net::{IpAddr, Ipv4Addr},
+    net::IpAddr,
     process::Command,
     ptr,
     sync::{

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -12,14 +12,14 @@ use alvr_common::{
 };
 use alvr_events::EventType;
 use alvr_packets::{AudioDevicesList, ClientListAction, PathSegment, PathValuePair};
-use alvr_session::{ClientConnectionConfig, ConnectionState, SessionConfig, Settings};
+use alvr_session::{ClientConnectionConfig, ConnectionState, SessionConfig, Settings, SocketProtocolDefaultVariant};
 use cpal::traits::{DeviceTrait, HostTrait};
 use serde_json as json;
 use std::{
     collections::{hash_map::Entry, HashMap},
     fs,
     ops::{Deref, DerefMut},
-    path::{Path, PathBuf},
+    path::{Path, PathBuf}, net::{Ipv4Addr, IpAddr},
 };
 
 fn save_session(session: &SessionConfig, path: &Path) -> Result<()> {
@@ -203,6 +203,7 @@ impl ServerDataManager {
                         manual_ips: manual_ips.into_iter().collect(),
                         trusted,
                         connection_state: ConnectionState::Disconnected,
+                        cabled: false,
                     };
                     new_entry.insert(client_connection_desc);
 
@@ -253,6 +254,23 @@ impl ServerDataManager {
 
                         updated = true;
                     }
+                }
+            }
+            ClientListAction::ToggleCabled => {
+                if let Entry::Occupied(mut entry) = maybe_client_entry {
+                    entry.get_mut().cabled = !entry.get().cabled;
+                    
+                    if entry.get().cabled {
+                        entry.get_mut().manual_ips.insert(IpAddr::V4(Ipv4Addr::LOCALHOST));
+                        self.session.session_settings.connection.client_discovery.enabled = false;
+                        self.session.session_settings.connection.stream_protocol.variant =
+                            SocketProtocolDefaultVariant::Tcp;
+                    } else {
+                        entry.get_mut().manual_ips.remove(&IpAddr::V4(Ipv4Addr::LOCALHOST));
+                        self.session.session_settings.connection.client_discovery.enabled = true;
+                    }
+
+                    updated = true;
                 }
             }
         }

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -12,14 +12,17 @@ use alvr_common::{
 };
 use alvr_events::EventType;
 use alvr_packets::{AudioDevicesList, ClientListAction, PathSegment, PathValuePair};
-use alvr_session::{ClientConnectionConfig, ConnectionState, SessionConfig, Settings, SocketProtocolDefaultVariant};
+use alvr_session::{
+    ClientConnectionConfig, ConnectionState, SessionConfig, Settings, SocketProtocolDefaultVariant,
+};
 use cpal::traits::{DeviceTrait, HostTrait};
 use serde_json as json;
 use std::{
     collections::{hash_map::Entry, HashMap},
     fs,
+    net::{IpAddr, Ipv4Addr},
     ops::{Deref, DerefMut},
-    path::{Path, PathBuf}, net::{Ipv4Addr, IpAddr},
+    path::{Path, PathBuf},
 };
 
 fn save_session(session: &SessionConfig, path: &Path) -> Result<()> {
@@ -259,15 +262,32 @@ impl ServerDataManager {
             ClientListAction::ToggleCabled => {
                 if let Entry::Occupied(mut entry) = maybe_client_entry {
                     entry.get_mut().cabled = !entry.get().cabled;
-                    
+
                     if entry.get().cabled {
-                        entry.get_mut().manual_ips.insert(IpAddr::V4(Ipv4Addr::LOCALHOST));
-                        self.session.session_settings.connection.client_discovery.enabled = false;
-                        self.session.session_settings.connection.stream_protocol.variant =
-                            SocketProtocolDefaultVariant::Tcp;
+                        entry
+                            .get_mut()
+                            .manual_ips
+                            .insert(IpAddr::V4(Ipv4Addr::LOCALHOST));
+                        self.session
+                            .session_settings
+                            .connection
+                            .client_discovery
+                            .enabled = false;
+                        self.session
+                            .session_settings
+                            .connection
+                            .stream_protocol
+                            .variant = SocketProtocolDefaultVariant::Tcp;
                     } else {
-                        entry.get_mut().manual_ips.remove(&IpAddr::V4(Ipv4Addr::LOCALHOST));
-                        self.session.session_settings.connection.client_discovery.enabled = true;
+                        entry
+                            .get_mut()
+                            .manual_ips
+                            .remove(&IpAddr::V4(Ipv4Addr::LOCALHOST));
+                        self.session
+                            .session_settings
+                            .connection
+                            .client_discovery
+                            .enabled = true;
                     }
 
                     updated = true;

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -259,9 +259,9 @@ impl ServerDataManager {
                     }
                 }
             }
-            ClientListAction::ToggleCabled => {
+            ClientListAction::SetCabled(state) => {
                 if let Entry::Occupied(mut entry) = maybe_client_entry {
-                    entry.get_mut().cabled = !entry.get().cabled;
+                    entry.get_mut().cabled = state;
 
                     if entry.get().cabled {
                         entry

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -116,6 +116,7 @@ pub struct ClientConnectionConfig {
     pub manual_ips: HashSet<IpAddr>,
     pub trusted: bool,
     pub connection_state: ConnectionState,
+    pub cabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
Appears for each device, and when toggled - automatically adds local ip, disables client discovery and switches to TCP.
When disabled, it removes local ip (though really not that necessary, still did it), enables client discovery, and leaves TCP as is (because alvr doesn't know about previous state, it's safer to just leave it as is).

Supposed to be very easy and useful toggle to not force people to go and learn where those settings are.

In addition, i made label a hyperlink so people can check out what they need to be able to use that toggle.

I think that's my first "real" pr so any comments about how to do things better (especially when writing settings) appreciated.

![image](https://github.com/alvr-org/ALVR/assets/7141787/8f517c31-4890-4564-aa3d-c4290e929500)
