### PR TITLE
Android: When the hardware/default decoder fails to initialize, fall back to software.

### DIFF
--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -457,7 +457,7 @@ fn connection_pipeline(
 
                 match maybe_packet {
                     Ok(ServerControlPacket::InitializeDecoder(config)) => {
-                        decoder::create_decoder(config);
+                        decoder::create_decoder(config, settings.video.force_software_decoder);
                     }
                     Ok(ServerControlPacket::Restarting) => {
                         info!("{SERVER_RESTART_MESSAGE}");

--- a/alvr/client_core/src/decoder.rs
+++ b/alvr/client_core/src/decoder.rs
@@ -7,6 +7,9 @@ use std::time::Duration;
 #[derive(Clone)]
 pub struct DecoderInitConfig {
     pub codec: CodecType,
+    pub width: i32,
+    pub height: i32,
+    pub force_software_decoder: bool,
     pub max_buffering_frames: f32,
     pub buffering_history_weight: f32,
     pub options: Vec<(String, MediacodecDataType)>,
@@ -15,6 +18,12 @@ pub struct DecoderInitConfig {
 pub static DECODER_INIT_CONFIG: Lazy<Mutex<DecoderInitConfig>> = Lazy::new(|| {
     Mutex::new(DecoderInitConfig {
         codec: CodecType::H264,
+        // TODO: Actually get the real values for these and update accordingly.
+        // These are inherited from the previous code to avoid breaking anything.
+        // Would also be nice if force_software_decoder was configurable.
+        width: 512,
+        height: 1024,
+        force_software_decoder: false,
         max_buffering_frames: 1.0,
         buffering_history_weight: 0.9,
         options: vec![],

--- a/alvr/client_core/src/decoder.rs
+++ b/alvr/client_core/src/decoder.rs
@@ -38,9 +38,10 @@ pub static DECODER_SOURCE: alvr_common::OptLazy<crate::platform::VideoDecoderSou
 
 pub static EXTERNAL_DECODER: RelaxedAtomic = RelaxedAtomic::new(false);
 
-pub fn create_decoder(lazy_config: DecoderInitializationConfig) {
+pub fn create_decoder(lazy_config: DecoderInitializationConfig, force_software_decoder: bool) {
     let mut config = DECODER_INIT_CONFIG.lock();
     config.codec = lazy_config.codec;
+    config.force_software_decoder = force_software_decoder;
 
     if EXTERNAL_DECODER.value() {
         EVENT_QUEUE

--- a/alvr/client_core/src/decoder.rs
+++ b/alvr/client_core/src/decoder.rs
@@ -7,8 +7,6 @@ use std::time::Duration;
 #[derive(Clone)]
 pub struct DecoderInitConfig {
     pub codec: CodecType,
-    pub width: i32,
-    pub height: i32,
     pub force_software_decoder: bool,
     pub max_buffering_frames: f32,
     pub buffering_history_weight: f32,
@@ -18,11 +16,6 @@ pub struct DecoderInitConfig {
 pub static DECODER_INIT_CONFIG: Lazy<Mutex<DecoderInitConfig>> = Lazy::new(|| {
     Mutex::new(DecoderInitConfig {
         codec: CodecType::H264,
-        // TODO: Actually get the real values for these and update accordingly.
-        // These are inherited from the previous code to avoid breaking anything.
-        // Would also be nice if force_software_decoder was configurable.
-        width: 512,
-        height: 1024,
         force_software_decoder: false,
         max_buffering_frames: 1.0,
         buffering_history_weight: 0.9,

--- a/alvr/client_core/src/platform/android/decoder.rs
+++ b/alvr/client_core/src/platform/android/decoder.rs
@@ -170,14 +170,14 @@ fn decoder_attempt_setup(
         MediaCodec::from_decoder_type(&mime)
             .ok_or(anyhow!("unable to find decoder for mime type: {}", &mime))?
     };
-    decoder
-        .configure(
-            &format,
-            Some(&image_reader.window()?),
-            MediaCodecDirection::Decoder,
-        )
-        .with_context(|| "failed to configure decoder")?;
-    decoder.start().with_context(|| "failed to start decoder")?;
+    let decoder_configure_err = decoder.configure(
+        &format,
+        Some(&image_reader.window()?),
+        MediaCodecDirection::Decoder,
+    );
+    decoder_configure_err.with_context(|| format!("failed to configure decoder"))?;
+    let decoder_start_err = decoder.start();
+    decoder_start_err.with_context(|| format!("failed to start decoder"))?;
     Ok(decoder)
 }
 

--- a/alvr/client_core/src/platform/android/decoder.rs
+++ b/alvr/client_core/src/platform/android/decoder.rs
@@ -144,9 +144,7 @@ impl Drop for VideoDecoderSource {
     }
 }
 
-fn mime_for_codec(
-    codec: CodecType
-) -> &'static str {
+fn mime_for_codec(codec: CodecType) -> &'static str {
     match codec {
         CodecType::H264 => "video/avc",
         CodecType::Hevc => "video/hevc",

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -128,7 +128,8 @@ pub fn show_e_blocking<E: Display>(e: E) {
 }
 
 pub fn show_err<T, E: Display>(res: Result<T, E>) -> Option<T> {
-    res.map_err(|e| show_e_block(format!("{:#}", e), false)).ok()
+    res.map_err(|e| show_e_block(format!("{:#}", e), false))
+        .ok()
 }
 
 pub fn show_err_blocking<T, E: Display>(res: Result<T, E>) -> Option<T> {

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -128,12 +128,11 @@ pub fn show_e_blocking<E: Display>(e: E) {
 }
 
 pub fn show_err<T, E: Display>(res: Result<T, E>) -> Option<T> {
-    res.map_err(|e| show_e_block(format!("{:#}", e), false))
-        .ok()
+    res.map_err(|e| show_e_block(e, false)).ok()
 }
 
 pub fn show_err_blocking<T, E: Display>(res: Result<T, E>) -> Option<T> {
-    res.map_err(|e| show_e_block(format!("{:#}", e), true)).ok()
+    res.map_err(|e| show_e_block(e, true)).ok()
 }
 
 pub trait ToAny<T> {

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -128,11 +128,11 @@ pub fn show_e_blocking<E: Display>(e: E) {
 }
 
 pub fn show_err<T, E: Display>(res: Result<T, E>) -> Option<T> {
-    res.map_err(|e| show_e_block(e, false)).ok()
+    res.map_err(|e| show_e_block(format!("{:#}", e), false)).ok()
 }
 
 pub fn show_err_blocking<T, E: Display>(res: Result<T, E>) -> Option<T> {
-    res.map_err(|e| show_e_block(e, true)).ok()
+    res.map_err(|e| show_e_block(format!("{:#}", e), true)).ok()
 }
 
 pub trait ToAny<T> {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -479,6 +479,11 @@ pub struct VideoConfig {
 
     pub clientside_foveation: Switch<ClientsideFoveationConfig>,
 
+    #[schema(strings(
+        help = "Attempts to use a software decoder on the device. Slow, but may work around broken codecs."
+    ))]
+    pub force_software_decoder: bool,
+
     #[schema(flag = "steamvr-restart")]
     pub color_correction: Switch<ColorCorrectionConfig>,
 }
@@ -1272,6 +1277,7 @@ pub fn session_settings_default() -> SettingsDefault {
                     vertical_offset_deg: 0.0,
                 },
             },
+            force_software_decoder: false,
             color_correction: SwitchDefault {
                 enabled: true,
                 content: ColorCorrectionConfigDefault {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -472,17 +472,17 @@ pub struct VideoConfig {
     #[schema(flag = "steamvr-restart")]
     pub encoder_config: EncoderConfig,
 
+    #[schema(strings(
+        help = "Attempts to use a software decoder on the device. Slow, but may work around broken codecs."
+    ))]
+    pub force_software_decoder: bool,
+
     pub mediacodec_extra_options: Vec<(String, MediacodecDataType)>,
 
     #[schema(flag = "steamvr-restart")]
     pub foveated_encoding: Switch<FoveatedEncodingConfig>,
 
     pub clientside_foveation: Switch<ClientsideFoveationConfig>,
-
-    #[schema(strings(
-        help = "Attempts to use a software decoder on the device. Slow, but may work around broken codecs."
-    ))]
-    pub force_software_decoder: bool,
 
     #[schema(flag = "steamvr-restart")]
     pub color_correction: Switch<ColorCorrectionConfig>,


### PR DESCRIPTION
*To be clear, this commit was only tested (and I only have the hardware to test it) with PhoneVR.*

That version is https://github.com/20kdc/ALVR/tree/changeling-buffet-pt-2-phonevr-edition .

This code first attempts to use the hardware decoder as usual, and failing that, attempts the software decoder. These software decoder names are "well known" names. As far as I'm aware they're not strictly API-defined, but the alternative is API functions which are *way* too new to be usable to determine software-ness.

Since this functionality only triggers when the previous code would panic, it shouldn't make anything worse.

*To be actually effective, this PR might need constrained baseline encoding. See https://github.com/alvr-org/ALVR/pull/1932*

Possible things of future research:
* "Whatever Moonlight is doing is probably the right thing to do"?
* Embed openh264 to avoid weirdness with system provided software decoders? (AHardwareBuffer needs to be abstracted into invisibility as much as possible)
* Explicitly select a codec by name?
