### PR TITLE
Use VRSkeletalTracking_Estimated Instead of VRSkeletalTracking_Partial

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -81,7 +81,7 @@ vr::EVRInitError Controller::Activate(vr::TrackedDeviceIndex_t unObjectId) {
             "/skeleton/hand/left",
             "/pose/raw",
             this->device_id == HAND_LEFT_ID
-                ? vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Partial
+                ? vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Estimated
                 : vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Full,
             nullptr,
             0U,
@@ -94,7 +94,7 @@ vr::EVRInitError Controller::Activate(vr::TrackedDeviceIndex_t unObjectId) {
             "/skeleton/hand/right",
             "/pose/raw",
             this->device_id == HAND_RIGHT_ID
-                ? vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Partial
+                ? vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Estimated
                 : vr::EVRSkeletalTrackingLevel::VRSkeletalTracking_Full,
             nullptr,
             0U,


### PR DESCRIPTION
Fixes #2300
This fix works on VRChat, but I was unable to verify compatibility with other games like Resonite due to Linux compatibility issues