### PR TITLE
dashboard(linux): add old audio script check

### DIFF
--- a/alvr/dashboard/src/dashboard/components/audio_script_check.rs
+++ b/alvr/dashboard/src/dashboard/components/audio_script_check.rs
@@ -33,7 +33,9 @@ impl AudioScriptCheck {
                 ui.add_space(60.0);
                 ui.with_layout(Layout::top_down(Align::LEFT), |ui| {
                     ui.add_space(15.0);
-                    ui.heading("To reset outdated On connect / On disconnect scripts press button bellow");
+                    ui.heading(
+                        "To reset outdated On connect / On disconnect scripts press button bellow",
+                    );
                     ui.add_space(30.0);
                     ui.vertical_centered(|ui| {
                         if ui.button("Reset scripts").clicked() {

--- a/alvr/dashboard/src/dashboard/components/audio_script_check.rs
+++ b/alvr/dashboard/src/dashboard/components/audio_script_check.rs
@@ -1,0 +1,65 @@
+use alvr_packets::{PathValuePair, ServerRequest};
+use eframe::egui::{Align, Layout, RichText, Ui};
+
+pub struct AudioScriptCheck;
+
+pub enum AudioScriptCheckRequest {
+    ServerRequest(ServerRequest),
+}
+
+impl AudioScriptCheck {
+    pub fn new() -> Self {
+        Self {}
+    }
+    pub fn ui(&mut self, ui: &mut Ui) -> Option<AudioScriptCheckRequest> {
+        let mut request = None;
+
+        ui.horizontal(|ui| {
+            ui.add_space(60.0);
+            ui.vertical(|ui| {
+                ui.add_space(30.0);
+                ui.heading(RichText::new("Outdated audio script detected").size(30.0));
+                ui.add_space(5.0);
+            });
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                ui.add_space(15.0);
+                ui.button("❌")
+            })
+        });
+        ui.separator();
+        ui.with_layout(Layout::right_to_left(Align::Min), |ui| {
+            ui.add_space(60.0);
+            ui.with_layout(Layout::left_to_right(Align::Min), |ui| {
+                ui.add_space(60.0);
+                ui.with_layout(Layout::top_down(Align::LEFT), |ui| {
+                    ui.add_space(15.0);
+                    ui.heading("To reset outdated On connect / On disconnect scripts press button bellow");
+                    ui.add_space(30.0);
+                    ui.vertical_centered(|ui| {
+                        if ui.button("Reset scripts").clicked() {
+                            request = Some(AudioScriptCheckRequest::ServerRequest(
+                                ServerRequest::SetValues(vec![
+                                    PathValuePair {
+                                        path: alvr_packets::parse_path(
+                                            "session_settings.connection.on_connect_script",
+                                        ),
+                                        value: serde_json::Value::String(String::default()),
+                                    },
+                                    PathValuePair {
+                                        path: alvr_packets::parse_path(&format!(
+                                            "session_settings.connection.{}",
+                                            "on_disconnect_script"
+                                        )),
+                                        value: serde_json::Value::String(String::default()),
+                                    },
+                                ]),
+                            ));
+                        }
+                    });
+                });
+            })
+        });
+
+        request
+    }
+}

--- a/alvr/dashboard/src/dashboard/components/mod.rs
+++ b/alvr/dashboard/src/dashboard/components/mod.rs
@@ -1,4 +1,5 @@
 mod about;
+mod audio_script_check;
 mod debug;
 mod devices;
 mod logs;
@@ -6,13 +7,13 @@ mod notifications;
 mod settings;
 mod settings_controls;
 mod setup_wizard;
-mod audio_script_check;
 mod statistics;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod installation;
 
 pub use about::*;
+pub use audio_script_check::*;
 pub use debug::*;
 pub use devices::*;
 pub use logs::*;
@@ -20,7 +21,6 @@ pub use notifications::*;
 pub use settings::*;
 pub use settings_controls::*;
 pub use setup_wizard::*;
-pub use audio_script_check::*;
 pub use statistics::*;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/alvr/dashboard/src/dashboard/components/mod.rs
+++ b/alvr/dashboard/src/dashboard/components/mod.rs
@@ -6,6 +6,7 @@ mod notifications;
 mod settings;
 mod settings_controls;
 mod setup_wizard;
+mod audio_script_check;
 mod statistics;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -19,6 +20,7 @@ pub use notifications::*;
 pub use settings::*;
 pub use settings_controls::*;
 pub use setup_wizard::*;
+pub use audio_script_check::*;
 pub use statistics::*;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -17,7 +17,6 @@ use std::{
     ops::Deref,
     sync::{atomic::AtomicUsize, Arc},
 };
-use tungstenite::http::request;
 
 #[derive(Clone)]
 pub struct DisplayString {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1201,6 +1201,7 @@ pub struct ExtraConfig {
     pub logging: LoggingConfig,
     pub patches: Patches,
     pub open_setup_wizard: bool,
+    pub open_audio_script_check: bool,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -1721,6 +1722,7 @@ pub fn session_settings_default() -> SettingsDefault {
                 linux_async_reprojection: false,
             },
             open_setup_wizard: alvr_common::is_stable() || alvr_common::is_nightly(),
+            open_audio_script_check: true,
         },
     }
 }


### PR DESCRIPTION
Probably should have been added with pipewire impl at the same time, but if user doesn't reset it - most likely user will think audio is broken or misbehaving.

![image](https://github.com/user-attachments/assets/0d8f7289-d81b-4eaa-aeac-b7427de0beb8)
