### PR TITLE
Prevent setting SharedTextureDesc to 0 when CreateTexture2D

### DIFF
--- a/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
@@ -37,7 +37,8 @@ void OvrDirectModeComponent::CreateSwapTextureSet(
     }
     SharedTextureDesc.ArraySize = 1;
     SharedTextureDesc.MipLevels = 1;
-    SharedTextureDesc.SampleDesc.Count = pSwapTextureSetDesc->nSampleCount;
+    SharedTextureDesc.SampleDesc.Count
+        = pSwapTextureSetDesc->nSampleCount == 0 ? 1 : pSwapTextureSetDesc->nSampleCount;
     SharedTextureDesc.SampleDesc.Quality = 0;
     SharedTextureDesc.Usage = D3D11_USAGE_DEFAULT;
     SharedTextureDesc.Format = format;


### PR DESCRIPTION
Setting `SharedTextureDesc.SampleDesc.Count` to 0 return an error when using `CreateTexture2D`
Closes #2308