### PR TITLE
fix(ci): 🐛 Enable GPL on linux build and remove AppImage from CI

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -137,10 +137,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libfuse2 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit libgtk-3-dev
-          git clone https://github.com/FFmpeg/nv-codec-headers.git
-          cd nv-codec-headers/
-          sudo make install
-          cd ..
           cp alvr/xtask/deb/cuda.pc /usr/share/pkgconfig
           cargo xtask prepare-deps --platform linux
 
@@ -148,7 +144,7 @@ jobs:
         id: build
         env:
           RUST_BACKTRACE: 1
-        run: cargo xtask package-streamer
+        run: cargo xtask package-streamer --gpl
 
       - name: Upload streamer for Linux
         uses: actions/upload-release-asset@v1
@@ -159,31 +155,6 @@ jobs:
           asset_path: ./build/alvr_streamer_linux.tar.gz
           asset_name: alvr_streamer_linux.tar.gz
           asset_content_type: application/gzip
-
-      - name: Build and package ALVR portable (.AppImage)
-        id: build_portable
-        env:
-          RUST_BACKTRACE: 1
-        run: cargo xtask package-streamer --appimage --zsync
-
-      - name: Upload portable streamer for Linux
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/ALVR-x86_64.AppImage
-          asset_name: ALVR-x86_64.AppImage
-          asset_content_type: application/x-executable
-      - name: Upload portable streamer for Linux (zsync)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/ALVR-x86_64.AppImage.zsync
-          asset_name: ALVR-x86_64.AppImage.zsync
-          asset_content_type: application/octet-stream
 
   build_flatpak_bundle:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Same deal as on nightlies

### Merge only after it gets tested at least on nightlies, otherwise i don't know if it works on nvidia (double-checking removal of nc-codec-headers)