### PR TITLE
Support AV1 encoding using AMF on Windows

### DIFF
--- a/alvr/server/cpp/alvr_server/Settings.cpp
+++ b/alvr/server/cpp/alvr_server/Settings.cpp
@@ -65,6 +65,7 @@ void Settings::Load() {
         m_fillerData = config.get("filler_data").get<bool>();
         m_entropyCoding = (uint32_t)config.get("entropy_coding").get<int64_t>();
         m_use10bitEncoder = config.get("use_10bit_encoder").get<bool>();
+        m_enablePreAnalysis = config.get("enable_pre_analysis").get<bool>();
         m_enableVbaq = config.get("enable_vbaq").get<bool>();
         m_enableHmqb = config.get("enable_hmqb").get<bool>();
         m_usePreproc = config.get("use_preproc").get<bool>();

--- a/alvr/server/cpp/alvr_server/Settings.cpp
+++ b/alvr/server/cpp/alvr_server/Settings.cpp
@@ -66,6 +66,7 @@ void Settings::Load() {
         m_entropyCoding = (uint32_t)config.get("entropy_coding").get<int64_t>();
         m_use10bitEncoder = config.get("use_10bit_encoder").get<bool>();
         m_enableVbaq = config.get("enable_vbaq").get<bool>();
+        m_enableHmqb = config.get("enable_hmqb").get<bool>();
         m_usePreproc = config.get("use_preproc").get<bool>();
         m_preProcSigma = (uint32_t)config.get("preproc_sigma").get<int64_t>();
         m_preProcTor = (uint32_t)config.get("preproc_tor").get<int64_t>();

--- a/alvr/server/cpp/alvr_server/Settings.h
+++ b/alvr/server/cpp/alvr_server/Settings.h
@@ -42,6 +42,7 @@ class Settings {
     int m_codec;
     int m_h264Profile;
     bool m_use10bitEncoder;
+    bool m_enablePreAnalysis;
     bool m_enableVbaq;
     bool m_enableHmqb;
     bool m_usePreproc;

--- a/alvr/server/cpp/alvr_server/Settings.h
+++ b/alvr/server/cpp/alvr_server/Settings.h
@@ -43,6 +43,7 @@ class Settings {
     int m_h264Profile;
     bool m_use10bitEncoder;
     bool m_enableVbaq;
+    bool m_enableHmqb;
     bool m_usePreproc;
     uint32_t m_preProcSigma;
     uint32_t m_preProcTor;

--- a/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
@@ -205,6 +205,17 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 				break;
 		}
 
+		amf::AMFCapsPtr caps;
+		if (amfEncoder->GetCaps(&caps) == AMF_OK) {
+			caps->GetProperty(AMF_VIDEO_ENCODER_CAP_PRE_ANALYSIS, &m_hasPreAnalysis);
+			caps->GetProperty(AMF_VIDEO_ENCODER_CAPS_QUERY_TIMEOUT_SUPPORT, &m_hasQueryTimeout);
+		}
+		if (m_hasPreAnalysis) {
+			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
+		} else {
+			Warn("Pre-analysis could not be enabled because your GPU does not support it for h264 encoding.");
+		}
+
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_ENABLE_VBAQ, Settings::Instance().m_enableVbaq);
 
@@ -222,10 +233,6 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_MAX_NUM_REFRAMES, 0);
 
-		amf::AMFCapsPtr caps;
-		if (amfEncoder->GetCaps(&caps) == AMF_OK) {
-			caps->GetProperty(AMF_VIDEO_ENCODER_CAPS_QUERY_TIMEOUT_SUPPORT, &m_hasQueryTimeout);
-		}
 		if (m_hasQueryTimeout) {
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_QUERY_TIMEOUT, 1000); // 1s timeout
 		}
@@ -269,6 +276,17 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PROFILE, AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN);
 		}
 
+		amf::AMFCapsPtr caps;
+		if (amfEncoder->GetCaps(&caps) == AMF_OK) {
+			caps->GetProperty(AMF_VIDEO_ENCODER_HEVC_CAP_PRE_ANALYSIS, &m_hasPreAnalysis);
+			caps->GetProperty(AMF_VIDEO_ENCODER_CAPS_HEVC_QUERY_TIMEOUT_SUPPORT, &m_hasQueryTimeout);
+		}
+		if (m_hasPreAnalysis) {
+			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
+		} else {
+			Warn("Pre-analysis could not be enabled because your GPU does not support it for HEVC encoding.");
+		}
+
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, Settings::Instance().m_enableVbaq);
 
@@ -288,10 +306,6 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_NUM_REFRAMES, 0);
 
