### PR TITLE
Enable VRChat gesture support by changing EVRSkeletalTrackingLevel to Full

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -80,7 +80,7 @@ vr::EVRInitError Controller::Activate(vr::TrackedDeviceIndex_t unObjectId) {
             "/input/skeleton/left",
             "/skeleton/hand/left",
             "/pose/raw",
-            vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Partial,
+            vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Full,
             nullptr,
             0U,
             &m_compSkeleton
@@ -91,7 +91,7 @@ vr::EVRInitError Controller::Activate(vr::TrackedDeviceIndex_t unObjectId) {
             "/input/skeleton/right",
             "/skeleton/hand/right",
             "/pose/raw",
-            vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Partial,
+            vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Full,
             nullptr,
             0U,
             &m_compSkeleton


### PR DESCRIPTION
Small change, already tested by multiple people, works. 

May cause gestures to trigger when using controllers, not an issue in VRChat with pico(quest) controllers.
This can be mitigated as so but I don't have the time to implement this:
"In the case of supporting switching between finger tracking and controllers, the way to make it so that a driver's skeleton data, as available to the application over the API is clearly identifiable as being suitable for interactions or not, is to have the driver define two different controller types, one for controllers that always initializes its skeleton as either partial or estimated, and one for finger tracking that always initializes its skeleton as full, and switch between them when the source input provider switches between controller and hand tracking "