### PR TITLE
Add support for 10bit AV1 encoding in VA-API

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
@@ -42,7 +42,7 @@ void set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx)
   }
   frames_ctx = (AVHWFramesContext *)(hw_frames_ref->data);
   frames_ctx->format = AV_PIX_FMT_VAAPI;
-  frames_ctx->sw_format = Settings::Instance().m_codec == ALVR_CODEC_HEVC && Settings::Instance().m_use10bitEncoder ? AV_PIX_FMT_P010 : AV_PIX_FMT_NV12;
+  frames_ctx->sw_format = (Settings::Instance().m_codec == ALVR_CODEC_HEVC || ALVR_CODEC_AV1) && Settings::Instance().m_use10bitEncoder ? AV_PIX_FMT_P010 : AV_PIX_FMT_NV12;
   frames_ctx->width = ctx->width;
   frames_ctx->height = ctx->height;
   frames_ctx->initial_pool_size = 3;
@@ -290,7 +290,7 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(Renderer *render, VkContext &vk_c
   inputs->next = NULL;
 
   std::string filters = "scale_vaapi=format=";
-  if (Settings::Instance().m_codec == ALVR_CODEC_HEVC && Settings::Instance().m_use10bitEncoder) {
+  if ((Settings::Instance().m_codec == ALVR_CODEC_HEVC || ALVR_CODEC_AV1) && Settings::Instance().m_use10bitEncoder) {
     filters += "p010";
   } else {
     filters += "nv12";


### PR DESCRIPTION
As the title suggests, this patch enables 10bit AV1 encoding in VA-API. Thanks to nowrep for explaining how it works. I was looking for a 10bit profile - turns out there isn't one, the encoder just needs a 10bit input. 