### PR TITLE
fix: linux views when using modified playspace

### DIFF
--- a/alvr/server/cpp/alvr_server/ChaperoneUpdater.cpp
+++ b/alvr/server/cpp/alvr_server/ChaperoneUpdater.cpp
@@ -48,6 +48,10 @@ void ShutdownOpenvrClient() {
 #endif
 }
 
+bool IsOpenvrClientReady() {
+    return isOpenvrInit;
+}
+
 void _SetChaperoneArea(float areaWidth, float areaHeight) {
 #ifndef __APPLE__
     std::unique_lock<std::mutex> lock(chaperone_mutex);

--- a/alvr/server/cpp/alvr_server/PoseHistory.h
+++ b/alvr/server/cpp/alvr_server/PoseHistory.h
@@ -21,7 +21,6 @@ public:
 	// Return the most recent pose known at the given timestamp
 	std::optional<TrackingHistoryFrame> GetPoseAt(uint64_t timestampNs) const;
 
-	void SetTransformUpdating();
 	void SetTransform(const vr::HmdMatrix34_t &transform);
 
 private:
@@ -29,5 +28,4 @@ private:
 	std::list<TrackingHistoryFrame> m_poseBuffer;
 	vr::HmdMatrix34_t m_transform = {{{1.0, 0.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 0.0}, {0.0, 0.0, 1.0, 0.0}}};
 	bool m_transformIdentity = true;
-	bool m_transformUpdating = false;
 };

--- a/alvr/server/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server/cpp/alvr_server/alvr_server.cpp
@@ -35,7 +35,7 @@ bool IsOpenvrClientReady();
 #endif
 void _SetChaperoneArea(float areaWidth, float areaHeight);
 
