### PR TITLE
Update Fedora instructions on Building-From-Source.md

### DIFF
--- a/wiki/Building-From-Source.md
+++ b/wiki/Building-From-Source.md
@@ -32,7 +32,8 @@ If you are on Linux, install these additional packages:
 * **Fedora**
   ```bash
   sudo dnf groupinstall 'Development Tools' | For c++ and build tools
-  sudo dnf install yasm libdrm-devel vulkan-headers jack-audio-connection-kit-devel atk-devel gdk-pixbuf2-devel cairo-devel rust-gdk0.15-devel x264-devel vulkan-devel libunwind-devel clang
+  sudo dnf install yasm libdrm-devel vulkan-headers pipewire-jack-audio-connection-kit-devel atk-devel gdk-pixbuf2-devel cairo-devel rust-gdk0.15-devel x264-devel vulkan-devel libunwind-devel clang openssl-devel alsa-lib-devel libva-devel
+
   ```
   If you are using Nvidia, see [Fedora cuda installation](https://github.com/alvr-org/ALVR/wiki/Building-From-Source#fedora-cuda-installation)
   
@@ -81,7 +82,7 @@ Change the Fedora version if you are on a different version. You should check if
 sudo dnf clean all
 sudo dnf module disable nvidia-driver
 sudo dnf -y install cuda
-export PATH=/usr/local/cuda-12.2/bin${PATH:+:${PATH}}
+export PATH=/usr/local/cuda-12.3/bin${PATH:+:${PATH}}
 ```
 If your cuda version is different, change it to the version that is installed. You can check installed versions by doing ```ls /usr/local/ | grep "cuda"``` in your terminal
 
@@ -109,7 +110,7 @@ echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bashrc
 ### 4. Modify dependencies.rs to use correct cuda path and gcc version
 Because CURA installs as a symlink by default, we need to change the dependencies.rs to use the directory
 From the ALVR directory edit the ./alvr/xtask/src/dependencies.rs, and change two lines:
-* Line 159, change ```cuda``` -> ```cuda-12.2``` (or whatever version you have)
+* Line 159, change ```cuda``` -> ```cuda-12.3``` (or whatever version you have)
 * Line 179, replace that line with ```--nvccflags=\"-ccbin /home/linuxbrew/.linuxbrew/bin/g++-11 -gencode arch=compute_52,code=sm_52 -O2\"``` (Change homebrew path if needed, default is used)
 
 You should be good to go! Refer to [Streamer Building](https://github.com/alvr-org/ALVR/wiki/Building-From-Source#streamer-building) for the commands to build ALVR


### PR DESCRIPTION
Updated the instructions to work on Fedora 39 and the latest cuda libs.

I tested this in a small project I made to build ALVR for Fedora 39 in the Gitlab CI/CD system (since the tar.gz didn't work on my env and I wanted to learn how the GitLab CI/CD system worked).

Here is the build output when making this changes: https://gitlab.com/grillo_delmal/alvr_fedora_build/-/pipelines/1061260602