-		amf::AMFCapsPtr caps;
-		if (amfEncoder->GetCaps(&caps) == AMF_OK) {
-			caps->GetProperty(AMF_VIDEO_ENCODER_CAPS_HEVC_QUERY_TIMEOUT_SUPPORT, &m_hasQueryTimeout);
-		}
 		if (m_hasQueryTimeout) {
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT, 1000); // 1s timeout
 		}
@@ -341,6 +355,17 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_AQ_MODE, AMF_VIDEO_ENCODER_AV1_AQ_MODE_CAQ);
 		} else {
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_AQ_MODE, AMF_VIDEO_ENCODER_AV1_AQ_MODE_NONE);
+		}
+
+		amf::AMFCapsPtr caps;
+		if (amfEncoder->GetCaps(&caps) == AMF_OK) {
+			caps->GetProperty(AMF_VIDEO_ENCODER_AV1_CAP_PRE_ANALYSIS, &m_hasPreAnalysis);
+		}
+		if (m_hasPreAnalysis) {
+			Warn("Enabling AV1 pre-analysis.");
+			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
+		} else {
+			Warn("Pre-analysis could not be enabled because your GPU does not support it for AV1 encoding.");
 		}
 
 		// May impact performance but improves quality in high-motion areas

--- a/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
@@ -330,7 +330,7 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PROFILE, AMF_VIDEO_ENCODER_AV1_PROFILE_MAIN);
 		}
 
-		// There is no VBAQ option for AV1. Instead it has AQ (Adaptive Quality)
+		// There is no VBAQ option for AV1. Instead it has CAQ (Content adaptive quantization)
 		if (Settings::Instance().m_enableVbaq) {
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_AQ_MODE, AMF_VIDEO_ENCODER_AV1_AQ_MODE_CAQ);
 		} else {

--- a/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
@@ -208,6 +208,9 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_ENABLE_VBAQ, Settings::Instance().m_enableVbaq);
 
+		// May impact performance but improves quality in high-motion areas
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HIGH_MOTION_QUALITY_BOOST_ENABLE, Settings::Instance().m_enableHmqb);
+
 		//Turns Off IDR/I Frames
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, 0);
 
@@ -268,6 +271,9 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, Settings::Instance().m_enableVbaq);
+
+		// May impact performance but improves quality in high-motion areas
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_HIGH_MOTION_QUALITY_BOOST_ENABLE, Settings::Instance().m_enableHmqb);
 
 		//Turns Off IDR/I Frames
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, 0);
@@ -336,6 +342,9 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 		} else {
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_AQ_MODE, AMF_VIDEO_ENCODER_AV1_AQ_MODE_NONE);
 		}
+
+		// May impact performance but improves quality in high-motion areas
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_HIGH_MOTION_QUALITY_BOOST, Settings::Instance().m_enableHmqb);
 
 		// Set infinite GOP length
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_GOP_SIZE, 0);

--- a/alvr/server/cpp/platform/win32/VideoEncoderAMF.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderAMF.h
@@ -96,6 +96,7 @@ private:
 	int m_bitrateInMBits;
 
 	bool m_hasQueryTimeout;
+	bool m_hasPreAnalysis;
 
 	void ApplyFrameProperties(const amf::AMFSurfacePtr &surface, bool insertIDR);
 };

--- a/alvr/server/cpp/platform/win32/VideoEncoderAMF.h
+++ b/alvr/server/cpp/platform/win32/VideoEncoderAMF.h
@@ -4,6 +4,7 @@
 #include "../../shared/amf/public/common/AMFFactory.h"
 #include "../../shared/amf/public/include/components/VideoEncoderVCE.h"
 #include "../../shared/amf/public/include/components/VideoEncoderHEVC.h"
+#include "../../shared/amf/public/include/components/VideoEncoderAV1.h"
 #include "../../shared/amf/public/include/components/VideoConverter.h"
 #include "../../shared/amf/public/include/components/PreProcessing.h"
 #include "../../shared/amf/public/common/AMFSTL.h"

--- a/alvr/server/cpp/shared/amf/public/common/TraceAdapter.h
+++ b/alvr/server/cpp/shared/amf/public/common/TraceAdapter.h
@@ -40,7 +40,7 @@
 #include "../include/core/Debug.h"
 #include "../include/core/Trace.h"
 #include "../include/core/Result.h"
-#include "../common/AMFFactory.h"
+#include "public/common/AMFFactory.h"
 #include "AMFSTL.h"
 
 #ifndef WIN32
@@ -612,7 +612,7 @@ inline amf_wstring AMFFormatVkResult(int result) { return amf::amf_string_format
 *
 *   @brief
 *       Checks VkResult if succeeded, otherwise trace error, debug break and return specified error to upper level
-*
+* 
 *       Could be used: A) with just expression B) with optinal descriptive message C) message + args for printf
 *******************************************************************************
 */

