### PR TITLE
Increase maximum resolution from 4096 to 8192

### DIFF
--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -14,9 +14,9 @@ pub enum FrameSize {
     Scale(#[schema(gui(slider(min = 0.25, max = 2.0, step = 0.01)))] f32),
 
     Absolute {
-        #[schema(gui(slider(min = 32, max = 0x2000, step = 32)))]
+        #[schema(gui(slider(min = 32, max = 8192, step = 32)))]
         width: u32,
-        #[schema(gui(slider(min = 32, max = 0x2000, step = 32)))]
+        #[schema(gui(slider(min = 32, max = 8192, step = 32)))]
         height: Option<u32>,
     },
 }

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -14,9 +14,9 @@ pub enum FrameSize {
     Scale(#[schema(gui(slider(min = 0.25, max = 2.0, step = 0.01)))] f32),
 
     Absolute {
-        #[schema(gui(slider(min = 32, max = 0x1000, step = 32)))]
+        #[schema(gui(slider(min = 32, max = 0x2000, step = 32)))]
         width: u32,
-        #[schema(gui(slider(min = 32, max = 0x1000, step = 32)))]
+        #[schema(gui(slider(min = 32, max = 0x2000, step = 32)))]
         height: Option<u32>,
     },
 }


### PR DESCRIPTION
Useful on Apple headsets, but maybe it'll be useful on Meta headsets at some point.