### PR TITLE
feat: :sparkles: Make video capabilities packet extensible; negotiate FFE support

### DIFF
--- a/alvr/client_mock/src/main.rs
+++ b/alvr/client_mock/src/main.rs
@@ -208,6 +208,7 @@ fn client_thread(
     alvr_client_core::initialize(
         UVec2::new(1920, 1832),
         vec![60.0, 72.0, 80.0, 90.0, 120.0],
+        false,
         true,
     );
     alvr_client_core::resume();
@@ -228,18 +229,16 @@ fn client_thread(
                     window_output.hud_message = message;
                 }
                 ClientCoreEvent::StreamingStarted {
-                    view_resolution,
-                    refresh_rate_hint: fps,
-                    ..
+                    negotiated_config, ..
                 } => {
-                    window_output.fps = fps;
+                    window_output.fps = negotiated_config.refresh_rate_hint;
                     window_output.connected = true;
-                    window_output.resolution = view_resolution;
+                    window_output.resolution = negotiated_config.view_resolution;
 
                     let streaming = Arc::clone(&streaming);
                     let input = Arc::clone(&window_input);
                     maybe_tracking_thread = Some(thread::spawn(move || {
-                        tracking_thread(streaming, fps, input)
+                        tracking_thread(streaming, negotiated_config.refresh_rate_hint, input)
                     }));
                 }
                 ClientCoreEvent::StreamingStopped => {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -385,6 +385,9 @@ pub struct ClientsideFoveationConfig {
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
 #[schema(collapsible)]
 pub struct FoveatedEncodingConfig {
+    #[schema(strings(help = "Force enable on smartphone clients"))]
+    pub force_enable: bool,
+
     #[schema(strings(display_name = "Center region width"))]
     #[schema(gui(slider(min = 0.0, max = 1.0, step = 0.01)))]
     #[schema(flag = "steamvr-restart")]
@@ -1358,6 +1361,7 @@ pub fn session_settings_default() -> SettingsDefault {
                 enabled: true,
                 content: FoveatedEncodingConfigDefault {
                     gui_collapsed: true,
+                    force_enable: false,
                     center_size_x: 0.45,
                     center_size_y: 0.4,
                     center_shift_x: 0.4,


### PR DESCRIPTION
Use ugly workaround to inject more info into the VideoStreamingCapabilities packet to not break protocol compatibility. The workaround is kept until v21 is released.