--- a/alvr/server/cpp/shared/amf/public/common/TraceAdapter.h
+++ b/alvr/server/cpp/shared/amf/public/common/TraceAdapter.h
@@ -40,7 +40,7 @@
 #include "../include/core/Debug.h"
 #include "../include/core/Trace.h"
 #include "../include/core/Result.h"
-#include "public/common/AMFFactory.h"
+#include "../common/AMFFactory.h"
 #include "AMFSTL.h"
 
 #ifndef WIN32
@@ -612,7 +612,7 @@ inline amf_wstring AMFFormatVkResult(int result) { return amf::amf_string_format
 *
 *   @brief
 *       Checks VkResult if succeeded, otherwise trace error, debug break and return specified error to upper level
-* 
+*
 *       Could be used: A) with just expression B) with optinal descriptive message C) message + args for printf
 *******************************************************************************
 */

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -147,6 +147,7 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
         filler_data: settings.video.encoder_config.filler_data,
         entropy_coding: settings.video.encoder_config.entropy_coding as u32,
         use_10bit_encoder: settings.video.encoder_config.use_10bit,
+        // enable_pre_analysis: amf_controls.enable_pre_analysis,
         enable_vbaq: amf_controls.enable_vbaq,
         enable_hmqb: amf_controls.enable_hmqb,
         use_preproc: amf_controls.use_preproc,

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -148,6 +148,7 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
         entropy_coding: settings.video.encoder_config.entropy_coding as u32,
         use_10bit_encoder: settings.video.encoder_config.use_10bit,
         enable_vbaq: amf_controls.enable_vbaq,
+        enable_hmqb: amf_controls.enable_hmqb,
         use_preproc: amf_controls.use_preproc,
         preproc_sigma: amf_controls.preproc_sigma,
         preproc_tor: amf_controls.preproc_tor,

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -49,6 +49,7 @@ pub struct OpenvrConfig {
     pub h264_profile: u32,
     pub refresh_rate: u32,
     pub use_10bit_encoder: bool,
+    pub enable_pre_analysis: bool,
     pub enable_vbaq: bool,
     pub enable_hmqb: bool,
     pub use_preproc: bool,

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -50,6 +50,7 @@ pub struct OpenvrConfig {
     pub refresh_rate: u32,
     pub use_10bit_encoder: bool,
     pub enable_vbaq: bool,
+    pub enable_hmqb: bool,
     pub use_preproc: bool,
     pub preproc_sigma: u32,
     pub preproc_tor: u32,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -169,6 +169,15 @@ Allows the encoder to perform pre-analysis the motion of the video and use the i
     #[schema(gui(slider(min = 0, max = 10)))]
     #[schema(flag = "steamvr-restart")]
     pub preproc_tor: u32,
+//     #[schema(
+//         strings(
+//             display_name = "Enable Pre-analysis",
+//             help = r#"Enables pre-analysis during encoding. This will likely result in reduced performance, but may increase quality.
+// Does not work with the \"Reduce color banding\" option, requires enabling \"Use preproc\""#
+//         ),
+//         flag = "steamvr-restart"
+//     )]
+//     pub enable_pre_analysis: bool,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -1273,6 +1282,7 @@ pub fn session_settings_default() -> SettingsDefault {
                     quality_preset: EncoderQualityPresetAmdDefault {
                         variant: EncoderQualityPresetAmdDefaultVariant::Speed,
                     },
+                    // enable_pre_analysis: false,
                     enable_vbaq: false,
                     enable_hmqb: false,
                     use_preproc: false,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -152,6 +152,15 @@ pub struct AmfConfig {
         flag = "steamvr-restart"
     )]
     pub enable_vbaq: bool,
+    #[schema(
+        strings(
+            display_name = "Enable High-Motion Quality Boost",
+            help = r#"Enables high motion quality boost mode.
+Allows the encoder to perform pre-analysis the motion of the video and use the information for better encoding"#
+        ),
+        flag = "steamvr-restart"
+    )]
+    pub enable_hmqb: bool,
     #[schema(flag = "steamvr-restart")]
     pub use_preproc: bool,
     #[schema(gui(slider(min = 0, max = 10)))]
@@ -1265,6 +1274,7 @@ pub fn session_settings_default() -> SettingsDefault {
                         variant: EncoderQualityPresetAmdDefaultVariant::Speed,
                     },
                     enable_vbaq: false,
