### PR TITLE
fix(client_openxr): only use float16 swapchains if HDR is on

### DIFF
--- a/alvr/client_openxr/src/lobby.rs
+++ b/alvr/client_openxr/src/lobby.rs
@@ -19,8 +19,8 @@ impl Lobby {
         let reference_space = interaction::get_stage_reference_space(&xr_session);
 
         let swapchains = [
-            graphics::create_swapchain(&xr_session, view_resolution, None),
-            graphics::create_swapchain(&xr_session, view_resolution, None),
+            graphics::create_swapchain(&xr_session, view_resolution, None, false),
+            graphics::create_swapchain(&xr_session, view_resolution, None, false),
         ];
 
         alvr_client_core::opengl::initialize_lobby(

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -154,11 +154,13 @@ impl StreamContext {
                 &xr_ctx.session,
                 config.view_resolution,
                 foveation_profile.as_ref(),
+                config.encoder_config.enable_hdr,
             ),
             graphics::create_swapchain(
                 &xr_ctx.session,
                 config.view_resolution,
                 foveation_profile.as_ref(),
+                config.encoder_config.enable_hdr,
             ),
         ];
 


### PR DESCRIPTION
Some headsets, including but not limited to the Quest 2 and Quest Pro get a severe performance hit when using float16 swapchain formats.

Let's only allow float16 formats if HDR has been explicitly requested.