### PR TITLE
fix: SetChaperoneArea crash

### DIFF
--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -431,7 +431,9 @@ pub extern "C" fn alvr_send_battery(device_id: u64, gauge_value: f32, is_plugged
 #[no_mangle]
 pub extern "C" fn alvr_send_playspace(width: f32, height: f32) {
     if let Some(context) = &*CLIENT_CORE_CONTEXT.lock() {
-        context.send_playspace(if width != 0.0 && height != 0.0 {
+        let wh = width * height;
+        // If either is NaN/Inf, the product will be NaN/Inf
+        context.send_playspace(if wh.is_finite() && wh > 0.0 {
             Some(Vec2::new(width, height))
         } else {
             None

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -431,13 +431,7 @@ pub extern "C" fn alvr_send_battery(device_id: u64, gauge_value: f32, is_plugged
 #[no_mangle]
 pub extern "C" fn alvr_send_playspace(width: f32, height: f32) {
     if let Some(context) = &*CLIENT_CORE_CONTEXT.lock() {
-        let wh = width * height;
-        // If either is NaN/Inf, the product will be NaN/Inf
-        context.send_playspace(if wh.is_finite() && wh > 0.0 {
-            Some(Vec2::new(width, height))
-        } else {
-            None
-        });
+        context.send_playspace(Some(Vec2::new(width, height)));
     }
 }
 

--- a/alvr/server/cpp/alvr_server/ChaperoneUpdater.cpp
+++ b/alvr/server/cpp/alvr_server/ChaperoneUpdater.cpp
@@ -70,7 +70,6 @@ void _SetChaperoneArea(float areaWidth, float areaHeight) {
     perimeterPoints[3][0] = 1.0f * areaWidth;
     perimeterPoints[3][1] = -1.0f * areaHeight;
 
-    vr::VRChaperoneSetup()->RoomSetupStarting();
     vr::VRChaperoneSetup()->SetWorkingPerimeter(
         reinterpret_cast<vr::HmdVector2_t *>(perimeterPoints), 4);
     vr::VRChaperoneSetup()->SetWorkingStandingZeroPoseToRawTrackingPose(&MATRIX_IDENTITY);

--- a/alvr/server/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server/cpp/alvr_server/alvr_server.cpp
@@ -429,12 +429,6 @@ void SetButton(unsigned long long buttonID, FfiButtonValue value) {
 
 void SetChaperoneArea(float areaWidth, float areaHeight) {
     _SetChaperoneArea(areaWidth, areaHeight);
-
-#ifdef __linux__
-    if (g_driver_provider.hmd && g_driver_provider.hmd->m_poseHistory) {
-        g_driver_provider.hmd->m_poseHistory->SetTransform(GetRawZeroPose());
-    }
-#endif
 }
 
 void CaptureFrame() {

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -1122,6 +1122,7 @@ fn connection_pipeline(
                                 unsafe { crate::SetChaperoneArea(area.x, area.y) };
                             } else {
                                 warn!("Received invalid playspace size: {}", area);
+                                unsafe { crate::SetChaperoneArea(2.0, 2.0) };
                             }
                         }
                     }

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -1116,7 +1116,13 @@ fn connection_pipeline(
                             );
 
                             let area = packet.unwrap_or(Vec2::new(2.0, 2.0));
-                            unsafe { crate::SetChaperoneArea(area.x, area.y) };
+                            let wh = area.x * area.y;
+                            if wh.is_finite() && wh > 0.0 {
+                                info!("Received new playspace with size: {}", area);
+                                unsafe { crate::SetChaperoneArea(area.x, area.y) };
+                            } else {
+                                warn!("Received invalid playspace size: {}", area);
+                            }
                         }
                     }
                     ClientControlPacket::RequestIdr => {


### PR DESCRIPTION
Fixes a segfault in `vrclient.so` originating from `SetChaperoneArea`.

Changes:
- Client: ensure that width and height are finite and not 0
- do not `GetRawZeroPose` from `SetChaperoneArea`. setting the play area will trigger a steamvr event that will cause ALVR to `GetRawZeroPose` in a separate thread. the segfault is likely due to this race condition.
- remove RoomSetupStarting because it's not needed