### PR TITLE
feature: pause body tracking at runtime

### DIFF
--- a/alvr/server/cpp/alvr_server/FakeViveTracker.cpp
+++ b/alvr/server/cpp/alvr_server/FakeViveTracker.cpp
@@ -86,9 +86,10 @@ void FakeViveTracker::OnPoseUpdated(uint64_t targetTimestampNs, FfiBodyTracker t
         return;
     }
     auto pose = vr::DriverPose_t{};
-    pose.poseIsValid = true;
-    pose.result = vr::TrackingResult_Running_OK;
-    pose.deviceIsConnected = true;
+    pose.poseIsValid = tracker.tracking;
+    pose.deviceIsConnected = tracker.tracking;
+    pose.result =
+        tracker.tracking ? vr::TrackingResult_Running_OK : vr::TrackingResult_Uninitialized;
 
     pose.qWorldFromDriverRotation = HmdQuaternion_Init(1, 0, 0, 0);
     pose.qDriverFromHeadRotation = HmdQuaternion_Init(1, 0, 0, 0);

--- a/alvr/server/cpp/alvr_server/bindings.h
+++ b/alvr/server/cpp/alvr_server/bindings.h
@@ -31,6 +31,7 @@ struct FfiBodyTracker {
     unsigned int trackerID;
     FfiQuat orientation;
     float position[3];
+    unsigned int tracking;
 };
 
 enum FfiOpenvrPropertyType {

--- a/alvr/server/src/tracking.rs
+++ b/alvr/server/src/tracking.rs
@@ -373,6 +373,7 @@ const BODY_TRACKER_ID_MAP: Lazy<HashMap<u64, u32>> = Lazy::new(|| {
 pub fn to_ffi_body_trackers(
     device_motions: &Vec<(u64, DeviceMotion)>,
     tracking_manager: &TrackingManager,
+    tracking: bool,
 ) -> Option<Vec<FfiBodyTracker>> {
     let mut trackers = Vec::<FfiBodyTracker>::new();
 
@@ -383,6 +384,7 @@ pub fn to_ffi_body_trackers(
                 trackerID: *BODY_TRACKER_ID_MAP.get(id).unwrap(),
                 orientation: to_ffi_quat(pose.orientation),
                 position: pose.position.to_array(),
+                tracking: tracking.into(),
             });
         }
     }

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -671,6 +671,9 @@ pub enum BodyTrackingSinkConfig {
 pub struct BodyTrackingConfig {
     pub sources: BodyTrackingSourcesConfig,
     pub sink: BodyTrackingSinkConfig,
+    #[schema(strings(help = "Turn this off to temporarily pause tracking."))]
+    #[schema(flag = "real-time")]
+    pub tracked: bool,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -1481,6 +1484,7 @@ pub fn session_settings_default() -> SettingsDefault {
                         VrchatBodyOsc: BodyTrackingSinkConfigVrchatBodyOscDefault { port: 9000 },
                         variant: BodyTrackingSinkConfigDefaultVariant::FakeViveTracker,
                     },
+                    tracked: true,
                 },
             },
             controllers: SwitchDefault {


### PR DESCRIPTION
adds the ability to disable body trackers without needing to restart steamvr. useful when you want to switch to real trackers, or just be in 3-point tracking for a while.