### PR TITLE
Enable NvEnc AV1 encoding on Linux

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -19,8 +19,7 @@ const char *encoder(ALVR_CODEC codec) {
     case ALVR_CODEC_HEVC:
         return "hevc_nvenc";
     case ALVR_CODEC_AV1:
-        Warn("AV1 is not supported by NvEnc. Using HEVC instead.");
-        return "hevc_nvenc";
+        return "av1_nvenc";
     }
     throw std::runtime_error("invalid codec " + std::to_string(codec));
 }


### PR DESCRIPTION
This looks way too simple to work, but then again, VA-API was basically the same, except it also expected an encoder profile and some other bits and bops for 10bit support, but the Linux NvEnc pipeline never sets a profile for HEVC, either - so I guess it just defaults to the MAIN profile. Somebody should probably test this before it gets merged.