### PR TITLE
Update Installation-guide for Arch Linux

### DIFF
--- a/wiki/Installation-guide.md
+++ b/wiki/Installation-guide.md
@@ -62,6 +62,7 @@ Check out the guide [here](https://github.com/alvr-org/ALVR/wiki/Using-ALVR-thro
 ### Arch Linux (AUR)
 
 * Install `rustup` and a rust toolchain, if you don't have it: <https://wiki.archlinux.org/title/Rust#Arch_Linux_package>.
+* Install `cuda` and make sure that you are using a supported version of gcc. At the moment of writing this, CUDA doesn't compile with gcc 13.
 * Install [alvr](https://aur.archlinux.org/packages/alvr)<sup>AUR</sup> (recommended), or [alvr-git](https://aur.archlinux.org/packages/alvr-git)<sup>AUR</sup>
 * Install SteamVR, **launch it once** then close it.
 * Run `alvr_dashboard` or ALVR from your DE's application launcher.


### PR DESCRIPTION
I've spent some time figuring out why my ALVR installation fails, so I propose mentioning the CUDA requirement together with gcc requirements in the installation guide.

In my case, I had gcc 13 and received the error "ERROR: failed checking for nvcc" during the installation of ALVR from AUR.

In the config.log, the last lines were:

nvcc -gencode arch=compute_52,code=sm_52 -O2 -std=c++11 -m64 -ptx -c -o /tmp/ffconf.Zn9N6o3Q/test.o /tmp/ffconf.Zn9N6o3Q/test.cu
/usr/include/bits/floatn.h(86): error: invalid combination of type specifiers
  typedef __float128 _Float128;
                     ^

/usr/include/bits/floatn-common.h(214): error: invalid combination of type specifiers
  typedef float _Float32;
                ^

/usr/include/bits/floatn-common.h(251): error: invalid combination of type specifiers
  typedef double _Float64;
                 ^

/usr/include/bits/floatn-common.h(268): error: invalid combination of type specifiers
  typedef double _Float32x;
                 ^

/usr/include/bits/floatn-common.h(285): error: invalid combination of type specifiers
  typedef long double _Float64x;
                      ^

5 errors detected in the compilation of "/tmp/ffconf.Zn9N6o3Q/test.cu".
ERROR: failed checking for nvcc.

After that, I found that nvcc doesn't support gcc 13 (https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#host-compiler-support-policy). So, I downgraded my gcc using 'sudo downgrade gcc gcc-libs' and finally installed ALVR.