### PR TITLE
docs: Specify location of commandline options

### DIFF
--- a/wiki/Linux-Troubleshooting.md
+++ b/wiki/Linux-Troubleshooting.md
@@ -5,7 +5,7 @@ The steam runtimes SteamVR runs in break the alvr driver loaded by SteamVR.
 This causes the screen to stay black on the client or an error to be reported that the pipewire device is missing or can even result in SteamVR crashing.
 
 ### Fix
-Add `~/.steam/steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` to the commandline options of SteamVR.
+Add `~/.steam/steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` to the commandline options of SteamVR (SteamVR -> Manage/Right Click -> Properties -> General -> Launch Options).
 
 The path might differ based on your installation of Steam, for example on systems using the deb-package like Debian and Mint `~/.steam/debian-installation/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` is needed.
 


### PR DESCRIPTION
Or should I also replace all instances of commandline options with "launch options"?