### PR TITLE
fix(connection): 🐛 Try localhost if broadcast fails, fixes wifi being required for cabled

### DIFF
--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -138,14 +138,14 @@ fn connection_pipeline(
                 return Ok(());
             }
 
-            if let Err(e) = announcer_socket.announce_to(Ipv4Addr::BROADCAST) {
+            if let Err(e) = announcer_socket.announce_broadcast() {
                 warn!("Global broadcast error. Is network available? {e:?}");
 
                 set_hud_message(LOCAL_TRY_MESSAGE);
 
                 thread::sleep(RETRY_CONNECT_MIN_INTERVAL);
 
-                if let Err(e) = announcer_socket.announce_to(Ipv4Addr::LOCALHOST) {
+                if let Err(e) = announcer_socket.announce_local() {
                     warn!("Couldn't announce to neither network or localhost. {e:?}");
                     set_hud_message(NETWORK_UNREACHABLE_MESSAGE);
 

--- a/alvr/client_core/src/sockets.rs
+++ b/alvr/client_core/src/sockets.rs
@@ -20,9 +20,8 @@ impl AnnouncerSocket {
         Ok(Self { socket, packet })
     }
 
-    pub fn broadcast(&self) -> Result<()> {
-        self.socket
-            .send_to(&self.packet, (Ipv4Addr::BROADCAST, CONTROL_PORT))?;
+    pub fn announce_to(&self, addr: Ipv4Addr) -> Result<()> {
+        self.socket.send_to(&self.packet, (addr, CONTROL_PORT))?;
 
         Ok(())
     }

--- a/alvr/client_core/src/sockets.rs
+++ b/alvr/client_core/src/sockets.rs
@@ -20,8 +20,16 @@ impl AnnouncerSocket {
         Ok(Self { socket, packet })
     }
 
-    pub fn announce_to(&self, addr: Ipv4Addr) -> Result<()> {
-        self.socket.send_to(&self.packet, (addr, CONTROL_PORT))?;
+    pub fn announce_local(&self) -> Result<()> {
+        self.socket
+            .send_to(&self.packet, (Ipv4Addr::LOCALHOST, CONTROL_PORT))?;
+
+        Ok(())
+    }
+
+    pub fn announce_broadcast(&self) -> Result<()> {
+        self.socket
+            .send_to(&self.packet, (Ipv4Addr::BROADCAST, CONTROL_PORT))?;
 
         Ok(())
     }

--- a/alvr/client_core/src/sockets.rs
+++ b/alvr/client_core/src/sockets.rs
@@ -20,13 +20,6 @@ impl AnnouncerSocket {
         Ok(Self { socket, packet })
     }
 
-    pub fn announce_local(&self) -> Result<()> {
-        self.socket
-            .send_to(&self.packet, (Ipv4Addr::LOCALHOST, CONTROL_PORT))?;
-
-        Ok(())
-    }
-
     pub fn announce_broadcast(&self) -> Result<()> {
         self.socket
             .send_to(&self.packet, (Ipv4Addr::BROADCAST, CONTROL_PORT))?;

--- a/wiki/Use-ALVR-through-a-USB-connection.md
+++ b/wiki/Use-ALVR-through-a-USB-connection.md
@@ -10,7 +10,6 @@
 
 * If your headset is detected, click "Trust." Click "Edit", "Add new" and change the IP address to `127.0.0.1`.
 * If your headset is not detected, click "Add client manually" and use the IP address `127.0.0.1`. Use the hostname displayed on your headset screen.
-* Turn off client discovery in Settings > Connection.
 * Switch the connection streaming protocol to TCP in Settings > Connection.
 
 ## Letting your PC communicate with your HMD


### PR DESCRIPTION
This makes so that if client can't broadcast, it will try to do announce on localhost.
Thus, making wifi requirement being needed on alvr being optional.

I also added and changed some hud signs, as well as removed wiki line about client discovery - apparently if you set ip on server and have adb working, it doesn't matter if you have client discovery enabled or not, it will connect to wired in either case.