-vr::EVREventType VendorEvent_ALVRHmdConnected = (vr::EVREventType) (vr::VREvent_VendorSpecific_Reserved_Start + ((vr::EVREventType) 0xC0));
+vr::EVREventType VendorEvent_ALVRDriverResync = (vr::EVREventType) (vr::VREvent_VendorSpecific_Reserved_Start + ((vr::EVREventType) 0xC0));
 
 static void load_debug_privilege(void) {
 #ifdef _WIN32
@@ -226,7 +226,7 @@ class DriverProvider : public vr::IServerTrackedDeviceProvider {
                 || event.eventType == vr::VREvent_SeatedZeroPoseReset
                 || event.eventType == vr::VREvent_StandingZeroPoseReset
                 || event.eventType == vr::VREvent_SceneApplicationChanged
-                || event.eventType == VendorEvent_ALVRHmdConnected) {
+                || event.eventType == VendorEvent_ALVRDriverResync) {
                 if (hmd && hmd->m_poseHistory && IsOpenvrClientReady()) {
                     hmd->m_poseHistory->SetTransform(GetRawZeroPose());
                 }
@@ -364,10 +364,10 @@ void VideoErrorReportReceive() {
     }
 }
 
-void HmdConnected() {
+void RequestDriverResync() {
     if (g_driver_provider.hmd) {
         vr::VRServerDriverHost()->VendorSpecificEvent(
-            g_driver_provider.hmd->object_id, VendorEvent_ALVRHmdConnected, {}, 0);
+            g_driver_provider.hmd->object_id, VendorEvent_ALVRDriverResync, {}, 0);
     }
 }
 

--- a/alvr/server/cpp/alvr_server/bindings.h
+++ b/alvr/server/cpp/alvr_server/bindings.h
@@ -147,6 +147,7 @@ extern "C" void SetTracking(unsigned long long targetTimestampNs,
                             const FfiBodyTracker *bodyTrackers,
                             int bodyTrackersCount);
 extern "C" void VideoErrorReportReceive();
+extern "C" void HmdConnected();
 extern "C" void ShutdownSteamvr();
 
 extern "C" void SetOpenvrProperty(unsigned long long deviceID, FfiOpenvrProperty prop);

--- a/alvr/server/cpp/alvr_server/bindings.h
+++ b/alvr/server/cpp/alvr_server/bindings.h
@@ -147,7 +147,7 @@ extern "C" void SetTracking(unsigned long long targetTimestampNs,
                             const FfiBodyTracker *bodyTrackers,
                             int bodyTrackersCount);
 extern "C" void VideoErrorReportReceive();
-extern "C" void HmdConnected();
+extern "C" void RequestDriverResync();
 extern "C" void ShutdownSteamvr();
 
 extern "C" void SetOpenvrProperty(unsigned long long deviceID, FfiOpenvrProperty prop);

--- a/alvr/server/cpp/alvr_server/include/openvr_math.h
+++ b/alvr/server/cpp/alvr_server/include/openvr_math.h
@@ -297,5 +297,45 @@ namespace vrmath {
 		result.m[2][3] = a.m[2][3];
 		return result;
 	}
+
+  inline vr::HmdMatrix34_t matInv33(const vr::HmdMatrix34_t &matrix) {
+    vr::HmdMatrix34_t result;
+    float cofac00 = matrix.m[1][1] * matrix.m[2][2] - matrix.m[1][2] * matrix.m[2][1];
+    float cofac10 = matrix.m[1][2] * matrix.m[2][0] - matrix.m[1][0] * matrix.m[2][2];
+    float cofac20 = matrix.m[1][0] * matrix.m[2][1] - matrix.m[1][1] * matrix.m[2][0];
+
+    float det = matrix.m[0][0] * cofac00 + matrix.m[0][1] * cofac10 + matrix.m[0][2] * cofac20;
+
+    if (det == 0) {
+        vr::HmdMatrix34_t result = { { { 1.0, 0.0, 0.0, 0.0 }, { 0.0, 1.0, 0.0, 0.0 }, { 0.0, 0.0, 1.0, 0.0 } } };
+        return result;
+    }
+
+    float invDet = 1.0f / det;
+
+    float cofac01 = matrix.m[0][2] * matrix.m[2][1] - matrix.m[0][1] * matrix.m[2][2];
+    float cofac02 = matrix.m[0][1] * matrix.m[1][2] - matrix.m[0][2] * matrix.m[1][1];
+    float cofac11 = matrix.m[0][0] * matrix.m[2][2] - matrix.m[0][2] * matrix.m[2][0];
+    float cofac12 = matrix.m[0][2] * matrix.m[1][0] - matrix.m[0][0] * matrix.m[1][2];
+    float cofac21 = matrix.m[0][1] * matrix.m[2][0] - matrix.m[0][0] * matrix.m[2][1];
+    float cofac22 = matrix.m[0][0] * matrix.m[1][1] - matrix.m[0][1] * matrix.m[1][0];
+
+    result.m[0][0] = invDet * cofac00;
+    result.m[0][1] = invDet * cofac01;
+    result.m[0][2] = invDet * cofac02;
+    result.m[0][3] = 0.0f;
+
+    result.m[1][0] = invDet * cofac10;
+    result.m[1][1] = invDet * cofac11;
+    result.m[1][2] = invDet * cofac12;
+    result.m[1][3] = 0.0f;
+
+    result.m[2][0] = invDet * cofac20;
+    result.m[2][1] = invDet * cofac21;
+    result.m[2][2] = invDet * cofac22;
+    result.m[2][3] = 0.0f;
+
+    return result;
+  }
 }
 

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -1001,7 +1001,7 @@ fn connection_pipeline(
     let statistics_thread = thread::spawn({
         let client_hostname = client_hostname.clone();
         move || {
-            let mut last_resync = Instant::now();
+            let mut _last_resync = Instant::now();
             while is_streaming(&client_hostname) {
                 let data = match statics_receiver.recv(STREAMING_RECV_TIMEOUT) {
                     Ok(stats) => stats,
@@ -1015,18 +1015,10 @@ fn connection_pipeline(
                 if let Some(stats) = &mut *STATISTICS_MANAGER.lock() {
                     let timestamp = client_stats.target_timestamp;
                     let decoder_latency = client_stats.video_decode;
-                    let (network_latency, game_latency) = stats.report_statistics(client_stats);
+                    let (network_latency, _game_latency) = stats.report_statistics(client_stats);
 
-                    if game_latency.as_secs_f32() > 0.25 {
-                        let now = Instant::now();
-                        if now.saturating_duration_since(last_resync).as_secs_f32() > 0.1 {
-                            last_resync = now;
-                            warn!("Desync detected. Attempting recovery.");
-                            unsafe {
-                                crate::RequestDriverResync();
-                            }
-                        }
-                    }
+                    #[cfg(target_os = "linux")]
+                    detect_desync(&_game_latency, &mut _last_resync);
 
                     let server_data_lock = SERVER_DATA_MANAGER.read();
                     BITRATE_MANAGER.lock().report_frame_latencies(
@@ -1454,5 +1446,19 @@ pub extern "C" fn send_haptics(device_id: u64, duration_s: f32, frequency: f32, 
         sender
             .send_header(&haptics::map_haptics(&config, haptics))
             .ok();
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn detect_desync(game_latency: &Duration, last_resync: &mut Instant) {
+    if game_latency.as_secs_f32() > 0.25 {
+        let now = Instant::now();
+        if now.saturating_duration_since(*last_resync).as_secs_f32() > 0.1 {
+            *last_resync = now;
+            warn!("Desync detected. Attempting recovery.");
+            unsafe {
+                crate::RequestDriverResync();
+            }
+        }
     }
 }

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -1001,6 +1001,7 @@ fn connection_pipeline(
     let statistics_thread = thread::spawn({
         let client_hostname = client_hostname.clone();
         move || {
+            let mut last_resync = Instant::now();
             while is_streaming(&client_hostname) {
                 let data = match statics_receiver.recv(STREAMING_RECV_TIMEOUT) {
                     Ok(stats) => stats,
@@ -1014,7 +1015,18 @@ fn connection_pipeline(
                 if let Some(stats) = &mut *STATISTICS_MANAGER.lock() {
                     let timestamp = client_stats.target_timestamp;
                     let decoder_latency = client_stats.video_decode;
-                    let network_latency = stats.report_statistics(client_stats);
+                    let (network_latency, game_latency) = stats.report_statistics(client_stats);
+
+                    if game_latency.as_secs_f32() > 0.25 {
+                        let now = Instant::now();
+                        if now.saturating_duration_since(last_resync).as_secs_f32() > 0.1 {
+                            last_resync = now;
+                            warn!("Desync detected. Attempting recovery.");
+                            unsafe {
+                                crate::RequestDriverResync();
+                            }
+                        }
+                    }
 
                     let server_data_lock = SERVER_DATA_MANAGER.read();
                     BITRATE_MANAGER.lock().report_frame_latencies(
@@ -1075,7 +1087,7 @@ fn connection_pipeline(
         move || {
             unsafe {
                 crate::InitOpenvrClient();
-                crate::HmdConnected();
+                crate::RequestDriverResync();
             }
 
             let mut disconnection_deadline = Instant::now() + KEEPALIVE_TIMEOUT;

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -1073,7 +1073,10 @@ fn connection_pipeline(
         let control_sender = Arc::clone(&control_sender);
         let client_hostname = client_hostname.clone();
         move || {
-            unsafe { crate::InitOpenvrClient() };
+            unsafe {
+                crate::InitOpenvrClient();
+                crate::HmdConnected();
+            }
 
             let mut disconnection_deadline = Instant::now() + KEEPALIVE_TIMEOUT;
             while is_streaming(&client_hostname) {

--- a/alvr/server/src/statistics.rs
+++ b/alvr/server/src/statistics.rs
@@ -182,7 +182,7 @@ impl StatisticsManager {
 
     // Called every frame. Some statistics are reported once every frame
     // Returns network latency
-    pub fn report_statistics(&mut self, client_stats: ClientStatistics) -> Duration {
+    pub fn report_statistics(&mut self, client_stats: ClientStatistics) -> (Duration, Duration) {
         if let Some(frame) = self
             .history_buffer
             .iter_mut()
@@ -297,9 +297,9 @@ impl StatisticsManager {
                 actual_bitrate_bps: bitrate_bps,
             }));
 
-            network_latency
+            (network_latency, game_time_latency)
         } else {
-            Duration::ZERO
+            (Duration::ZERO, Duration::ZERO)
         }
     }
 

--- a/alvr/server/src/statistics.rs
+++ b/alvr/server/src/statistics.rs
@@ -181,7 +181,7 @@ impl StatisticsManager {
     }
 
     // Called every frame. Some statistics are reported once every frame
-    // Returns network latency
+    // Returns (network latency, game time latency)
     pub fn report_statistics(&mut self, client_stats: ClientStatistics) -> (Duration, Duration) {
         if let Some(frame) = self
             .history_buffer


### PR DESCRIPTION
Closes https://github.com/alvr-org/ALVR/issues/2013

What was changed:
- mat3x3 multiplication in `OnPoseUpdated` was wrong
  - replaced with `vrmath::matMul33`
  - this alone fixed playspace rotation but only while using standing universe
- do not throw away queued poses when playspace changes
  - with the old logic, there would be ~1s drunken period
  - transition is smooth after the change
- switch to `VRApplication_Background`
  -  this is to get access to `GetTrackingSpace()` which tells us if the universe is seated or standing
- pull seated or standing transform based on current universe
- handle more events that can cause the playspace to shift
  - previously, it would only trigger on universe change (standing <> seated)
- `InitOpenvrClient` and `ShutdownOpenvrClient` are now state-aware
- An automatic recovery mechanism was added that triggers if the reported game_render time goes above 250ms.

Thanks to @Vixea for gathering info & testing