### PR TITLE
set b_ref_mode=0 for ffmpeg NVENC encoder

### DIFF
--- a/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -151,6 +151,8 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(Renderer *render,
     // Delay isn't actually a delay instead its how many surfaces to encode at a time
     av_opt_set_int(encoder_ctx->priv_data, "delay", 1, 0);
     av_opt_set_int(encoder_ctx->priv_data, "forced-idr", 1, 0);
+    // work around ffmpeg default not working for older NVIDIA cards
+    av_opt_set_int(encoder_ctx->priv_data, "b_ref_mode", 0, 0);
 
     encoder_ctx->pix_fmt = AV_PIX_FMT_CUDA;
     encoder_ctx->width = width;


### PR DESCRIPTION
Older NVIDIA cards (e.g. GTX 1650) don't support this feature, and
ffmpeg somehow force-enabled it, despite docs saying it should be set to
"auto", and --help saying the default is "disabled". Setting it to
"disabled" in the encoder works around this issue.

ALVR does not currently use multiple B frames, so there should be no
difference and no obvious difference was visible when testing.

The feature is documented as:
"Using B frame as a reference improves subjective and objective encoded
quality with no performance impact. Hence the users enabling multiple B
frames are strongly recommended to enable this feature."

----

Wise man @nowrep said: "just disable it, it's ffmpeg or nvenc bug (it shouldn't explode on this not being supported when b-frames are not used)"

See https://github.com/alvr-org/ALVR/issues/2064 for someone saying this workaround does work for them on an older card. I didn't notice anything different on a 3090 with 550 drivers and cuda 12.4.