### PR TITLE
fix(client): reconnect default audio device on disconnect

### DIFF
--- a/alvr/client_core/src/audio.rs
+++ b/alvr/client_core/src/audio.rs
@@ -140,9 +140,9 @@ impl AudioOutputCallback for PlayerCallback {
     fn on_error_before_close(
         &mut self,
         _audio_stream: &mut dyn AudioOutputStreamSafe,
-        _error: oboe::Error,
+        error: oboe::Error,
     ) {
-        *self.state.lock() = AudioPlaybackState::Err(_error.into());
+        *self.state.lock() = AudioPlaybackState::Err(error);
     }
 }
 
@@ -202,7 +202,7 @@ pub fn play_audio_loop(
 
     let result = match *state.lock() {
         AudioPlaybackState::Err(error) => Err(error.into()),
-        _ => Ok(()),
+        AudioPlaybackState::Playing => Ok(()),
     };
     result
 }

--- a/alvr/client_core/src/audio.rs
+++ b/alvr/client_core/src/audio.rs
@@ -166,7 +166,6 @@ pub fn play_audio_loop(
         sample_rate as usize * config.average_buffering_ms as usize / 1000;
 
     let sample_buffer = Arc::new(Mutex::new(VecDeque::new()));
-    let device_connected = Arc::new(Mutex::new(true));
     let state = Arc::new(Mutex::new(AudioPlaybackState::Playing));
 
     let mut stream = AudioStreamBuilder::default()

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -339,20 +339,41 @@ fn connection_pipeline(
     });
 
     let game_audio_thread = if let Switch::Enabled(config) = settings.audio.game_audio {
-        let device = AudioDevice::new_output(None, None).to_con()?;
-
+        let mut device = AudioDevice::new_output(None, None).to_con()?;
         thread::spawn({
             let ctx = Arc::clone(&ctx);
             move || {
                 while is_streaming(&ctx) {
-                    alvr_common::show_err(audio::play_audio_loop(
+                    info!("Audio output started");
+                    let res = audio::play_audio_loop(
                         || is_streaming(&ctx),
                         &device,
                         2,
                         negotiated_config.game_audio_sample_rate,
                         config.buffering.clone(),
                         &mut game_audio_receiver,
-                    ));
+                    );
+                    match res {
+                        Ok(()) => break,
+                        Err(e) => match e.downcast_ref::<oboe::Error>() {
+                            Some(oboe::Error::Disconnected) => {
+                                warn!("Audio output device disconnected, trying to reconnect");
+                                match AudioDevice::new_output(None, None) {
+                                    Ok(new_device) => {
+                                        device = new_device;
+                                    }
+                                    Err(e) => {
+                                        error!("Failed to reopen default audio device: {e}");
+                                        break;
+                                    }
+                                }
+                            }
+                            _ => {
+                                error!("Audio playback error: {e}");
+                                break;
+                            }
+                        },
+                    }
                 }
             }
         })


### PR DESCRIPTION
This makes it possible to plug in your headphones without restarting the client(Fixes #1092).

I am still new to rust and not sure if this is best way to solve this but it works for me and it annoyed me a bunch. Open for suggestions!



