### PR TITLE
io::ErrorKind::Interrupted error

### DIFF
--- a/alvr/common/src/connection_result.rs
+++ b/alvr/common/src/connection_result.rs
@@ -65,7 +65,7 @@ pub trait HandleTryAgain<T> {
 impl<T> HandleTryAgain<T> for io::Result<T> {
     fn handle_try_again(self) -> ConResult<T> {
         self.map_err(|e| {
-            if e.kind() == io::ErrorKind::TimedOut || e.kind() == io::ErrorKind::WouldBlock {
+            if e.kind() == io::ErrorKind::TimedOut || e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::Interrupted {
                 ConnectionError::TryAgain(e.into())
             } else {
                 ConnectionError::Other(e.into())

--- a/alvr/common/src/connection_result.rs
+++ b/alvr/common/src/connection_result.rs
@@ -65,7 +65,9 @@ pub trait HandleTryAgain<T> {
 impl<T> HandleTryAgain<T> for io::Result<T> {
     fn handle_try_again(self) -> ConResult<T> {
         self.map_err(|e| {
-            if e.kind() == io::ErrorKind::TimedOut || e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::Interrupted {
+            if e.kind() == io::ErrorKind::TimedOut 
+                || e.kind() == io::ErrorKind::WouldBlock 
+                || e.kind() == io::ErrorKind::Interrupted {
                 ConnectionError::TryAgain(e.into())
             } else {
                 ConnectionError::Other(e.into())


### PR DESCRIPTION
Sometimes io::ErrorKind::Interrupted error occurs on socket peek. let it to retry.