### PR TITLE
fix: Add quest3 as supported device in manifest

### DIFF
--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -123,7 +123,9 @@ name = "com.oculus.intent.category.VR"
 value = "vr_only"
 [[package.metadata.android.application.meta_data]]
 name = "com.oculus.supportedDevices"
-value = "quest|quest2|questpro"
+value = "all"
+# Use this for applab releases
+# value = "quest2|questpro|quest3"
 [[package.metadata.android.application.meta_data]]
 name = "com.oculus.vr.focusaware"
 value = "true"


### PR DESCRIPTION
Fixes #2244

Fixes a bug where alvr couldn't use 120hz mode on quest 3 due to the system defaulting to reporting max 90hz if the quest 3 isn't listed as a supported device.