### PR TITLE
Fix missing aux bones in hand skeleton

### DIFF
--- a/alvr/events/src/lib.rs
+++ b/alvr/events/src/lib.rs
@@ -54,7 +54,7 @@ pub struct GraphStatistics {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TrackingEvent {
     pub device_motions: Vec<(String, DeviceMotion)>,
-    pub hand_skeletons: [Option<[Pose; 26]>; 2],
+    pub hand_skeletons: [Option<[Pose; 31]>; 2],
     pub eye_gazes: [Option<Pose>; 2],
     pub fb_face_expression: Option<Vec<f32>>,
     pub htc_eye_expression: Option<Vec<f32>>,

--- a/alvr/server/cpp/alvr_server/Controller.cpp
+++ b/alvr/server/cpp/alvr_server/Controller.cpp
@@ -227,7 +227,7 @@ bool Controller::onPoseUpdate(float predictionS,
     m_pose = pose;
 
     if (handSkeleton != nullptr) {
-        vr::VRBoneTransform_t boneTransform[SKELETON_BONE_COUNT];
+        vr::VRBoneTransform_t boneTransform[SKELETON_BONE_COUNT] = {};
         for (int j = 0; j < 26; j++) {
             boneTransform[j].orientation.w = handSkeleton->jointRotations[j].w;
             boneTransform[j].orientation.x = handSkeleton->jointRotations[j].x;
@@ -237,6 +237,54 @@ bool Controller::onPoseUpdate(float predictionS,
             boneTransform[j].position.v[1] = handSkeleton->jointPositions[j][1];
             boneTransform[j].position.v[2] = handSkeleton->jointPositions[j][2];
             boneTransform[j].position.v[3] = 1.0;
+        }
+
+        // TODO: aux bone orientations
+        for (int j = 26; j < SKELETON_BONE_COUNT; j++) {
+            boneTransform[j].orientation.w = 1.0;
+            boneTransform[j].orientation.x = 0.0;
+            boneTransform[j].orientation.y = 0.0;
+            boneTransform[j].orientation.z = 0.0;
+        }
+
+        // Thumb aux
+        for (int j = 2; j <= 5; j++) {
+            boneTransform[26].position.v[0] += handSkeleton->jointPositions[j][0];
+            boneTransform[26].position.v[1] += handSkeleton->jointPositions[j][1];
+            boneTransform[26].position.v[2] += handSkeleton->jointPositions[j][2];
+            boneTransform[26].position.v[3] = 1.0;
+        }
+
+        // Index aux
+        for (int j = 6; j <= 6+4; j++) {
+            boneTransform[27].position.v[0] += handSkeleton->jointPositions[j][0];
+            boneTransform[27].position.v[1] += handSkeleton->jointPositions[j][1];
+            boneTransform[27].position.v[2] += handSkeleton->jointPositions[j][2];
+            boneTransform[27].position.v[3] = 1.0;
+        }
+
+        // Middle aux
+        for (int j = 11; j <= 11+4; j++) {
+            boneTransform[28].position.v[0] += handSkeleton->jointPositions[j][0];
+            boneTransform[28].position.v[1] += handSkeleton->jointPositions[j][1];
+            boneTransform[28].position.v[2] += handSkeleton->jointPositions[j][2];
+            boneTransform[28].position.v[3] = 1.0;
+        }
+
+        // Ring aux
+        for (int j = 16; j <= 16+4; j++) {
+            boneTransform[29].position.v[0] += handSkeleton->jointPositions[j][0];
+            boneTransform[29].position.v[1] += handSkeleton->jointPositions[j][1];
+            boneTransform[29].position.v[2] += handSkeleton->jointPositions[j][2];
+            boneTransform[29].position.v[3] = 1.0;
+        }
+
+        // Pinky aux
+        for (int j = 21; j <= 21+4; j++) {
+            boneTransform[30].position.v[0] += handSkeleton->jointPositions[j][0];
+            boneTransform[30].position.v[1] += handSkeleton->jointPositions[j][1];
+            boneTransform[30].position.v[2] += handSkeleton->jointPositions[j][2];
+            boneTransform[30].position.v[3] = 1.0;
         }
 
         vr_driver_input->UpdateSkeletonComponent(m_compSkeleton,

--- a/alvr/server/cpp/alvr_server/Controller.cpp
+++ b/alvr/server/cpp/alvr_server/Controller.cpp
@@ -228,7 +228,7 @@ bool Controller::onPoseUpdate(float predictionS,
 
     if (handSkeleton != nullptr) {
         vr::VRBoneTransform_t boneTransform[SKELETON_BONE_COUNT] = {};
-        for (int j = 0; j < 26; j++) {
+        for (int j = 0; j < 31; j++) {
             boneTransform[j].orientation.w = handSkeleton->jointRotations[j].w;
             boneTransform[j].orientation.x = handSkeleton->jointRotations[j].x;
             boneTransform[j].orientation.y = handSkeleton->jointRotations[j].y;
@@ -237,54 +237,6 @@ bool Controller::onPoseUpdate(float predictionS,
             boneTransform[j].position.v[1] = handSkeleton->jointPositions[j][1];
             boneTransform[j].position.v[2] = handSkeleton->jointPositions[j][2];
             boneTransform[j].position.v[3] = 1.0;
-        }
-
-        // TODO: aux bone orientations
-        for (int j = 26; j < SKELETON_BONE_COUNT; j++) {
-            boneTransform[j].orientation.w = 1.0;
-            boneTransform[j].orientation.x = 0.0;
-            boneTransform[j].orientation.y = 0.0;
-            boneTransform[j].orientation.z = 0.0;
-        }
-
-        // Thumb aux
-        for (int j = 2; j <= 5; j++) {
-            boneTransform[26].position.v[0] += handSkeleton->jointPositions[j][0];
-            boneTransform[26].position.v[1] += handSkeleton->jointPositions[j][1];
-            boneTransform[26].position.v[2] += handSkeleton->jointPositions[j][2];
-            boneTransform[26].position.v[3] = 1.0;
-        }
-
-        // Index aux
-        for (int j = 6; j <= 6+4; j++) {
-            boneTransform[27].position.v[0] += handSkeleton->jointPositions[j][0];
-            boneTransform[27].position.v[1] += handSkeleton->jointPositions[j][1];
-            boneTransform[27].position.v[2] += handSkeleton->jointPositions[j][2];
-            boneTransform[27].position.v[3] = 1.0;
-        }
-
-        // Middle aux
-        for (int j = 11; j <= 11+4; j++) {
-            boneTransform[28].position.v[0] += handSkeleton->jointPositions[j][0];
-            boneTransform[28].position.v[1] += handSkeleton->jointPositions[j][1];
-            boneTransform[28].position.v[2] += handSkeleton->jointPositions[j][2];
-            boneTransform[28].position.v[3] = 1.0;
-        }
-
-        // Ring aux
-        for (int j = 16; j <= 16+4; j++) {
-            boneTransform[29].position.v[0] += handSkeleton->jointPositions[j][0];
-            boneTransform[29].position.v[1] += handSkeleton->jointPositions[j][1];
-            boneTransform[29].position.v[2] += handSkeleton->jointPositions[j][2];
-            boneTransform[29].position.v[3] = 1.0;
-        }
-
-        // Pinky aux
-        for (int j = 21; j <= 21+4; j++) {
-            boneTransform[30].position.v[0] += handSkeleton->jointPositions[j][0];
-            boneTransform[30].position.v[1] += handSkeleton->jointPositions[j][1];
-            boneTransform[30].position.v[2] += handSkeleton->jointPositions[j][2];
-            boneTransform[30].position.v[3] = 1.0;
         }
 
         vr_driver_input->UpdateSkeletonComponent(m_compSkeleton,

--- a/alvr/server/cpp/alvr_server/bindings.h
+++ b/alvr/server/cpp/alvr_server/bindings.h
@@ -15,8 +15,8 @@ struct FfiQuat {
 };
 
 struct FfiHandSkeleton {
-    float jointPositions[26][3];
-    FfiQuat jointRotations[26];
+    float jointPositions[31][3];
+    FfiQuat jointRotations[31];
 };
 
 struct FfiDeviceMotion {

--- a/alvr/server/src/tracking.rs
+++ b/alvr/server/src/tracking.rs
@@ -245,8 +245,36 @@ pub fn to_openvr_hand_skeleton(
     config: &HeadsetConfig,
     device_id: u64,
     hand_skeleton: [Pose; 26],
-) -> [Pose; 26] {
+) -> [Pose; 31] {
     let (left_hand_skeleton_offset, right_hand_skeleton_offset) = get_hand_skeleton_offsets(config);
+    let id = device_id;
+
+    // global joints
+    let gj = hand_skeleton;
+
+    // Correct the orientation for auxiliary bones.
+    pub fn aux_orientation(id: u64, pose: Pose) -> Pose {
+        let o = pose.orientation;
+        let p = pose.position;
+
+        // Convert to SteamVR basis orientations
+        let (orientation, position) = if id == *HAND_LEFT_ID {
+            (
+                Quat::from_xyzw(o.x, o.y, o.z, o.w) * Quat::from_euler(EulerRot::YXZ, -FRAC_PI_2, FRAC_PI_2, 0.0),
+                Vec3::new(p.x, p.y, p.z),
+            )
+        } else {
+            (
+                Quat::from_xyzw(o.x, o.y, o.z, o.w) * Quat::from_euler(EulerRot::YXZ, FRAC_PI_2, -FRAC_PI_2, 0.0),
+                Vec3::new(p.x, p.y, p.z),
+            )
+        };
+
+        Pose {
+            orientation,
+            position,
+        }
+    }
 
     // Convert from global to local joint pose. The orientation frame of reference is also
     // converted from OpenXR to SteamVR (hand-specific!)
@@ -273,10 +301,32 @@ pub fn to_openvr_hand_skeleton(
         }
     }
 
-    let id = device_id;
+    // Adjust hand position based on the emulated controller for joints
+    // parented to the root.
+    let root_parented_pose =  |pose: Pose| -> Pose
+    {
+        let pose_offset = if id == *HAND_LEFT_ID {
+            left_hand_skeleton_offset
+        } else {
+            right_hand_skeleton_offset
+        };
 
-    // global joints
-    let gj = hand_skeleton;
+        let sign = if id == *HAND_LEFT_ID { -1.0 } else { 1.0 };
+        let orientation = pose_offset.orientation.conjugate()
+            * gj[0].orientation.conjugate()
+            * pose.orientation
+            * Quat::from_euler(EulerRot::XZY, PI, sign * FRAC_PI_2, 0.0);
+
+        let position = -pose_offset.position
+            + pose_offset.orientation.conjugate()
+                * gj[0].orientation.conjugate()
+                * (pose.position - gj[0].position);
+
+        Pose {
+            orientation,
+            position,
+        }
+    };
 
     let fixed_g_wrist = Pose {
         orientation: gj[1].orientation
@@ -288,29 +338,7 @@ pub fn to_openvr_hand_skeleton(
         // Palm. NB: this is ignored by SteamVR
         Pose::default(),
         // Wrist
-        {
-            let pose_offset = if device_id == *HAND_LEFT_ID {
-                left_hand_skeleton_offset
-            } else {
-                right_hand_skeleton_offset
-            };
-
-            let sign = if id == *HAND_LEFT_ID { -1.0 } else { 1.0 };
-            let orientation = pose_offset.orientation.conjugate()
-                * gj[0].orientation.conjugate()
-                * gj[1].orientation
-                * Quat::from_euler(EulerRot::XZY, PI, sign * FRAC_PI_2, 0.0);
-
-            let position = -pose_offset.position
-                + pose_offset.orientation.conjugate()
-                    * gj[0].orientation.conjugate()
-                    * (gj[1].position - gj[0].position);
-
-            Pose {
-                orientation,
-                position,
-            }
-        },
+        root_parented_pose(gj[1]),
         // Thumb
         local_pose(id, fixed_g_wrist, gj[2]),
         local_pose(id, gj[2], gj[3]),
@@ -340,6 +368,12 @@ pub fn to_openvr_hand_skeleton(
         local_pose(id, gj[22], gj[23]),
         local_pose(id, gj[23], gj[24]),
         local_pose(id, gj[24], gj[25]),
+        // Aux bones
+        aux_orientation(id, root_parented_pose(gj[4])),
+        aux_orientation(id, root_parented_pose(gj[9])),
+        aux_orientation(id, root_parented_pose(gj[14])),
+        aux_orientation(id, root_parented_pose(gj[19])),
+        aux_orientation(id, root_parented_pose(gj[24]))
     ]
 }
 
@@ -353,7 +387,7 @@ pub fn to_ffi_motion(device_id: u64, motion: DeviceMotion) -> FfiDeviceMotion {
     }
 }
 
-pub fn to_ffi_skeleton(skeleton: [Pose; 26]) -> FfiHandSkeleton {
+pub fn to_ffi_skeleton(skeleton: [Pose; 31]) -> FfiHandSkeleton {
     FfiHandSkeleton {
         jointRotations: skeleton
             .iter()

--- a/alvr/server/src/tracking.rs
+++ b/alvr/server/src/tracking.rs
@@ -260,12 +260,14 @@ pub fn to_openvr_hand_skeleton(
         // Convert to SteamVR basis orientations
         let (orientation, position) = if id == *HAND_LEFT_ID {
             (
-                Quat::from_xyzw(o.x, o.y, o.z, o.w) * Quat::from_euler(EulerRot::YXZ, -FRAC_PI_2, FRAC_PI_2, 0.0),
+                Quat::from_xyzw(o.x, o.y, o.z, o.w)
+                    * Quat::from_euler(EulerRot::YXZ, -FRAC_PI_2, FRAC_PI_2, 0.0),
                 Vec3::new(p.x, p.y, p.z),
             )
         } else {
             (
-                Quat::from_xyzw(o.x, o.y, o.z, o.w) * Quat::from_euler(EulerRot::YXZ, FRAC_PI_2, -FRAC_PI_2, 0.0),
+                Quat::from_xyzw(o.x, o.y, o.z, o.w)
+                    * Quat::from_euler(EulerRot::YXZ, FRAC_PI_2, -FRAC_PI_2, 0.0),
                 Vec3::new(p.x, p.y, p.z),
             )
         };
@@ -303,8 +305,7 @@ pub fn to_openvr_hand_skeleton(
 
     // Adjust hand position based on the emulated controller for joints
     // parented to the root.
-    let root_parented_pose =  |pose: Pose| -> Pose
-    {
+    let root_parented_pose = |pose: Pose| -> Pose {
         let pose_offset = if id == *HAND_LEFT_ID {
             left_hand_skeleton_offset
         } else {
@@ -373,7 +374,7 @@ pub fn to_openvr_hand_skeleton(
         aux_orientation(id, root_parented_pose(gj[9])),
         aux_orientation(id, root_parented_pose(gj[14])),
         aux_orientation(id, root_parented_pose(gj[19])),
-        aux_orientation(id, root_parented_pose(gj[24]))
+        aux_orientation(id, root_parented_pose(gj[24])),
     ]
 }
 


### PR DESCRIPTION
Indices 26-30 are used for the auxiliary bones, and were uninitialized before. This fixes not being able to press the button at the start of The Lab with the Index/robot hands.

Currently I'm not setting the orientation, because I wasn't sure how to accumulate the quaternions.