+                    enable_hmqb: false,
                     use_preproc: false,
                     preproc_sigma: 4,
                     preproc_tor: 7,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -144,10 +144,13 @@ Temporal: Helps improve overall encoding quality, very small trade-off in speed.
 pub struct AmfConfig {
     #[schema(flag = "steamvr-restart")]
     pub quality_preset: EncoderQualityPresetAmd,
-    #[schema(strings(
-        display_name = "Enable VBAQ/AQ",
-        help = "Enables Variance Based Adaptive Quantization on h264 and HEVC, and Adaptive Quality on AV1"
-    ), flag = "steamvr-restart")]
+    #[schema(
+        strings(
+            display_name = "Enable VBAQ/AQ",
+            help = "Enables Variance Based Adaptive Quantization on h264 and HEVC, and Adaptive Quality on AV1"
+        ),
+        flag = "steamvr-restart"
+    )]
     pub enable_vbaq: bool,
     #[schema(flag = "steamvr-restart")]
     pub use_preproc: bool,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -169,15 +169,15 @@ Allows the encoder to perform pre-analysis the motion of the video and use the i
     #[schema(gui(slider(min = 0, max = 10)))]
     #[schema(flag = "steamvr-restart")]
     pub preproc_tor: u32,
-//     #[schema(
-//         strings(
-//             display_name = "Enable Pre-analysis",
-//             help = r#"Enables pre-analysis during encoding. This will likely result in reduced performance, but may increase quality.
-// Does not work with the \"Reduce color banding\" option, requires enabling \"Use preproc\""#
-//         ),
-//         flag = "steamvr-restart"
-//     )]
-//     pub enable_pre_analysis: bool,
+    #[schema(
+        strings(
+            display_name = "Enable Pre-analysis",
+            help = r#"Enables pre-analysis during encoding. This will likely result in reduced performance, but may increase quality.
+Does not work with the "Reduce color banding" option, requires enabling "Use preproc""#
+        ),
+        flag = "steamvr-restart"
+    )]
+    pub enable_pre_analysis: bool,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -1282,7 +1282,7 @@ pub fn session_settings_default() -> SettingsDefault {
                     quality_preset: EncoderQualityPresetAmdDefault {
                         variant: EncoderQualityPresetAmdDefaultVariant::Speed,
                     },
-                    // enable_pre_analysis: false,
+                    enable_pre_analysis: false,
                     enable_vbaq: false,
                     enable_hmqb: false,
                     use_preproc: false,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -431,7 +431,7 @@ pub enum CodecType {
     H264 = 0,
     #[schema(strings(display_name = "HEVC"))]
     Hevc = 1,
-    #[schema(strings(display_name = "AV1"))]
+    #[schema(strings(display_name = "AV1 (AMD only)"))]
     AV1 = 2,
 }
 

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -146,8 +146,8 @@ pub struct AmfConfig {
     pub quality_preset: EncoderQualityPresetAmd,
     #[schema(
         strings(
-            display_name = "Enable VBAQ/AQ",
-            help = "Enables Variance Based Adaptive Quantization on h264 and HEVC, and Adaptive Quality on AV1"
+            display_name = "Enable VBAQ/CAQ",
+            help = "Enables Variance Based Adaptive Quantization on h264 and HEVC, and Content Adaptive Quantization on AV1"
         ),
         flag = "steamvr-restart"
     )]

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -144,7 +144,10 @@ Temporal: Helps improve overall encoding quality, very small trade-off in speed.
 pub struct AmfConfig {
     #[schema(flag = "steamvr-restart")]
     pub quality_preset: EncoderQualityPresetAmd,
-    #[schema(strings(display_name = "Enable VBAQ"), flag = "steamvr-restart")]
+    #[schema(strings(
+        display_name = "Enable VBAQ/AQ",
+        help = "Enables Variance Based Adaptive Quantization on h264 and HEVC, and Adaptive Quality on AV1"
+    ), flag = "steamvr-restart")]
     pub enable_vbaq: bool,
     #[schema(flag = "steamvr-restart")]
     pub use_preproc: bool,
@@ -425,7 +428,7 @@ pub enum CodecType {
     H264 = 0,
     #[schema(strings(display_name = "HEVC"))]
     Hevc = 1,
-    #[schema(strings(display_name = "AV1 (VAAPI only)"))]
+    #[schema(strings(display_name = "AV1"))]
     AV1 = 2,
 }
 


### PR DESCRIPTION
It seems to be working nicely from my testing with a Quest 3 and RX 7700XT.

There's a couple of changes to settings, namely:
- Removed "(VAAPI only)" from AV1 codec name.
- Renamed "Enable VBAQ" to "Enable VBAQ/AQ" and added help text explaining that it's AQ on AV1 and VBAQ on the other two.

With this I also updated AMF to v1.4.33, which may bring some improvements elsewhere. (It may be worth looking into the "New AVC / HEVC encoder rate control methods" added in v1.4.28)