### PR TITLE
Fix pre-analysis setting for AMF

### DIFF
--- a/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
@@ -210,11 +210,16 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 			caps->GetProperty(AMF_VIDEO_ENCODER_CAP_PRE_ANALYSIS, &m_hasPreAnalysis);
 			caps->GetProperty(AMF_VIDEO_ENCODER_CAPS_QUERY_TIMEOUT_SUPPORT, &m_hasQueryTimeout);
 		}
-		if (m_hasPreAnalysis) {
-			Warn("Enabling h264 pre-analysis. You may experience higher latency when this is enabled.");
-			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
-		} else {
-			Warn("Pre-analysis could not be enabled because your GPU does not support it for h264 encoding.");
+
+		if (Settings::Instance().m_enablePreAnalysis) {
+			if (!Settings::Instance().m_usePreproc || Settings::Instance().m_use10bitEncoder) {
+				Warn("Pre-analysis could not be enabled because your you \"Use preproc\" is not enabled or \"Reduce color banding\" is enabled.");
+			} else if (m_hasPreAnalysis) {
+				Warn("Enabling h264 pre-analysis. You may experience higher latency when this is enabled.");
+				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
+			} else {
+				Warn("Pre-analysis could not be enabled because your GPU does not support it for h264 encoding.");
+			}
 		}
 
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
@@ -282,11 +287,16 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 			caps->GetProperty(AMF_VIDEO_ENCODER_HEVC_CAP_PRE_ANALYSIS, &m_hasPreAnalysis);
 			caps->GetProperty(AMF_VIDEO_ENCODER_CAPS_HEVC_QUERY_TIMEOUT_SUPPORT, &m_hasQueryTimeout);
 		}
