### PR TITLE
Fix linux segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Release
 
 # editor
 .vs/
+.idea/
 
 # NuGet Packages
 *.nupkg

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ node_modules
 .flatpak*
 
 ALVR-Launcher
+
+#allows adding CMake files for some IDEs to parse C++ files correctly
+CMakeLists.txt
+cmake-build-debug/

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -47,13 +47,15 @@ pub fn set_panic_hook() {
             Backtrace::new()
         );
 
-        log::error!("{err_str}");
+        let short_err_str = panic_info.to_string();
+
+        log::error!("ALVR panicked: {err_str}");
 
         #[cfg(all(not(target_os = "android"), feature = "enable-messagebox"))]
         std::thread::spawn(move || {
             rfd::MessageDialog::new()
                 .set_title("ALVR panicked")
-                .set_description(&err_str)
+                .set_description(&short_err_str)
                 .set_level(rfd::MessageLevel::Error)
                 .show();
         });

--- a/alvr/server/cpp/alvr_server/include/openvr_math.h
+++ b/alvr/server/cpp/alvr_server/include/openvr_math.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cmath>
-
+#include <memory>
 
 inline vr::HmdQuaternion_t operator+(const vr::HmdQuaternion_t& lhs, const vr::HmdQuaternion_t& rhs) {
 	return {
@@ -298,42 +298,42 @@ namespace vrmath {
 		return result;
 	}
 
-  inline vr::HmdMatrix34_t matInv33(const vr::HmdMatrix34_t &matrix) {
-    vr::HmdMatrix34_t result;
-    float cofac00 = matrix.m[1][1] * matrix.m[2][2] - matrix.m[1][2] * matrix.m[2][1];
-    float cofac10 = matrix.m[1][2] * matrix.m[2][0] - matrix.m[1][0] * matrix.m[2][2];
-    float cofac20 = matrix.m[1][0] * matrix.m[2][1] - matrix.m[1][1] * matrix.m[2][0];
+  inline std::unique_ptr<vr::HmdMatrix34_t> matInv33(std::unique_ptr<vr::HmdMatrix34_t> matrix) {
+    std::unique_ptr<vr::HmdMatrix34_t> result;
+    float cofac00 = matrix->m[1][1] * matrix->m[2][2] - matrix->m[1][2] * matrix->m[2][1];
+    float cofac10 = matrix->m[1][2] * matrix->m[2][0] - matrix->m[1][0] * matrix->m[2][2];
+    float cofac20 = matrix->m[1][0] * matrix->m[2][1] - matrix->m[1][1] * matrix->m[2][0];
 
-    float det = matrix.m[0][0] * cofac00 + matrix.m[0][1] * cofac10 + matrix.m[0][2] * cofac20;
+    float det = matrix->m[0][0] * cofac00 + matrix->m[0][1] * cofac10 + matrix->m[0][2] * cofac20;
 
     if (det == 0) {
         vr::HmdMatrix34_t result = { { { 1.0, 0.0, 0.0, 0.0 }, { 0.0, 1.0, 0.0, 0.0 }, { 0.0, 0.0, 1.0, 0.0 } } };
-        return result;
+        return std::make_unique<vr::HmdMatrix34_t>(result);
     }
 
     float invDet = 1.0f / det;
 
-    float cofac01 = matrix.m[0][2] * matrix.m[2][1] - matrix.m[0][1] * matrix.m[2][2];
-    float cofac02 = matrix.m[0][1] * matrix.m[1][2] - matrix.m[0][2] * matrix.m[1][1];
-    float cofac11 = matrix.m[0][0] * matrix.m[2][2] - matrix.m[0][2] * matrix.m[2][0];
-    float cofac12 = matrix.m[0][2] * matrix.m[1][0] - matrix.m[0][0] * matrix.m[1][2];
-    float cofac21 = matrix.m[0][1] * matrix.m[2][0] - matrix.m[0][0] * matrix.m[2][1];
-    float cofac22 = matrix.m[0][0] * matrix.m[1][1] - matrix.m[0][1] * matrix.m[1][0];
+    float cofac01 = matrix->m[0][2] * matrix->m[2][1] - matrix->m[0][1] * matrix->m[2][2];
+    float cofac02 = matrix->m[0][1] * matrix->m[1][2] - matrix->m[0][2] * matrix->m[1][1];
+    float cofac11 = matrix->m[0][0] * matrix->m[2][2] - matrix->m[0][2] * matrix->m[2][0];
+    float cofac12 = matrix->m[0][2] * matrix->m[1][0] - matrix->m[0][0] * matrix->m[1][2];
+    float cofac21 = matrix->m[0][1] * matrix->m[2][0] - matrix->m[0][0] * matrix->m[2][1];
+    float cofac22 = matrix->m[0][0] * matrix->m[1][1] - matrix->m[0][1] * matrix->m[1][0];
 
-    result.m[0][0] = invDet * cofac00;
-    result.m[0][1] = invDet * cofac01;
-    result.m[0][2] = invDet * cofac02;
-    result.m[0][3] = 0.0f;
+    result->m[0][0] = invDet * cofac00;
+    result->m[0][1] = invDet * cofac01;
+    result->m[0][2] = invDet * cofac02;
+    result->m[0][3] = 0.0f;
 
-    result.m[1][0] = invDet * cofac10;
-    result.m[1][1] = invDet * cofac11;
-    result.m[1][2] = invDet * cofac12;
-    result.m[1][3] = 0.0f;
+    result->m[1][0] = invDet * cofac10;
+    result->m[1][1] = invDet * cofac11;
+    result->m[1][2] = invDet * cofac12;
+    result->m[1][3] = 0.0f;
 
-    result.m[2][0] = invDet * cofac20;
-    result.m[2][1] = invDet * cofac21;
-    result.m[2][2] = invDet * cofac22;
-    result.m[2][3] = 0.0f;
+    result->m[2][0] = invDet * cofac20;
+    result->m[2][1] = invDet * cofac21;
+    result->m[2][2] = invDet * cofac22;
+    result->m[2][3] = 0.0f;
 
     return result;
   }


### PR DESCRIPTION
Problem: on linux, when GetRawZeroPose is called in alvr_server.cpp, the code first checks if OpenVR is initialized. If it is, GetRawZeroPose is called. But in between the check and the call something can call ShutdownOpenvrClient concurrently (and that's what's happening on my machine), and this leads to SEGFAULT because vr::VRCompositor() or vr::VRChaperoneSetup() in GetInvZeroPose returns NULL and the further calls happen on NULL objects. 

Solution: add GetRawZeroPose ability to return nullptr if OpenVR is not initialized and do nothing in this case. Also add the same lock to GetInvZeroPose as all the functions above it use. 

Solution 2: just an idea and not implemented in this PR. The whole ChaperoneUpdater can be separated to a class and be used atomically/with mutex. 

P.S. My previous PR which is not merged yet is included into this one, so it has a bit more code than it should have.