### PR TITLE
Don't attempt to build AMF cpp files on linux

### DIFF
--- a/alvr/server/build.rs
+++ b/alvr/server/build.rs
@@ -34,6 +34,7 @@ fn main() {
             entry.file_name() != "tools"
                 && entry.file_name() != "platform"
                 && (platform_name != "macos" || entry.file_name() != "amf")
+                && (platform_name != "linux" || entry.file_name() != "amf")
         });
 
     let platform_iter = walkdir::WalkDir::new(platform_subpath).into_iter();


### PR DESCRIPTION
This was throwing up large amounts of warnings that were not suppressed by warning-suppression pragmas intended for MSVC. Since VideoEncoderAMF is only used on win32, filter out AMF cpp files as is done for macos.
