### PR TITLE
Add firewall rules for iptables on linux

### DIFF
--- a/alvr/xtask/firewall/alvr_fw_config.sh
+++ b/alvr/xtask/firewall/alvr_fw_config.sh
@@ -14,18 +14,18 @@ firewalld_cfg() {
         if [ "${1}" == 'add' ]; then
             # If running or permanent alvr service is missing, add it
             if ! firewall-cmd --zone="${zone}" --list-services | grep 'alvr' >/dev/null 2>&1; then
-                firewall-cmd --zone="${zone}"  --add-service='alvr'
+                firewall-cmd --zone="${zone}" --add-service='alvr'
             fi
             if ! firewall-cmd --zone="${zone}" --list-services --permanent | grep 'alvr' >/dev/null 2>&1; then
-                firewall-cmd --zone="${zone}"  --add-service='alvr' --permanent
+                firewall-cmd --zone="${zone}" --add-service='alvr' --permanent
             fi
         elif [ "${1}" == 'remove' ]; then
             # If running or persistent alvr service exists, remove it
             if firewall-cmd --zone="${zone}" --list-services | grep 'alvr' >/dev/null 2>&1; then
-                firewall-cmd --zone="${zone}"  --remove-service='alvr'
+                firewall-cmd --zone="${zone}" --remove-service='alvr'
             fi
             if firewall-cmd --zone="${zone}" --list-services --permanent | grep 'alvr' >/dev/null 2>&1; then
-                firewall-cmd --zone="${zone}"  --remove-service='alvr' --permanent
+                firewall-cmd --zone="${zone}" --remove-service='alvr' --permanent
             fi
         else
             exit 2
@@ -55,6 +55,38 @@ ufw_cfg() {
     fi
 }
 
+iptables_cfg() {
+    first_port_match_count=$(iptables -S | grep -c '9943')
+    second_port_match_count=$(iptables -S | grep -c '9944')
+    if [ "${1}" == 'add' ]; then
+        if [ "$first_port_match_count" != "4" ] || [ "$second_port_match_count" != "4" ]; then
+            iptables -I OUTPUT -p tcp --sport 9943 -j ACCEPT
+            iptables -I INPUT -p tcp --dport 9943 -j ACCEPT
+            iptables -I OUTPUT -p udp --sport 9943 -j ACCEPT
+            iptables -I INPUT -p udp --dport 9943 -j ACCEPT
+            iptables -I OUTPUT -p tcp --sport 9944 -j ACCEPT
+            iptables -I INPUT -p tcp --dport 9944 -j ACCEPT
+            iptables -I OUTPUT -p udp --sport 9944 -j ACCEPT
+            iptables -I INPUT -p udp --dport 9944 -j ACCEPT
+            iptables-save >/etc/iptables/rules.v4
+        fi
+    elif [ "${1}" == 'remove' ]; then
+        if [ "$first_port_match_count" == "4" ] || [ "$second_port_match_count" == "4" ]; then
+            iptables -D OUTPUT -p tcp --sport 9943 -j ACCEPT
+            iptables -D INPUT -p tcp --dport 9943 -j ACCEPT
+            iptables -D OUTPUT -p udp --sport 9943 -j ACCEPT
+            iptables -D INPUT -p udp --dport 9943 -j ACCEPT
+            iptables -D OUTPUT -p tcp --sport 9944 -j ACCEPT
+            iptables -D INPUT -p tcp --dport 9944 -j ACCEPT
+            iptables -D OUTPUT -p udp --sport 9944 -j ACCEPT
+            iptables -D INPUT -p udp --dport 9944 -j ACCEPT
+            iptables-save >/etc/iptables/rules.v4
+        fi
+    else
+        exit 2
+    fi
+}
+
 main() {
     # If we're not root use pkexec for GUI prompt
     if [ "${USER}" == 'root' ]; then
@@ -64,6 +96,8 @@ main() {
         # Check if ufw exists and is running
         elif which ufw >/dev/null 2>&1 && ! ufw status | grep 'Status: inactive' >/dev/null 2>&1; then
             ufw_cfg "${1,,}"
+        elif which iptables >/dev/null 2>&1; then
+            iptables_cfg "${1,,}"
         else
             exit 99
         fi

--- a/alvr/xtask/firewall/alvr_fw_config.sh
+++ b/alvr/xtask/firewall/alvr_fw_config.sh
@@ -59,7 +59,7 @@ iptables_cfg() {
     first_port_match_count=$(iptables -S | grep -c '9943')
     second_port_match_count=$(iptables -S | grep -c '9944')
     if [ "${1}" == 'add' ]; then
-        if [ "$first_port_match_count" != "4" ] || [ "$second_port_match_count" != "4" ]; then
+        if [ "$first_port_match_count" == "0" ] || [ "$second_port_match_count" == "0" ]; then
             iptables -I OUTPUT -p tcp --sport 9943 -j ACCEPT
             iptables -I INPUT -p tcp --dport 9943 -j ACCEPT
             iptables -I OUTPUT -p udp --sport 9943 -j ACCEPT


### PR DESCRIPTION
Figured that it's easy enough to add and will prevent errors in setup for those who doesn't have ufw/firewalld