### PR TITLE
Add Pipewire socket permission setup for Flatpak and improve the example path

### DIFF
--- a/wiki/Flatpak.md
+++ b/wiki/Flatpak.md
@@ -120,7 +120,11 @@ Currently the game audio and microphone to and from the headset isn't routed aut
 
 3. Download the [audio-flatpak-setup.sh](../alvr/xtask/flatpak/audio-flatpak-setup.sh) script and place it into the Flatpak app data directory located at `~/.var/app/com.valvesoftware.Steam/`. Make sure it has execute permissions (e.g. `chmod +x audio-flatpak-setup.sh`).
 
-4. In the ALVR Dashboard, under All Settings (Advanced) > Connection, set the On connect script and On disconnect script to the absolute path of the script (relative to the Flatpak environment), e.g. `/var/home/$USERNAME/audio-flatpak-setup.sh`.
+5. In the ALVR Dashboard, under All Settings (Advanced) > Connection, set the On connect script and On disconnect script to the absolute path of the script (relative to the Flatpak environment), e.g. `/home/$USER/.var/app/com.valvesoftware.Steam/audio-flatpak-setup.sh`.
+
+6. In a terminal, run `flatpak override --user --filesystem=xdg-run/pipewire-0 com.valvesoftware.Steam` to allow the script to set and map your headset's microphone
+
+7. Restart both Steam and the ALVR Dashboard
 
 ### Other Applications
 


### PR DESCRIPTION
## Introduction
The script for setting up audio devices for Flatpak uses the `pw-link` command to connect the microphone's sink to the source. However, this command requires access to the Pipewire socket which is not available in the Steam Flatpak environment by default.

The ff. is the error that occurs when running without the PW socket within the Steam flatpak:
```
~ ❯❯❯ flatpak run --command=sh com.valvesoftware.Steam
[📦 com.valvesoftware.Steam ~]$ pw-link ALVR-MIC-Sink:monitor_FL ALVR-MIC-Source:input_FL
can't connect: Host is down
```

## Changes
This PR adds a step to add a Flatpak override for the Pipewire socket in order to make the pw-link command work.

It also updates the example path to point to where the previous step asked the user to save the script.