### PR TITLE
Encoders: support full 0-255 color range

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -160,7 +160,7 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(Renderer *render,
     encoder_ctx->sample_aspect_ratio = AVRational{1, 1};
     encoder_ctx->max_b_frames = 0;
     encoder_ctx->gop_size = INT16_MAX;
-    encoder_ctx->color_range = AVCOL_RANGE_JPEG;
+    encoder_ctx->color_range = Settings::Instance().m_useFullRangeEncoding ? AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
     auto params = FfiDynamicEncoderParams {};
     params.updated = true;
     params.bitrate_bps = 30'000'000;

--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -160,6 +160,7 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(Renderer *render,
     encoder_ctx->sample_aspect_ratio = AVRational{1, 1};
     encoder_ctx->max_b_frames = 0;
     encoder_ctx->gop_size = INT16_MAX;
+    encoder_ctx->color_range = AVCOL_RANGE_JPEG;
     auto params = FfiDynamicEncoderParams {};
     params.updated = true;
     params.bitrate_bps = 30'000'000;

--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
@@ -225,7 +225,7 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(Renderer *render, VkContext &vk_c
   encoder_ctx->pix_fmt = AV_PIX_FMT_VAAPI;
   encoder_ctx->max_b_frames = 0;
   encoder_ctx->gop_size = INT_MAX;
-  encoder_ctx->color_range = AVCOL_RANGE_JPEG;
+  encoder_ctx->color_range = Settings::Instance().m_useFullRangeEncoding ? AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
 
   auto params = FfiDynamicEncoderParams {};
   params.updated = true;
@@ -333,7 +333,7 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(Renderer *render, VkContext &vk_c
   inputs->pad_idx = 0;
   inputs->next = NULL;
 
-  std::string filters = "scale_vaapi=out_range=full:format=";
+  std::string filters = Settings::Instance().m_useFullRangeEncoding ? "scale_vaapi=out_range=full:format=" : "scale_vaapi=format=";
   if ((Settings::Instance().m_codec == ALVR_CODEC_HEVC || Settings::Instance().m_codec == ALVR_CODEC_AV1) && Settings::Instance().m_use10bitEncoder) {
     filters += "p010";
   } else {

--- a/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineVAAPI.cpp
@@ -225,6 +225,7 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(Renderer *render, VkContext &vk_c
   encoder_ctx->pix_fmt = AV_PIX_FMT_VAAPI;
   encoder_ctx->max_b_frames = 0;
   encoder_ctx->gop_size = INT_MAX;
+  encoder_ctx->color_range = AVCOL_RANGE_JPEG;
 
   auto params = FfiDynamicEncoderParams {};
   params.updated = true;
@@ -332,7 +333,7 @@ alvr::EncodePipelineVAAPI::EncodePipelineVAAPI(Renderer *render, VkContext &vk_c
   inputs->pad_idx = 0;
   inputs->next = NULL;
 
-  std::string filters = "scale_vaapi=format=";
+  std::string filters = "scale_vaapi=out_range=full:format=";
   if ((Settings::Instance().m_codec == ALVR_CODEC_HEVC || Settings::Instance().m_codec == ALVR_CODEC_AV1) && Settings::Instance().m_use10bitEncoder) {
     filters += "p010";
   } else {

--- a/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
@@ -222,6 +222,9 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 			}
 		}
 
+		// Enable Full Range 
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_FULL_RANGE_COLOR, Settings::Instance().m_useFullRangeEncoding);
+
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_ENABLE_VBAQ, Settings::Instance().m_enableVbaq);
 
@@ -298,6 +301,9 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 				Warn("Pre-analysis could not be enabled because your GPU does not support it for HEVC encoding.");
 			}
 		}
+
+		// Enable Full Range 
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NOMINAL_RANGE, Settings::Instance().m_useFullRangeEncoding ? AMF_VIDEO_ENCODER_HEVC_NOMINAL_RANGE_FULL : AMF_VIDEO_ENCODER_HEVC_NOMINAL_RANGE_STUDIO);
 
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, Settings::Instance().m_enableVbaq);
@@ -384,6 +390,9 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 				Warn("Pre-analysis could not be enabled because your GPU does not support it for AV1 encoding.");
 			}
 		}
+
+		// Enable Full Range 
+		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_OUTPUT_COLOR_PROFILE, Settings::Instance().m_useFullRangeEncoding ? AMF_VIDEO_CONVERTER_COLOR_PROFILE_JPEG : AMF_VIDEO_CONVERTER_COLOR_PROFILE_UNKNOWN);
 
 		// May impact performance but improves quality in high-motion areas
 		amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_HIGH_MOTION_QUALITY_BOOST, Settings::Instance().m_enableHmqb);


### PR DESCRIPTION
Tested with VAAPI, untested with NvEnc. Windows related changes soon.