### PR TITLE
fix(dashboard): 🐛 Check for vrserver instead of vrcompositor, fix first-time startup

### DIFF
--- a/alvr/dashboard/src/steamvr_launcher.rs
+++ b/alvr/dashboard/src/steamvr_launcher.rs
@@ -39,12 +39,16 @@ pub fn maybe_wrap_vrcompositor_launcher() -> alvr_common::anyhow::Result<()> {
     let steamvr_bin_dir = alvr_server_io::steamvr_root_dir()?
         .join("bin")
         .join("linux64");
-    let launcher_path = steamvr_bin_dir.join("vrcompositor");
-    match launcher_path.try_exists() {
+    let steamvr_vrserver_path = steamvr_bin_dir.join("vrserver");
+    debug!(
+        "File path used to check for linux files: {}",
+        steamvr_vrserver_path.display().to_string()
+    );
+    match steamvr_vrserver_path.try_exists() {
         Ok(exists) => {
             if !exists {
                 bail!(
-                    "SteamVR linux files missing, aborting startup, please re-check compatibility tools for SteamVR."
+                    "SteamVR linux files missing, aborting startup, please re-check compatibility tools for SteamVR or verify integrity of files for SteamVR."
                 );
             }
         }
@@ -53,6 +57,7 @@ pub fn maybe_wrap_vrcompositor_launcher() -> alvr_common::anyhow::Result<()> {
         }
     };
 
+    let launcher_path = steamvr_bin_dir.join("vrcompositor");
     // In case of SteamVR update, vrcompositor will be restored
     if fs::read_link(&launcher_path).is_ok() {
         fs::remove_file(&launcher_path)?; // recreate the link


### PR DESCRIPTION
Small fixes, wasn't correctly working for first-time startup (also added logging, verifying just in case)