-		if (m_hasPreAnalysis) {
-			Warn("Enabling HEVC pre-analysis. You may experience higher latency when this is enabled.");
-			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
-		} else {
-			Warn("Pre-analysis could not be enabled because your GPU does not support it for HEVC encoding.");
+
+		if (Settings::Instance().m_enablePreAnalysis) {
+			if (!Settings::Instance().m_usePreproc || Settings::Instance().m_use10bitEncoder) {
+				Warn("Pre-analysis could not be enabled because your you \"Use preproc\" is not enabled or \"Reduce color banding\" is enabled.");
+			} else if (m_hasPreAnalysis) {
+				Warn("Enabling HEVC pre-analysis. You may experience higher latency when this is enabled.");
+				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
+			} else {
+				Warn("Pre-analysis could not be enabled because your GPU does not support it for HEVC encoding.");
+			}
 		}
 
 		//No noticable performance difference and should improve subjective quality by allocating more bits to smooth areas
@@ -363,11 +373,16 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 		if (amfEncoder->GetCaps(&caps) == AMF_OK) {
 			caps->GetProperty(AMF_VIDEO_ENCODER_AV1_CAP_PRE_ANALYSIS, &m_hasPreAnalysis);
 		}
-		if (m_hasPreAnalysis) {
-			Warn("Enabling AV1 pre-analysis. You may experience higher latency when this is enabled.");
-			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
-		} else {
-			Warn("Pre-analysis could not be enabled because your GPU does not support it for AV1 encoding.");
+		
+		if (Settings::Instance().m_enablePreAnalysis) {
+			if (!Settings::Instance().m_usePreproc || Settings::Instance().m_use10bitEncoder) {
+				Warn("Pre-analysis could not be enabled because your you \"Use preproc\" is not enabled or \"Reduce color banding\" is enabled.");
+			} else if (m_hasPreAnalysis) {
+				Warn("Enabling AV1 pre-analysis. You may experience higher latency when this is enabled.");
+				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
+			} else {
+				Warn("Pre-analysis could not be enabled because your GPU does not support it for AV1 encoding.");
+			}
 		}
 
 		// May impact performance but improves quality in high-motion areas

--- a/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
@@ -213,7 +213,7 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 
 		if (Settings::Instance().m_enablePreAnalysis) {
 			if (!Settings::Instance().m_usePreproc || Settings::Instance().m_use10bitEncoder) {
-				Warn("Pre-analysis could not be enabled because your you \"Use preproc\" is not enabled or \"Reduce color banding\" is enabled.");
+				Warn("Pre-analysis could not be enabled because \"Use preproc\" is not enabled or \"Reduce color banding\" is enabled.");
 			} else if (m_hasPreAnalysis) {
 				Warn("Enabling h264 pre-analysis. You may experience higher latency when this is enabled.");
 				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
@@ -290,7 +290,7 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 
 		if (Settings::Instance().m_enablePreAnalysis) {
 			if (!Settings::Instance().m_usePreproc || Settings::Instance().m_use10bitEncoder) {
-				Warn("Pre-analysis could not be enabled because your you \"Use preproc\" is not enabled or \"Reduce color banding\" is enabled.");
+				Warn("Pre-analysis could not be enabled because \"Use preproc\" is not enabled or \"Reduce color banding\" is enabled.");
 			} else if (m_hasPreAnalysis) {
 				Warn("Enabling HEVC pre-analysis. You may experience higher latency when this is enabled.");
 				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
@@ -376,7 +376,7 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 		
 		if (Settings::Instance().m_enablePreAnalysis) {
 			if (!Settings::Instance().m_usePreproc || Settings::Instance().m_use10bitEncoder) {
-				Warn("Pre-analysis could not be enabled because your you \"Use preproc\" is not enabled or \"Reduce color banding\" is enabled.");
+				Warn("Pre-analysis could not be enabled because \"Use preproc\" is not enabled or \"Reduce color banding\" is enabled.");
 			} else if (m_hasPreAnalysis) {
 				Warn("Enabling AV1 pre-analysis. You may experience higher latency when this is enabled.");
 				amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);

--- a/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderAMF.cpp
@@ -211,6 +211,7 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 			caps->GetProperty(AMF_VIDEO_ENCODER_CAPS_QUERY_TIMEOUT_SUPPORT, &m_hasQueryTimeout);
 		}
 		if (m_hasPreAnalysis) {
+			Warn("Enabling h264 pre-analysis. You may experience higher latency when this is enabled.");
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
 		} else {
 			Warn("Pre-analysis could not be enabled because your GPU does not support it for h264 encoding.");
@@ -282,6 +283,7 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 			caps->GetProperty(AMF_VIDEO_ENCODER_CAPS_HEVC_QUERY_TIMEOUT_SUPPORT, &m_hasQueryTimeout);
 		}
 		if (m_hasPreAnalysis) {
+			Warn("Enabling HEVC pre-analysis. You may experience higher latency when this is enabled.");
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
 		} else {
 			Warn("Pre-analysis could not be enabled because your GPU does not support it for HEVC encoding.");
@@ -362,7 +364,7 @@ amf::AMFComponentPtr VideoEncoderAMF::MakeEncoder(
 			caps->GetProperty(AMF_VIDEO_ENCODER_AV1_CAP_PRE_ANALYSIS, &m_hasPreAnalysis);
 		}
 		if (m_hasPreAnalysis) {
-			Warn("Enabling AV1 pre-analysis.");
+			Warn("Enabling AV1 pre-analysis. You may experience higher latency when this is enabled.");
 			amfEncoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PRE_ANALYSIS_ENABLE, Settings::Instance().m_enablePreAnalysis);
 		} else {
 			Warn("Pre-analysis could not be enabled because your GPU does not support it for AV1 encoding.");

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -170,7 +170,7 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
         filler_data: settings.video.encoder_config.filler_data,
         entropy_coding: settings.video.encoder_config.entropy_coding as u32,
         use_10bit_encoder: settings.video.encoder_config.use_10bit,
-        // enable_pre_analysis: amf_controls.enable_pre_analysis,
+        enable_pre_analysis: amf_controls.enable_pre_analysis,
         enable_vbaq: amf_controls.enable_vbaq,
         enable_hmqb: amf_controls.enable_hmqb,
         use_preproc: amf_controls.use_preproc,


### PR DESCRIPTION
Fixes the fact that pre-analysis setting was not obeying the settings in the dashboard.
Also adds warnings about latency in the log.
Finally also prevents any errors due to incompatible settings, prioritising the clashing options over enabling pre-analysis (i.e. don't enable preproc if it isn't, don't disable 10-bit if it's enabled)