### PR TITLE
fix: routing assumption basis of microphone loopback detection

### DIFF
--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -563,14 +563,14 @@ fn connection_pipeline(
             .to_con()?;
 
             #[cfg(not(target_os = "linux"))]
-            if let Switch::Enabled(microphone_desc) = &settings.audio.microphone {
+            if let Switch::Enabled(microphone_config) = &settings.audio.microphone {
                 let (sink, source) = AudioDevice::new_virtual_microphone_pair(
                     Some(settings.audio.linux_backend),
-                    microphone_desc.devices.clone(),
+                    microphone_config.devices.clone(),
                 )
                 .to_con()?;
                 if matches!(
-                    microphone_desc.devices,
+                    microphone_config.devices,
                     alvr_session::MicrophoneDevicesConfig::VBCable
                 ) {
                     // VoiceMeeter and Custom devices may have arbitrary internal routing.

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -569,10 +569,22 @@ fn connection_pipeline(
                     microphone_desc.devices.clone(),
                 )
                 .to_con()?;
-                if alvr_audio::is_same_device(&game_audio_device, &sink)
-                    || alvr_audio::is_same_device(&game_audio_device, &source)
-                {
-                    con_bail!("Game audio and microphone cannot point to the same device!");
+                match &settings.audio.microphone.as_option().map(|config: &alvr_session::MicrophoneConfig| {
+                    config.devices.clone()
+                }).unwrap(){
+                    alvr_session::MicrophoneDevicesConfig::VBCable => {
+                        // Stream played via VA-CABLE-X will be directly routed to VA-CABLE-X's virtual microphone.
+                        // Game audio will loop back to the game microphone if they are set to the same VA-CABLE-X device.
+                        if alvr_audio::is_same_device(&game_audio_device, &sink)
+                            || alvr_audio::is_same_device(&game_audio_device, &source)
+                        {
+                            con_bail!("Game audio and microphone cannot point to the same device!");
+                        }
+                    }
+                    _ => {
+                        // VoiceMeeter and Custom devices may have arbitrary internal routing.
+                        // Therefore, we cannot detect the loopback issue without knowing the routing.
+                    }
                 }
             }
 

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -569,7 +569,10 @@ fn connection_pipeline(
                     microphone_desc.devices.clone(),
                 )
                 .to_con()?;
-                if matches!(microphone_desc.devices, alvr_session::MicrophoneDevicesConfig::VBCable) {
+                if matches!(
+                    microphone_desc.devices,
+                    alvr_session::MicrophoneDevicesConfig::VBCable
+                ) {
                     // VoiceMeeter and Custom devices may have arbitrary internal routing.
                     // Therefore, we cannot detect the loopback issue without knowing the routing.
                     if alvr_audio::is_same_device(&game_audio_device, &sink)

--- a/alvr/server/src/connection.rs
+++ b/alvr/server/src/connection.rs
@@ -569,9 +569,13 @@ fn connection_pipeline(
                     microphone_desc.devices.clone(),
                 )
                 .to_con()?;
-                match &settings.audio.microphone.as_option().map(|config: &alvr_session::MicrophoneConfig| {
-                    config.devices.clone()
-                }).unwrap(){
+                match &settings
+                    .audio
+                    .microphone
+                    .as_option()
+                    .map(|config: &alvr_session::MicrophoneConfig| config.devices.clone())
+                    .unwrap()
+                {
                     alvr_session::MicrophoneDevicesConfig::VBCable => {
                         // Stream played via VA-CABLE-X will be directly routed to VA-CABLE-X's virtual microphone.
                         // Game audio will loop back to the game microphone if they are set to the same VA-CABLE-X device.


### PR DESCRIPTION
The streamer refused me to set game audio and microphone to the same device when I was using a custom device.

I can see in the VB cable it may create a loopback problem, where device A's output will be loopback to A's input. But for custom devices, it shouldn't be an issue, as people can route the steam manually within the audio interface.

For example, in my case, Speaker CH 1-2 is my main output that routes to my physical speaker, and Microphone CH 1-2 is my main input, which aggregates streams from both my physical microphone and Virtual Speaker CH 5-6. In this case, I don't see any issue if I set Microphone CH 1-2 as SteamVR's mic which obtains microphone stream via Virtual Speaker CH 5-6.

![Screenshot 2024-06-23 213030](https://github.com/alvr-org/ALVR/assets/29728710/9b7f5136-ea3c-4122-9f0a-fbb6b8b2d26d)
