### PR TITLE
Fix panic message boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Release
 
 # editor
 .vs/
+.idea/
 
 # NuGet Packages
 *.nupkg

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -47,13 +47,15 @@ pub fn set_panic_hook() {
             Backtrace::new()
         );
 
-        log::error!("{err_str}");
+        let short_err_str = panic_info.to_string();
+
+        log::error!("ALVR panicked: {err_str}");
 
         #[cfg(all(not(target_os = "android"), feature = "enable-messagebox"))]
         std::thread::spawn(move || {
             rfd::MessageDialog::new()
                 .set_title("ALVR panicked")
-                .set_description(&err_str)
+                .set_description(&short_err_str)
                 .set_level(rfd::MessageLevel::Error)
                 .show();
         });


### PR DESCRIPTION
Problem: when alvr-server panics, it displays a message box with the panic info. But the rfd::MessageDialog replaces the whole message box content with just "An error occuried" which is not really informative. I played around it a little bit and it seems that it does not accept the panic info as the message box content. 

Solution: Shorten the info to display. After that the message box is displayed normally. 