### PR TITLE
feat: ✨ Make x264 statically linked on Linux

### DIFF
--- a/alvr/server/build.rs
+++ b/alvr/server/build.rs
@@ -16,6 +16,7 @@ fn get_ffmpeg_path() -> PathBuf {
     }
 }
 
+#[cfg(all(target_os = "linux", feature = "gpl"))]
 fn get_linux_x264_path() -> PathBuf {
     alvr_filesystem::deps_dir().join("linux/x264/alvr_build")
 }
@@ -92,7 +93,7 @@ fn main() {
         build.include(ffmpeg_path.join("include"));
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gpl"))]
     {
         let x264_path = get_linux_x264_path();
 
@@ -105,7 +106,7 @@ fn main() {
 
     build.compile("bindings");
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "gpl"))]
     {
         let x264_path = get_linux_x264_path();
         let x264_lib_path = x264_path.join("lib");
@@ -190,6 +191,11 @@ fn main() {
     #[cfg(target_os = "linux")]
     {
         pkg_config::Config::new().probe("vulkan").unwrap();
+
+        #[cfg(not(feature = "gpl"))]
+        {
+            pkg_config::Config::new().probe("x264").unwrap();
+        }
 
         // fail build if there are undefined symbols in final library
         println!("cargo:rustc-cdylib-link-arg=-Wl,--no-undefined");

--- a/alvr/server/build.rs
+++ b/alvr/server/build.rs
@@ -16,6 +16,10 @@ fn get_ffmpeg_path() -> PathBuf {
     }
 }
 
+fn get_linux_x264_path() -> PathBuf {
+    alvr_filesystem::deps_dir().join("linux/x264/alvr_build")
+}
+
 fn main() {
     let platform_name = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
@@ -79,13 +83,21 @@ fn main() {
     // #[cfg(debug_assertions)]
     // build.define("ALVR_DEBUG_LOG", None);
 
-    let use_ffmpeg = cfg!(feature = "gpl") || cfg!(target_os = "linux");
+    let gpl_or_linux = cfg!(feature = "gpl") || cfg!(target_os = "linux");
 
-    if use_ffmpeg {
+    if gpl_or_linux {
         let ffmpeg_path = get_ffmpeg_path();
 
         assert!(ffmpeg_path.join("include").exists());
         build.include(ffmpeg_path.join("include"));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let x264_path = get_linux_x264_path();
+
+        assert!(x264_path.join("include").exists());
+        build.include(x264_path.join("include"));
     }
 
     #[cfg(feature = "gpl")]
@@ -93,7 +105,36 @@ fn main() {
 
     build.compile("bindings");
 
-    if use_ffmpeg {
+    #[cfg(target_os = "linux")]
+    {
+        let x264_path = get_linux_x264_path();
+        let x264_lib_path = x264_path.join("lib");
+
+        println!(
+            "cargo:rustc-link-search=native={}",
+            x264_lib_path.to_string_lossy()
+        );
+
+        let x264_pkg_path = x264_lib_path.join("pkgconfig");
+        assert!(x264_pkg_path.exists());
+
+        let x264_pkg_path = x264_pkg_path.to_string_lossy().to_string();
+        env::set_var(
+            "PKG_CONFIG_PATH",
+            env::var("PKG_CONFIG_PATH").map_or(x264_pkg_path.clone(), |old| {
+                format!("{x264_pkg_path}:{old}")
+            }),
+        );
+        println!("cargo:rustc-link-lib=static=x264");
+
+        pkg_config::Config::new()
+            .statik(true)
+            .probe("x264")
+            .unwrap();
+    }
+
+    // ffmpeg
+    if gpl_or_linux {
         let ffmpeg_path = get_ffmpeg_path();
         let ffmpeg_lib_path = ffmpeg_path.join("lib");
 
@@ -149,7 +190,6 @@ fn main() {
     #[cfg(target_os = "linux")]
     {
         pkg_config::Config::new().probe("vulkan").unwrap();
-        pkg_config::Config::new().probe("x264").unwrap();
 
         // fail build if there are undefined symbols in final library
         println!("cargo:rustc-cdylib-link-arg=-Wl,--no-undefined");

--- a/alvr/xtask/src/command.rs
+++ b/alvr/xtask/src/command.rs
@@ -10,6 +10,10 @@ pub fn unzip(sh: &Shell, source: &Path, destination: &Path) -> Result<(), xshell
     cmd!(sh, "unzip {source} -d {destination}").run()
 }
 
+pub fn untar(sh: &Shell, source: &Path, destination: &Path) -> Result<(), xshell::Error> {
+    cmd!(sh, "tar -xvf {source} -C {destination}").run()
+}
+
 pub fn targz(sh: &Shell, source: &Path) -> Result<(), xshell::Error> {
     let parent_dir = source.parent().unwrap();
     let file_name = source.file_name().unwrap();
@@ -28,9 +32,17 @@ pub fn download_and_extract_zip(url: &str, destination: &Path) -> Result<(), xsh
     let zip_file = temp_dir_guard.path().join("temp_download.zip");
     download(&sh, url, &zip_file)?;
 
-    sh.remove_path(destination).ok();
-    sh.create_dir(destination)?;
     unzip(&sh, &zip_file, destination)
+}
+
+pub fn download_and_extract_tar(url: &str, destination: &Path) -> Result<(), xshell::Error> {
+    let sh = Shell::new().unwrap();
+    let temp_dir_guard = sh.create_temp_dir()?;
+
+    let tar_file = temp_dir_guard.path().join("temp_download.tar");
+    download(&sh, url, &tar_file)?;
+
+    untar(&sh, &tar_file, destination)
 }
 
 pub fn date_utc_yyyymmdd(sh: &Shell) -> Result<String, xshell::Error> {

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -123,8 +123,6 @@ pub fn build_x264_linux(deps_path: &Path) {
     )
     .unwrap();
 
-    println!("{}", final_path.to_str().unwrap());
-
     let flags = ["--enable-static", "--disable-cli", "--enable-pic"];
 
     let install_prefix = format!("--prefix={}", final_path.join("alvr_build").display());

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -202,65 +202,69 @@ pub fn build_ffmpeg_linux(nvenc_flag: bool, deps_path: &Path) {
            Nvidia docs:
            https://docs.nvidia.com/video-technologies/video-codec-sdk/ffmpeg-with-nvidia-gpu/#commonly-faced-issues-and-tips-to-resolve-them
         */
-        let codec_header_version = "12.1.14.0";
-        let temp_download_dir = deps_path.join("dl_temp");
-        command::download_and_extract_zip(
-            &format!("https://github.com/FFmpeg/nv-codec-headers/archive/refs/tags/n{codec_header_version}.zip"),
-            &temp_download_dir
-        )
-        .unwrap();
-
-        let header_dir = deps_path.join("nv-codec-headers");
-        let header_build_dir = header_dir.join("build");
-        fs::rename(
-            temp_download_dir.join(format!("nv-codec-headers-n{codec_header_version}")),
-            &header_dir,
-        )
-        .unwrap();
-        fs::remove_dir_all(temp_download_dir).unwrap();
+        #[cfg(target_os = "linux")]
         {
-            let make_header_cmd = format!("make install PREFIX='{}'", header_build_dir.display());
-            let _header_push_guard = sh.push_dir(&header_dir);
-            cmd!(sh, "bash -c {make_header_cmd}").run().unwrap();
+            let codec_header_version = "12.1.14.0";
+            let temp_download_dir = deps_path.join("dl_temp");
+            command::download_and_extract_zip(
+                &format!("https://github.com/FFmpeg/nv-codec-headers/archive/refs/tags/n{codec_header_version}.zip"),
+                &temp_download_dir
+            )
+            .unwrap();
+
+            let header_dir = deps_path.join("nv-codec-headers");
+            let header_build_dir = header_dir.join("build");
+            fs::rename(
+                temp_download_dir.join(format!("nv-codec-headers-n{codec_header_version}")),
+                &header_dir,
+            )
+            .unwrap();
+            fs::remove_dir_all(temp_download_dir).unwrap();
+            {
+                let make_header_cmd =
+                    format!("make install PREFIX='{}'", header_build_dir.display());
+                let _header_push_guard = sh.push_dir(&header_dir);
+                cmd!(sh, "bash -c {make_header_cmd}").run().unwrap();
+            }
+
+            let cuda = pkg_config::Config::new().probe("cuda").unwrap();
+            let include_flags = cuda
+                .include_paths
+                .iter()
+                .map(|path| format!("-I{}", path.to_string_lossy()))
+                .reduce(|a, b| format!("{a} {b}"))
+                .expect("pkg-config cuda entry to have include-paths");
+            let link_flags = cuda
+                .link_paths
+                .iter()
+                .map(|path| format!("-L{}", path.to_string_lossy()))
+                .reduce(|a, b| format!("{a} {b}"))
+                .expect("pkg-config cuda entry to have link-paths");
+
+            let nvenc_flags = &[
+                "--enable-encoder=h264_nvenc",
+                "--enable-encoder=hevc_nvenc",
+                "--enable-nonfree",
+                "--enable-cuda-nvcc",
+                "--enable-libnpp",
+                "--nvccflags=\"-gencode arch=compute_52,code=sm_52 -O2\"",
+                &format!("--extra-cflags=\"{include_flags}\""),
+                &format!("--extra-ldflags=\"{link_flags}\""),
+            ];
+
+            let env_vars = format!(
+                "PKG_CONFIG_PATH='{}'",
+                header_build_dir.join("lib/pkgconfig").display()
+            );
+            let flags_combined = flags.join(" ");
+            let nvenc_flags_combined = nvenc_flags.join(" ");
+
+            let command = format!(
+                "{env_vars} ./configure {install_prefix} {flags_combined} {nvenc_flags_combined}"
+            );
+
+            cmd!(sh, "bash -c {command}").run().unwrap();
         }
-
-        let cuda = pkg_config::Config::new().probe("cuda").unwrap();
-        let include_flags = cuda
-            .include_paths
-            .iter()
-            .map(|path| format!("-I{}", path.to_string_lossy()))
-            .reduce(|a, b| format!("{a} {b}"))
-            .expect("pkg-config cuda entry to have include-paths");
-        let link_flags = cuda
-            .link_paths
-            .iter()
-            .map(|path| format!("-L{}", path.to_string_lossy()))
-            .reduce(|a, b| format!("{a} {b}"))
-            .expect("pkg-config cuda entry to have link-paths");
-
-        let nvenc_flags = &[
-            "--enable-encoder=h264_nvenc",
-            "--enable-encoder=hevc_nvenc",
-            "--enable-nonfree",
-            "--enable-cuda-nvcc",
-            "--enable-libnpp",
-            "--nvccflags=\"-gencode arch=compute_52,code=sm_52 -O2\"",
-            &format!("--extra-cflags=\"{include_flags}\""),
-            &format!("--extra-ldflags=\"{link_flags}\""),
-        ];
-
-        let env_vars = format!(
-            "PKG_CONFIG_PATH='{}'",
-            header_build_dir.join("lib/pkgconfig").display()
-        );
-        let flags_combined = flags.join(" ");
-        let nvenc_flags_combined = nvenc_flags.join(" ");
-
-        let command = format!(
-            "{env_vars} ./configure {install_prefix} {flags_combined} {nvenc_flags_combined}"
-        );
-
-        cmd!(sh, "bash -c {command}").run().unwrap();
     } else {
         cmd!(sh, "./configure {install_prefix} {flags...}")
             .run()

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -1,6 +1,6 @@
 use crate::command;
 use alvr_filesystem as afs;
-use std::fs;
+use std::{fs, path::Path};
 use xshell::{cmd, Shell};
 
 pub fn choco_install(sh: &Shell, packages: &[&str]) -> Result<(), xshell::Error> {
@@ -11,20 +11,20 @@ pub fn choco_install(sh: &Shell, packages: &[&str]) -> Result<(), xshell::Error>
     .run()
 }
 
-pub fn prepare_x264_windows() {
+pub fn prepare_x264_windows(deps_path: &Path) {
     let sh = Shell::new().unwrap();
 
     const VERSION: &str = "0.164";
     const REVISION: usize = 3086;
 
-    let deps_dir = afs::deps_dir();
+    let destination = deps_path.join("x264");
 
     command::download_and_extract_zip(
         &format!(
             "{}/{VERSION}.r{REVISION}/libx264_{VERSION}.r{REVISION}_msvc16.zip",
             "https://github.com/ShiftMediaProject/x264/releases/download",
         ),
-        &afs::deps_dir().join("windows/x264"),
+        &destination,
     )
     .unwrap();
 
@@ -43,37 +43,37 @@ Version: {VERSION}
 Libs: -L${{libdir}} -lx264
 Cflags: -I${{includedir}}
 "#,
-            deps_dir
-                .join("windows/x264")
-                .to_string_lossy()
-                .replace('\\', "/")
+            destination.to_string_lossy().replace('\\', "/")
         ),
     )
     .unwrap();
 
-    cmd!(sh, "setx PKG_CONFIG_PATH {deps_dir}").run().unwrap();
+    cmd!(sh, "setx PKG_CONFIG_PATH {deps_path}").run().unwrap();
 }
 
-pub fn prepare_ffmpeg_windows() {
-    let download_path = afs::deps_dir().join("windows");
+pub fn prepare_ffmpeg_windows(deps_path: &Path) {
     command::download_and_extract_zip(
         &format!(
             "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/{}",
             "ffmpeg-n5.1-latest-win64-gpl-shared-5.1.zip"
         ),
-        &download_path,
+        &deps_path,
     )
     .unwrap();
 
     fs::rename(
-        download_path.join("ffmpeg-n5.1-latest-win64-gpl-shared-5.1"),
-        download_path.join("ffmpeg"),
+        deps_path.join("ffmpeg-n5.1-latest-win64-gpl-shared-5.1"),
+        deps_path.join("ffmpeg"),
     )
     .unwrap();
 }
 
 pub fn prepare_windows_deps(skip_admin_priv: bool) {
     let sh = Shell::new().unwrap();
+
+    let deps_path = afs::deps_dir().join("windows");
+    sh.remove_path(&deps_path).ok();
+    sh.create_dir(&deps_path).unwrap();
 
     if !skip_admin_priv {
         choco_install(
@@ -90,23 +90,68 @@ pub fn prepare_windows_deps(skip_admin_priv: bool) {
         .unwrap();
     }
 
-    prepare_x264_windows();
-    prepare_ffmpeg_windows();
+    prepare_x264_windows(&deps_path);
+    prepare_ffmpeg_windows(&deps_path);
 }
 
-pub fn build_ffmpeg_linux(nvenc_flag: bool) {
+pub fn prepare_linux_deps(nvenc_flag: bool) {
     let sh = Shell::new().unwrap();
 
-    let download_path = afs::deps_dir().join("linux");
-    command::download_and_extract_zip(
-        "https://codeload.github.com/FFmpeg/FFmpeg/zip/n6.0",
-        &download_path,
+    let deps_path = afs::deps_dir().join("linux");
+    sh.remove_path(&deps_path).ok();
+    sh.create_dir(&deps_path).unwrap();
+
+    build_x264_linux(&deps_path);
+    build_ffmpeg_linux(nvenc_flag, &deps_path);
+}
+
+pub fn build_x264_linux(deps_path: &Path) {
+    let sh = Shell::new().unwrap();
+
+    // x264 0.164
+    command::download_and_extract_tar(
+        "https://code.videolan.org/videolan/x264/-/archive/c196240409e4d7c01b47448d93b1f9683aaa7cf7/x264-c196240409e4d7c01b47448d93b1f9683aaa7cf7.tar.bz2",
+        &deps_path,
     )
     .unwrap();
 
-    let final_path = download_path.join("ffmpeg");
+    let final_path = deps_path.join("x264");
 
-    fs::rename(download_path.join("FFmpeg-n6.0"), &final_path).unwrap();
+    fs::rename(
+        deps_path.join("x264-c196240409e4d7c01b47448d93b1f9683aaa7cf7"),
+        &final_path,
+    )
+    .unwrap();
+
+    println!("{}", final_path.to_str().unwrap());
+
+    let flags = ["--enable-static", "--disable-cli", "--enable-pic"];
+
+    let install_prefix = format!("--prefix={}", final_path.join("alvr_build").display());
+
+    let _push_guard = sh.push_dir(final_path);
+
+    cmd!(sh, "./configure {install_prefix} {flags...}")
+        .run()
+        .unwrap();
+
+    let nproc = cmd!(sh, "nproc").read().unwrap();
+    cmd!(sh, "make -j{nproc}").run().unwrap();
+    cmd!(sh, "make install").run().unwrap();
+}
+
+pub fn build_ffmpeg_linux(nvenc_flag: bool, deps_path: &Path) {
+    let sh = Shell::new().unwrap();
+
+    command::download_and_extract_zip(
+        "https://codeload.github.com/FFmpeg/FFmpeg/zip/n6.0",
+        &deps_path,
+    )
+    .unwrap();
+
+    let final_path = deps_path.join("ffmpeg");
+
+    fs::rename(deps_path.join("FFmpeg-n6.0"), &final_path).unwrap();
 
     let flags = [
         "--enable-gpl",
@@ -157,69 +202,65 @@ pub fn build_ffmpeg_linux(nvenc_flag: bool) {
            Nvidia docs:
            https://docs.nvidia.com/video-technologies/video-codec-sdk/ffmpeg-with-nvidia-gpu/#commonly-faced-issues-and-tips-to-resolve-them
         */
-        #[cfg(target_os = "linux")]
+        let codec_header_version = "12.1.14.0";
+        let temp_download_dir = deps_path.join("dl_temp");
+        command::download_and_extract_zip(
+            &format!("https://github.com/FFmpeg/nv-codec-headers/archive/refs/tags/n{codec_header_version}.zip"),
+            &temp_download_dir
+        )
+        .unwrap();
+
+        let header_dir = deps_path.join("nv-codec-headers");
+        let header_build_dir = header_dir.join("build");
+        fs::rename(
+            temp_download_dir.join(format!("nv-codec-headers-n{codec_header_version}")),
+            &header_dir,
+        )
+        .unwrap();
+        fs::remove_dir_all(temp_download_dir).unwrap();
         {
-            let codec_header_version = "12.1.14.0";
-            let temp_download_dir = download_path.join("dl_temp");
-            command::download_and_extract_zip(
-                &format!("https://github.com/FFmpeg/nv-codec-headers/archive/refs/tags/n{codec_header_version}.zip"),
-                &temp_download_dir
-            )
-            .unwrap();
-
-            let header_dir = download_path.join("nv-codec-headers");
-            let header_build_dir = header_dir.join("build");
-            fs::rename(
-                temp_download_dir.join(format!("nv-codec-headers-n{codec_header_version}")),
-                &header_dir,
-            )
-            .unwrap();
-            fs::remove_dir_all(temp_download_dir).unwrap();
-            {
-                let make_header_cmd =
-                    format!("make install PREFIX='{}'", header_build_dir.display());
-                let _header_push_guard = sh.push_dir(&header_dir);
-                cmd!(sh, "bash -c {make_header_cmd}").run().unwrap();
-            }
-
-            let cuda = pkg_config::Config::new().probe("cuda").unwrap();
-            let include_flags = cuda
-                .include_paths
-                .iter()
-                .map(|path| format!("-I{}", path.to_string_lossy()))
-                .reduce(|a, b| format!("{a} {b}"))
-                .expect("pkg-config cuda entry to have include-paths");
-            let link_flags = cuda
-                .link_paths
-                .iter()
-                .map(|path| format!("-L{}", path.to_string_lossy()))
-                .reduce(|a, b| format!("{a} {b}"))
-                .expect("pkg-config cuda entry to have link-paths");
-
-            let nvenc_flags = &[
-                "--enable-encoder=h264_nvenc",
-                "--enable-encoder=hevc_nvenc",
-                "--enable-nonfree",
-                "--enable-cuda-nvcc",
-                "--enable-libnpp",
-                "--nvccflags=\"-gencode arch=compute_52,code=sm_52 -O2\"",
-                &format!("--extra-cflags=\"{include_flags}\""),
-                &format!("--extra-ldflags=\"{link_flags}\""),
-            ];
-
-            let env_vars = format!(
-                "PKG_CONFIG_PATH='{}'",
-                header_build_dir.join("lib/pkgconfig").display()
-            );
-            let flags_combined = flags.join(" ");
-            let nvenc_flags_combined = nvenc_flags.join(" ");
-
-            let command = format!(
-                "{env_vars} ./configure {install_prefix} {flags_combined} {nvenc_flags_combined}"
-            );
-
-            cmd!(sh, "bash -c {command}").run().unwrap();
+            let make_header_cmd = format!("make install PREFIX='{}'", header_build_dir.display());
+            let _header_push_guard = sh.push_dir(&header_dir);
+            cmd!(sh, "bash -c {make_header_cmd}").run().unwrap();
         }
+
+        let cuda = pkg_config::Config::new().probe("cuda").unwrap();
+        let include_flags = cuda
+            .include_paths
+            .iter()
+            .map(|path| format!("-I{}", path.to_string_lossy()))
+            .reduce(|a, b| format!("{a} {b}"))
+            .expect("pkg-config cuda entry to have include-paths");
+        let link_flags = cuda
+            .link_paths
+            .iter()
+            .map(|path| format!("-L{}", path.to_string_lossy()))
+            .reduce(|a, b| format!("{a} {b}"))
+            .expect("pkg-config cuda entry to have link-paths");
+
+        let nvenc_flags = &[
+            "--enable-encoder=h264_nvenc",
+            "--enable-encoder=hevc_nvenc",
+            "--enable-nonfree",
+            "--enable-cuda-nvcc",
+            "--enable-libnpp",
+            "--nvccflags=\"-gencode arch=compute_52,code=sm_52 -O2\"",
+            &format!("--extra-cflags=\"{include_flags}\""),
+            &format!("--extra-ldflags=\"{link_flags}\""),
+        ];
+
+        let env_vars = format!(
+            "PKG_CONFIG_PATH='{}'",
+            header_build_dir.join("lib/pkgconfig").display()
+        );
+        let flags_combined = flags.join(" ");
+        let nvenc_flags_combined = nvenc_flags.join(" ");
+
+        let command = format!(
+            "{env_vars} ./configure {install_prefix} {flags_combined} {nvenc_flags_combined}"
+        );
+
+        cmd!(sh, "bash -c {command}").run().unwrap();
     } else {
         cmd!(sh, "./configure {install_prefix} {flags...}")
             .run()

--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -175,7 +175,7 @@ fn main() {
                     if let Some(platform) = platform {
                         match platform.as_str() {
                             "windows" => dependencies::prepare_windows_deps(for_ci),
-                            "linux" => dependencies::build_ffmpeg_linux(!no_nvidia),
+                            "linux" => dependencies::prepare_linux_deps(!no_nvidia),
                             "android" => dependencies::build_android_deps(for_ci),
                             _ => panic!("Unrecognized platform."),
                         }
@@ -183,7 +183,7 @@ fn main() {
                         if cfg!(windows) {
                             dependencies::prepare_windows_deps(for_ci);
                         } else if cfg!(target_os = "linux") {
-                            dependencies::build_ffmpeg_linux(!no_nvidia);
+                            dependencies::prepare_linux_deps(!no_nvidia);
                         }
 
                         dependencies::build_android_deps(for_ci);


### PR DESCRIPTION
In-between did some minor refactor, which probably would need testing on windows just to make sure everything works fine.
Theoretically ffmpeg can use statically linked x264 and be used instead, but it would require refactoring SW encoder to ffmpeg instead, which would be way more work.
Improvement for #1786

For now leaving for review