### PR TITLE
Clarify link names in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ assignees: ''
 
 ## General Troubleshooting
 - [ ] I carefully followed the instructions in the [README](https://github.com/alvr-org/ALVR/blob/master/README.md) and successfully completed the setup wizard
-- [ ] I read the ALVR Wikis [here](https://github.com/polygraphene/ALVR/wiki) and [here](https://github.com/alvr-org/ALVR/wiki)
+- [ ] I read the ALVR Wikis [polygraphene's ALVR GitHub Wiki](https://github.com/polygraphene/ALVR/wiki) and [ALVR GitHub Wiki](https://github.com/alvr-org/ALVR/wiki)
 
 ## Environment
 


### PR DESCRIPTION
"here" is not a name. It does not describe the link. The main reason this is bad is screen readers often list many/most links in a page and usually aren't going to read out the domain or link. Secondly, you have to read the context around the link to understand what is for. Thirdly, it doesn't say what the link is to or where it's from.