### PR TITLE
Fix swapchain unsupported on Lynx R1

### DIFF
--- a/alvr/client_openxr/src/graphics.rs
+++ b/alvr/client_openxr/src/graphics.rs
@@ -105,7 +105,7 @@ pub fn create_swapchain(
         glow::RGBA16F,
         glow::RGB16F,
         glow::SRGB8_ALPHA8,
-        glow::SRGB8_ALPHA8,
+        glow::SRGB8,
         glow::RGBA8,
         glow::BGRA,
         glow::RGB8,


### PR DESCRIPTION
Apparently Qualcomm's OpenXR runtime doesn't do RGBA16F, so now we have to run through a priority-sorted list of swapchain formats and pick the best one we can get.