### PR TITLE
flatpak nvidia

### DIFF
--- a/alvr/xtask/flatpak/com.valvesoftware.Steam.Utility.alvr.json
+++ b/alvr/xtask/flatpak/com.valvesoftware.Steam.Utility.alvr.json
@@ -1,64 +1,57 @@
 {
-    "id": "com.valvesoftware.Steam.Utility.alvr",
-    "branch": "stable",
-    "sdk": "org.freedesktop.Sdk//23.08",
-    "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.llvm16",
-        "org.freedesktop.Sdk.Extension.rust-stable"
-    ],
-    "runtime": "com.valvesoftware.Steam",
-    "runtime-version": "stable",
-    "build-extension": true,
-    "appstream-compose": false,
-    "separate-locales": false,
-    "build-options": {
-        "prefix": "/app/utils/alvr",
-        "append-path": "/usr/lib/sdk/llvm16/bin:/usr/lib/sdk/rust-stable/bin:/app/utils/alvr/bin",
-        "prepend-ld-library-path": "/app/utils/alvr/lib",
-        "prepend-pkg-config-path": "/app/utils/alvr/lib/pkgconfig",
-        "strip": true,
+  "id": "com.valvesoftware.Steam.Utility.alvr",
+  "branch": "stable",
+  "sdk": "org.freedesktop.Sdk//23.08",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.llvm16",
+    "org.freedesktop.Sdk.Extension.rust-stable"
+  ],
+  "runtime": "com.valvesoftware.Steam",
+  "runtime-version": "stable",
+  "build-extension": true,
+  "appstream-compose": false,
+  "separate-locales": false,
+  "build-options": {
+    "prefix": "/app/utils/alvr",
+    "append-path": "/usr/lib/sdk/llvm16/bin:/usr/lib/sdk/rust-stable/bin:/app/utils/alvr/bin:/run/build/alvr/cuda/bin",
+    "prepend-ld-library-path": "/app/utils/alvr/lib",
+    "prepend-pkg-config-path": "/app/utils/alvr/lib/pkgconfig",
+    "strip": true,
+    "env": { "PREFIX": "/app/utils/alvr" },
+    "build-args": [ "--share=network", "--filesystem=xdg-data" ]
+  },
+  "cleanup": [
+    "/lib/*.a",
+    "/lib/*.la",
+    "/share/doc",
+    "/share/man"
+  ],
+  "modules": [
+    {
+      "name": "alvr",
+      "buildsystem": "simple",
+      "build-options": {
         "env": {
-            "PREFIX": "/app/utils/alvr"
-        },
-        "build-args": [
-            "--share=network",
-            "--filesystem=xdg-data"
-        ]
-    },
-    "cleanup": [
-        "/lib/*.a",
-        "/lib/*.la",
-        "/share/doc",
-        "/share/man"
-    ],
-    "modules": [
-        {
-            "name": "alvr",
-            "buildsystem": "simple",
-            "build-options": {
-                "env": {
-                    "RUST_BACKTRACE": "full",
-                    "CURL_HOME": "/run/build/alvr",
-                    "CPATH": "/app/utils/alvr/include"
-                }
-            },
-            "build-commands": [
-                "echo 'insecure' >> .curlrc",
-                "cargo xtask prepare-deps --platform linux --no-nvidia",
-                "cargo xtask build-streamer --gpl --release",
-                "cp -r /run/build/alvr/build/alvr_streamer_linux/* /app/utils/alvr",
-                "cp -r /run/build/alvr/alvr/xtask/flatpak/com.valvesoftware.Steam.Utility.alvr.desktop ~/.local/share/applications/com.valvesoftware.Steam.Utility.alvr.desktop"
-            ],
-            "modules": [
-                "modules/yasm/yasm.json",
-                "modules/vulkan-headers/vulkan-headers.json"
-            ],
-            "sources": [
-                {
-                    "type": "dir",
-                    "path": "../../../"
-                }
-            ]
+          "RUST_BACKTRACE": "full",
+          "CURL_HOME": "/run/build/alvr",
+          "CPATH": "/app/utils/alvr/include",
+          "LD_LIBRARY_PATH": "/run/build/alvr/cuda/lib",
+          "CUDA_HOME": "/run/build/alvr/cuda/",
+          "NVCC_PREPEND_FLAGS": "-I /run/build/alvr/cuda/include -L /run/build/alvr/cuda/lib"
         }
-    ]
+      },
+      "build-commands": [
+        "echo 'insecure' >> .curlrc",
+        "ls -Ral /app/utils/alvr/lib/",
+        "mkdir -p /app/utils/alvr/lib/pkgconfig/",
+        "cp /run/build/alvr/alvr/xtask/flatpak/cuda.pc /app/utils/alvr/lib/pkgconfig/",
+        "cargo xtask prepare-deps --platform linux",
+        "cargo xtask build-streamer --gpl --release",
+        "cp -r /run/build/alvr/build/alvr_streamer_linux/* /app/utils/alvr",
+        "echo this line does not work - cp -r /run/build/alvr/alvr/xtask/flatpak/com.valvesoftware.Steam.Utility.alvr.desktop ~/.local/share/applications/com.valvesoftware.Steam.Utility.alvr.desktop"
+      ],
+      "modules": [ "modules/yasm/yasm.json", "modules/vulkan-headers/vulkan-headers.json" ],
+      "sources": [ { "type": "dir", "path": "../../../" }, { "type": "dir", "path": "/opt/cuda/", "dest": "cuda" } ]
+    }
+  ]
 }

--- a/alvr/xtask/flatpak/cuda.pc
+++ b/alvr/xtask/flatpak/cuda.pc
@@ -1,0 +1,9 @@
+prefix=/run/build/alvr/cuda
+includedir=${prefix}/include
+libdir=${prefix}/lib64
+
+Name: cuda
+Description: CUDA Driver Library
+Version: 0.0.0
+Libs: -L${libdir}/stubs -lcuda
+Cflags: -I${includedir}


### PR DESCRIPTION
To enable nvidia encoding inside flatpak we need to build ffmpeg with cuda support. This needs the nvcc compiler - which is not easily obtainable via flatpak. The current freedesktop nvidia driver packages have the driver but are missing nvcc. In the future maybe there will be some sdk extension package that can be added to enable this. 

But for now, we can add the hosts cuda folder to the flatpak build env and get it to work. I'm using arch which has a non-standard install location for cuda (/opt/cuda) - other distros might use different. NVCC is also fussy about it's gcc version - 13.2 is the max supported right now. But arch comes with gcc-14 so even without flatpak this requires extra settings. Flatpak actually makes this easier because the runtime used has 13.2 right now. 

So the changes needed are quite small, we just copy cuda into the build folder, and update the pkgconfig to point to it. Then just set some env variables and the build works. Note that NVCC is only needed for the build, not at runtime. 

Improvements that can be made:
Print error if cuda not installed - or continue without nvidia support
Detect where host has cuda installed, update paths to reflect

Testing:
Works well for me with arch+flatpak steam+4090 555+kde plasma 6.1.
Does this also work for amd users? Would there be an nvidia vs non-nvidia version needed?

