### PR TITLE
chore(client): :rocket: Update manifest for AppLab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ ALVR-Launcher
 #allows adding CMake files for some IDEs to parse C++ files correctly
 CMakeLists.txt
 cmake-build-debug/
+
+*.jks

--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -28,6 +28,7 @@ ndk-context = "0.1"
 
 [package.metadata.android]
 package = "alvr.client"
+install_location = "auto"
 build_targets = ["aarch64-linux-android"]
 runtime_libs = "../../deps/android_openxr"
 
@@ -41,7 +42,7 @@ keystore_password = "alvrclient"
 
 [package.metadata.android.sdk]
 min_sdk_version = 26
-target_sdk_version = 29
+target_sdk_version = 32
 
 [[package.metadata.android.uses_feature]]
 name = "android.hardware.microphone"
@@ -64,8 +65,6 @@ name = "android.permission.INTERNET"
 [[package.metadata.android.uses_permission]]
 name = "android.permission.RECORD_AUDIO"
 [[package.metadata.android.uses_permission]]
-name = "android.permission.WAKE_LOCK"
-[[package.metadata.android.uses_permission]]
 name = "org.khronos.openxr.permission.OPENXR"
 [[package.metadata.android.uses_permission]]
 name = "org.khronos.openxr.permission.OPENXR_SYSTEM"
@@ -75,7 +74,7 @@ name = "org.khronos.openxr"
 authorities = "org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker"
 
 [package.metadata.android.application]
-debuggable = true
+debuggable = false
 theme = "@android:style/Theme.Black.NoTitleBar.Fullscreen"
 # icon = todo
 label = "ALVR"
@@ -107,9 +106,6 @@ required = false
 [[package.metadata.android.uses_feature]]
 name = "com.oculus.software.body_tracking"
 required = false
-[[package.metadata.android.uses_feature]]
-name = "com.oculus.experimental.enabled"
-required = false
 [[package.metadata.android.uses_permission]]
 name = "com.oculus.permission.EYE_TRACKING"
 [[package.metadata.android.uses_permission]]
@@ -125,7 +121,7 @@ name = "com.oculus.intent.category.VR"
 value = "vr_only"
 [[package.metadata.android.application.meta_data]]
 name = "com.oculus.supportedDevices"
-value = "all"
+value = "quest|quest2|questpro"
 [[package.metadata.android.application.meta_data]]
 name = "com.oculus.vr.focusaware"
 value = "true"

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -122,14 +122,14 @@ pub fn entry_point() {
         | Platform::Quest2
         | Platform::Quest3
         | Platform::QuestPro
-        | Platform::QuestUnknown => "quest",
-        Platform::PicoNeo3 | Platform::Pico4 => "pico",
-        Platform::Yvr => "yvr",
-        Platform::Lynx => "lynx",
-        _ => "generic",
+        | Platform::QuestUnknown => "_quest",
+        Platform::PicoNeo3 | Platform::Pico4 => "_pico",
+        Platform::Yvr => "_yvr",
+        Platform::Lynx => "_lynx",
+        _ => "",
     };
     let xr_entry = unsafe {
-        xr::Entry::load_from(Path::new(&format!("libopenxr_loader_{loader_suffix}.so"))).unwrap()
+        xr::Entry::load_from(Path::new(&format!("libopenxr_loader{loader_suffix}.so"))).unwrap()
     };
 
     #[cfg(target_os = "android")]

--- a/alvr/xtask/src/build.rs
+++ b/alvr/xtask/src/build.rs
@@ -372,7 +372,13 @@ pub fn build_android_client(profile: Profile) {
     sh.create_dir(&build_dir).unwrap();
 
     // Create debug keystore (signing will be overwritten by CI)
-    if matches!(profile, Profile::Release | Profile::Distribution) {
+    if env::var(format!(
+        "CARGO_APK_{}_KEYSTORE",
+        profile.to_string().to_uppercase()
+    ))
+    .is_err()
+        && matches!(profile, Profile::Release | Profile::Distribution)
+    {
         let keystore_path = build_dir.join("debug.keystore");
         if !keystore_path.exists() {
             let keytool = PathBuf::from(env::var("JAVA_HOME").unwrap())

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -287,14 +287,14 @@ fn get_android_openxr_loaders() {
         command::download_and_extract_zip(url, &temp_dir).unwrap();
         fs::copy(
             temp_dir.join(source_dir).join("libopenxr_loader.so"),
-            destination_dir.join(format!("libopenxr_loader_{name}.so")),
+            destination_dir.join(format!("libopenxr_loader{name}.so")),
         )
         .unwrap();
         fs::remove_dir_all(&temp_dir).ok();
     }
 
     get_openxr_loader(
-        "generic",
+        "",
         &format!(
             "https://github.com/KhronosGroup/OpenXR-SDK-Source/releases/download/{}",
             "release-1.0.27/openxr_loader_for_android-1.0.27.aar",
@@ -303,25 +303,25 @@ fn get_android_openxr_loaders() {
     );
 
     get_openxr_loader(
-        "quest",
+        "_quest",
         "https://securecdn.oculus.com/binaries/download/?id=7092833820755144", // version 60
         "OpenXR/Libs/Android/arm64-v8a/Release",
     );
 
     get_openxr_loader(
-        "pico",
+        "_pico",
         "https://sdk.picovr.com/developer-platform/sdk/PICO_OpenXR_SDK_220.zip",
         "libs/android.arm64-v8a",
     );
 
     get_openxr_loader(
-        "yvr",
+        "_yvr",
         "https://developer.yvrdream.com/yvrdoc/sdk/openxr/yvr_openxr_mobile_sdk_1.0.0.zip",
         "yvr_openxr_mobile_sdk_1.0.0/OpenXR/Libs/Android/arm64-v8a",
     );
 
     get_openxr_loader(
-        "lynx",
+        "_lynx",
         "https://portal.lynx-r.com/downloads/download/16", // version 1.0.0
         "jni/arm64-v8a",
     );
@@ -346,9 +346,13 @@ pub fn build_android_deps(skip_admin_priv: bool) {
     cmd!(sh, "rustup target add i686-linux-android")
         .run()
         .unwrap();
-    cmd!(sh, "cargo install cargo-apk cargo-ndk cbindgen")
-        .run()
-        .unwrap();
+    cmd!(sh, "cargo install cargo-ndk cbindgen").run().unwrap();
+    cmd!(
+        sh,
+        "cargo install --git https://github.com/zarik5/cargo-apk cargo-apk"
+    )
+    .run()
+    .unwrap();
 
     get_android_openxr_loaders();
 }


### PR DESCRIPTION
This PR also removes the permission `WAKE_LOCK`, because AppLab doesn't like it. I forgot why it was there, the app doesn't seem to be affected without it.
The `supportedDevices` doesn't contain "quest3" because that crashes the Quest 1. the Quest 3 support should not actually be affected.