### PR TITLE
feat: :sparkles: Add debug groups

### DIFF
--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -192,6 +192,16 @@ pub unsafe extern "C" fn alvr_log(level: AlvrLogLevel, message: *const c_char) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn alvr_dbg_client_impl(message: *const c_char) {
+    alvr_common::dbg_client_impl(CStr::from_ptr(message).to_str().unwrap())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn alvr_dbg_decoder(message: *const c_char) {
+    alvr_common::dbg_decoder(CStr::from_ptr(message).to_str().unwrap())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn alvr_log_time(tag: *const c_char) {
     let tag = CStr::from_ptr(tag).to_str().unwrap();
     error!("[ALVR NATIVE] {tag}: {:?}", Instant::now());

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -193,12 +193,12 @@ pub unsafe extern "C" fn alvr_log(level: AlvrLogLevel, message: *const c_char) {
 
 #[no_mangle]
 pub unsafe extern "C" fn alvr_dbg_client_impl(message: *const c_char) {
-    alvr_common::dbg_client_impl(CStr::from_ptr(message).to_str().unwrap())
+    alvr_common::dbg_client_impl!("{}", CStr::from_ptr(message).to_str().unwrap())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn alvr_dbg_decoder(message: *const c_char) {
-    alvr_common::dbg_decoder(CStr::from_ptr(message).to_str().unwrap())
+    alvr_common::dbg_decoder!("{}", CStr::from_ptr(message).to_str().unwrap())
 }
 
 #[no_mangle]

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -551,6 +551,7 @@ fn connection_pipeline(
         *LOG_CHANNEL_SENDER.lock() = Some(LogMirrorData {
             sender: log_channel_sender,
             filter_level,
+            debug_groups_config: settings.extra.logging.debug_groups,
         });
     }
     event_queue.lock().push_back(streaming_start_event);

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use alvr_audio::AudioDevice;
 use alvr_common::{
-    debug, error, info,
+    dbg_connection, debug, error, info,
     parking_lot::{Condvar, Mutex, RwLock},
     wait_rwlock, warn, AnyhowToCon, ConResult, ConnectionError, ConnectionState, LifecycleState,
     ALVR_VERSION,
@@ -94,6 +94,8 @@ pub fn connection_lifecycle_loop(
     lifecycle_state: Arc<RwLock<LifecycleState>>,
     event_queue: Arc<Mutex<VecDeque<ClientCoreEvent>>>,
 ) {
+    dbg_connection!("connection_lifecycle_loop: Begin");
+
     set_hud_message(&event_queue, INITIAL_MESSAGE);
 
     while *lifecycle_state.read() != LifecycleState::ShuttingDown {
@@ -117,6 +119,8 @@ pub fn connection_lifecycle_loop(
 
         thread::sleep(CONNECTION_RETRY_INTERVAL);
     }
+
+    dbg_connection!("connection_lifecycle_loop: End");
 }
 
 fn connection_pipeline(
@@ -125,6 +129,8 @@ fn connection_pipeline(
     lifecycle_state: Arc<RwLock<LifecycleState>>,
     event_queue: Arc<Mutex<VecDeque<ClientCoreEvent>>>,
 ) -> ConResult {
+    dbg_connection!("connection_pipeline: Begin");
+
     let (mut proto_control_socket, server_ip) = {
         let config = Config::load();
         let announcer_socket = AnnouncerSocket::new(&config.hostname).to_con()?;
@@ -158,6 +164,7 @@ fn connection_pipeline(
         .input_sample_rate()
         .to_con()?;
 
+    dbg_connection!("connection_pipeline: Send stream capabilities");
     proto_control_socket
         .send(&ClientConnectionResult::ConnectionAccepted {
             client_protocol_id: alvr_common::protocol_id_u64(),
@@ -179,6 +186,7 @@ fn connection_pipeline(
         .to_con()?;
     let config_packet =
         proto_control_socket.recv::<StreamConfigPacket>(HANDSHAKE_ACTION_TIMEOUT)?;
+    dbg_connection!("connection_pipeline: stream config received");
 
     let (settings, negotiated_config) =
         alvr_packets::decode_stream_config(&config_packet).to_con()?;
@@ -224,6 +232,7 @@ fn connection_pipeline(
         }
     }
 
+    dbg_connection!("connection_pipeline: create StreamSocket");
     let stream_socket_builder = StreamSocketBuilder::listen_for_server(
         Duration::from_secs(1),
         settings.connection.stream_port,
@@ -234,12 +243,14 @@ fn connection_pipeline(
     )
     .to_con()?;
 
+    dbg_connection!("connection_pipeline: Send StreamReady");
     if let Err(e) = control_sender.send(&ClientControlPacket::StreamReady) {
         info!("Server disconnected. Cause: {e:?}");
         set_hud_message(&event_queue, SERVER_DISCONNECTED_MESSAGE);
         return Ok(());
     }
 
+    dbg_connection!("connection_pipeline: accept connection");
     let mut stream_socket = stream_socket_builder.accept_from_server(
         server_ip,
         settings.connection.stream_port,
@@ -558,6 +569,8 @@ fn connection_pipeline(
 
     *connection_state_lock = ConnectionState::Streaming;
 
+    dbg_connection!("connection_pipeline: Unlock streams");
+
     // Make sure IPD and FoV are resent after reconnection
     // todo: send this data as part of the connection handshake
     ctx.view_params_queue.write().clear();
@@ -582,6 +595,8 @@ fn connection_pipeline(
     // Remove lock to allow threads to properly exit:
     drop(connection_state_lock);
 
+    dbg_connection!("connection_pipeline: Destroying streams");
+
     video_receive_thread.join().ok();
     game_audio_thread.join().ok();
     microphone_thread.join().ok();
@@ -589,6 +604,8 @@ fn connection_pipeline(
     control_send_thread.join().ok();
     control_receive_thread.join().ok();
     stream_receive_thread.join().ok();
+
+    dbg_connection!("connection_pipeline: End");
 
     Ok(())
 }

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -8,7 +8,7 @@ pub const SERVER_IMPL_DBG_LABEL: &str = "SERVER IMPL";
 pub const CLIENT_IMPL_DBG_LABEL: &str = "CLIENT IMPL";
 pub const SERVER_CORE_DBG_LABEL: &str = "SERVER CORE";
 pub const CLIENT_CORE_DBG_LABEL: &str = "CLIENT CORE";
-pub const HANDSHAKE_DBG_LABEL: &str = "HANDSHAKE";
+pub const CONNECTION_DBG_LABEL: &str = "CONNECTION";
 pub const SOCKETS_DBG_LABEL: &str = "SOCKETS";
 pub const SERVER_GFX_DBG_LABEL: &str = "SERVER GFX";
 pub const CLIENT_GFX_DBG_LABEL: &str = "CLIENT GFX";
@@ -52,9 +52,9 @@ macro_rules! dbg_client_core {
 }
 
 #[macro_export]
-macro_rules! dbg_handshake {
+macro_rules! dbg_connection {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::HANDSHAKE_DBG_LABEL, $($args)*);
+        $crate::_dbg_label!($crate::CONNECTION_DBG_LABEL, $($args)*);
     };
 }
 
@@ -104,7 +104,7 @@ pub struct DebugGroupsConfig {
     #[schema(flag = "steamvr-restart")]
     pub client_core: bool,
     #[schema(flag = "steamvr-restart")]
-    pub handshake: bool,
+    pub connection: bool,
     #[schema(flag = "steamvr-restart")]
     pub sockets: bool,
     #[schema(flag = "steamvr-restart")]
@@ -126,8 +126,8 @@ pub fn filter_debug_groups(message: &str, config: &DebugGroupsConfig) -> bool {
         config.server_core
     } else if message.starts_with(&format!("[{CLIENT_CORE_DBG_LABEL}]")) {
         config.client_core
-    } else if message.starts_with(&format!("[{HANDSHAKE_DBG_LABEL}]")) {
-        config.handshake
+    } else if message.starts_with(&format!("[{CONNECTION_DBG_LABEL}]")) {
+        config.connection
     } else if message.starts_with(&format!("[{SOCKETS_DBG_LABEL}]")) {
         config.sockets
     } else if message.starts_with(&format!("[{SERVER_GFX_DBG_LABEL}]")) {

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -60,7 +60,6 @@ pub fn dbg_decoder(message: &str) {
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
-#[schema(collapsible)]
 pub struct DebugGroupsConfig {
     #[schema(flag = "steamvr-restart")]
     pub server_impl: bool,

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -4,6 +4,112 @@ use serde::{Deserialize, Serialize};
 use settings_schema::SettingsSchema;
 use std::{error::Error, fmt::Display};
 
+const SERVER_IMPL_DBG_LABEL: &str = "SERVER IMPL";
+const CLIENT_IMPL_DBG_LABEL: &str = "CLIENT IMPL";
+const SERVER_CORE_DBG_LABEL: &str = "SERVER CORE";
+const CLIENT_CORE_DBG_LABEL: &str = "CLIENT CORE";
+const HANDSHAKE_DBG_LABEL: &str = "HANDSHAKE";
+const SOCKETS_DBG_LABEL: &str = "SOCKETS";
+const SERVER_GFX_DBG_LABEL: &str = "SERVER GFX";
+const CLIENT_GFX_DBG_LABEL: &str = "CLIENT GFX";
+const ENCODER_DBG_LABEL: &str = "ENCODER";
+const DECODER_DBG_LABEL: &str = "DECODER";
+
+pub fn dbg_label(label: &str, message: &str) {
+    log::debug!("[{label}] {message}");
+}
+
+pub fn dbg_server_impl(message: &str) {
+    dbg_label(SERVER_IMPL_DBG_LABEL, message);
+}
+
+pub fn dbg_client_impl(message: &str) {
+    dbg_label(CLIENT_IMPL_DBG_LABEL, message);
+}
+
+pub fn dbg_server_core(message: &str) {
+    dbg_label(SERVER_CORE_DBG_LABEL, message);
+}
+
+pub fn dbg_client_core(message: &str) {
+    dbg_label(CLIENT_CORE_DBG_LABEL, message);
+}
+
+pub fn dbg_handshake(message: &str) {
+    dbg_label(HANDSHAKE_DBG_LABEL, message);
+}
+
+pub fn dbg_sockets(message: &str) {
+    dbg_label(SOCKETS_DBG_LABEL, message);
+}
+
+pub fn dbg_server_gfx(message: &str) {
+    dbg_label(SERVER_GFX_DBG_LABEL, message);
+}
+
+pub fn dbg_client_gfx(message: &str) {
+    dbg_label(CLIENT_GFX_DBG_LABEL, message);
+}
+
+pub fn dbg_encoder(message: &str) {
+    dbg_label(ENCODER_DBG_LABEL, message);
+}
+
+pub fn dbg_decoder(message: &str) {
+    dbg_label(DECODER_DBG_LABEL, message);
+}
+
+#[derive(SettingsSchema, Serialize, Deserialize, Clone)]
+#[schema(collapsible)]
+pub struct DebugGroupsConfig {
+    #[schema(flag = "steamvr-restart")]
+    pub server_impl: bool,
+    #[schema(flag = "steamvr-restart")]
+    pub client_impl: bool,
+    #[schema(flag = "steamvr-restart")]
+    pub server_core: bool,
+    #[schema(flag = "steamvr-restart")]
+    pub client_core: bool,
+    #[schema(flag = "steamvr-restart")]
+    pub handshake: bool,
+    #[schema(flag = "steamvr-restart")]
+    pub sockets: bool,
+    #[schema(flag = "steamvr-restart")]
+    pub server_gfx: bool,
+    #[schema(flag = "steamvr-restart")]
+    pub client_gfx: bool,
+    #[schema(flag = "steamvr-restart")]
+    pub encoder: bool,
+    #[schema(flag = "steamvr-restart")]
+    pub decoder: bool,
+}
+
+pub fn filter_debug_groups(message: &str, config: &DebugGroupsConfig) -> bool {
+    if message.starts_with(&format!("[{SERVER_IMPL_DBG_LABEL}]")) {
+        config.server_impl
+    } else if message.starts_with(&format!("[{CLIENT_IMPL_DBG_LABEL}]")) {
+        config.client_impl
+    } else if message.starts_with(&format!("[{SERVER_CORE_DBG_LABEL}]")) {
+        config.server_core
+    } else if message.starts_with(&format!("[{CLIENT_CORE_DBG_LABEL}]")) {
+        config.client_core
+    } else if message.starts_with(&format!("[{HANDSHAKE_DBG_LABEL}]")) {
+        config.handshake
+    } else if message.starts_with(&format!("[{SOCKETS_DBG_LABEL}]")) {
+        config.sockets
+    } else if message.starts_with(&format!("[{SERVER_GFX_DBG_LABEL}]")) {
+        config.server_gfx
+    } else if message.starts_with(&format!("[{CLIENT_GFX_DBG_LABEL}]")) {
+        config.client_gfx
+    } else if message.starts_with(&format!("[{ENCODER_DBG_LABEL}]")) {
+        config.encoder
+    } else if message.starts_with(&format!("[{DECODER_DBG_LABEL}]")) {
+        config.decoder
+    } else {
+        true
+    }
+}
+
 #[derive(
     SettingsSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord,
 )]

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -4,59 +4,93 @@ use serde::{Deserialize, Serialize};
 use settings_schema::SettingsSchema;
 use std::{error::Error, fmt::Display};
 
-const SERVER_IMPL_DBG_LABEL: &str = "SERVER IMPL";
-const CLIENT_IMPL_DBG_LABEL: &str = "CLIENT IMPL";
-const SERVER_CORE_DBG_LABEL: &str = "SERVER CORE";
-const CLIENT_CORE_DBG_LABEL: &str = "CLIENT CORE";
-const HANDSHAKE_DBG_LABEL: &str = "HANDSHAKE";
-const SOCKETS_DBG_LABEL: &str = "SOCKETS";
-const SERVER_GFX_DBG_LABEL: &str = "SERVER GFX";
-const CLIENT_GFX_DBG_LABEL: &str = "CLIENT GFX";
-const ENCODER_DBG_LABEL: &str = "ENCODER";
-const DECODER_DBG_LABEL: &str = "DECODER";
+pub const SERVER_IMPL_DBG_LABEL: &str = "SERVER IMPL";
+pub const CLIENT_IMPL_DBG_LABEL: &str = "CLIENT IMPL";
+pub const SERVER_CORE_DBG_LABEL: &str = "SERVER CORE";
+pub const CLIENT_CORE_DBG_LABEL: &str = "CLIENT CORE";
+pub const HANDSHAKE_DBG_LABEL: &str = "HANDSHAKE";
+pub const SOCKETS_DBG_LABEL: &str = "SOCKETS";
+pub const SERVER_GFX_DBG_LABEL: &str = "SERVER GFX";
+pub const CLIENT_GFX_DBG_LABEL: &str = "CLIENT GFX";
+pub const ENCODER_DBG_LABEL: &str = "ENCODER";
+pub const DECODER_DBG_LABEL: &str = "DECODER";
 
-pub fn dbg_label(label: &str, message: &str) {
-    log::debug!("[{label}] {message}");
+#[macro_export]
+macro_rules! _dbg_label {
+    ($label:expr, $($args:tt)*) => {{
+        #[cfg(debug_assertions)]
+        $crate::log::debug!("[{}] {}", $label, format_args!($($args)*));
+    }};
 }
 
-pub fn dbg_server_impl(message: &str) {
-    dbg_label(SERVER_IMPL_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_server_impl {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::SERVER_IMPL_DBG_LABEL, $($args)*);
+    };
 }
 
-pub fn dbg_client_impl(message: &str) {
-    dbg_label(CLIENT_IMPL_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_client_impl {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::CLIENT_IMPL_DBG_LABEL, $($args)*);
+    };
 }
 
-pub fn dbg_server_core(message: &str) {
-    dbg_label(SERVER_CORE_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_server_core {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::SERVER_CORE_DBG_LABEL, $($args)*);
+    };
 }
 
-pub fn dbg_client_core(message: &str) {
-    dbg_label(CLIENT_CORE_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_client_core {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::CLIENT_CORE_DBG_LABEL, $($args)*);
+    };
 }
 
-pub fn dbg_handshake(message: &str) {
-    dbg_label(HANDSHAKE_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_handshake {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::HANDSHAKE_DBG_LABEL, $($args)*);
+    };
 }
 
-pub fn dbg_sockets(message: &str) {
-    dbg_label(SOCKETS_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_sockets {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::SOCKETS_DBG_LABEL, $($args)*);
+    };
 }
 
-pub fn dbg_server_gfx(message: &str) {
-    dbg_label(SERVER_GFX_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_server_gfx {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::SERVER_GFX_DBG_LABEL, $($args)*);
+    };
 }
 
-pub fn dbg_client_gfx(message: &str) {
-    dbg_label(CLIENT_GFX_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_client_gfx {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::CLIENT_GFX_DBG_LABEL, $($args)*);
+    };
 }
 
-pub fn dbg_encoder(message: &str) {
-    dbg_label(ENCODER_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_encoder {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::ENCODER_DBG_LABEL, $($args)*);
+    };
 }
 
-pub fn dbg_decoder(message: &str) {
-    dbg_label(DECODER_DBG_LABEL, message);
+#[macro_export]
+macro_rules! dbg_decoder {
+    ($($args:tt)*) => {
+        $crate::_dbg_label!($crate::DECODER_DBG_LABEL, $($args)*);
+    };
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]

--- a/alvr/server_core/src/c_api.rs
+++ b/alvr/server_core/src/c_api.rs
@@ -223,6 +223,16 @@ pub unsafe extern "C" fn alvr_log_debug(string_ptr: *const c_char) {
     log(log::Level::Debug, string_ptr);
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn alvr_dbg_server_impl(string_ptr: *const c_char) {
+    alvr_common::dbg_server_impl(CStr::from_ptr(string_ptr).to_str().unwrap());
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn alvr_dbg_encoder(string_ptr: *const c_char) {
+    alvr_common::dbg_encoder(CStr::from_ptr(string_ptr).to_str().unwrap());
+}
+
 // Should not be used in production
 #[no_mangle]
 pub unsafe extern "C" fn alvr_log_periodically(tag_ptr: *const c_char, message_ptr: *const c_char) {

--- a/alvr/server_core/src/c_api.rs
+++ b/alvr/server_core/src/c_api.rs
@@ -225,12 +225,12 @@ pub unsafe extern "C" fn alvr_log_debug(string_ptr: *const c_char) {
 
 #[no_mangle]
 pub unsafe extern "C" fn alvr_dbg_server_impl(string_ptr: *const c_char) {
-    alvr_common::dbg_server_impl(CStr::from_ptr(string_ptr).to_str().unwrap());
+    alvr_common::dbg_server_impl!("{}", CStr::from_ptr(string_ptr).to_str().unwrap());
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn alvr_dbg_encoder(string_ptr: *const c_char) {
-    alvr_common::dbg_encoder(CStr::from_ptr(string_ptr).to_str().unwrap());
+    alvr_common::dbg_encoder!("{}", CStr::from_ptr(string_ptr).to_str().unwrap());
 }
 
 // Should not be used in production

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -224,6 +224,16 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
         amd_bitrate_corruption_fix: settings.video.bitrate.image_corruption_fix,
         use_separate_hand_trackers,
         _controller_profile,
+        _server_impl_debug: settings.extra.logging.debug_groups.server_impl,
+        _client_impl_debug: settings.extra.logging.debug_groups.client_impl,
+        _server_core_debug: settings.extra.logging.debug_groups.server_core,
+        _client_core_debug: settings.extra.logging.debug_groups.client_core,
+        _handshake_debug: settings.extra.logging.debug_groups.handshake,
+        _sockets_debug: settings.extra.logging.debug_groups.sockets,
+        _server_gfx_debug: settings.extra.logging.debug_groups.server_gfx,
+        _client_gfx_debug: settings.extra.logging.debug_groups.client_gfx,
+        _encoder_debug: settings.extra.logging.debug_groups.encoder,
+        _decoder_debug: settings.extra.logging.debug_groups.decoder,
         ..old_config
     }
 }

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -228,7 +228,7 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
         _client_impl_debug: settings.extra.logging.debug_groups.client_impl,
         _server_core_debug: settings.extra.logging.debug_groups.server_core,
         _client_core_debug: settings.extra.logging.debug_groups.client_core,
-        _handshake_debug: settings.extra.logging.debug_groups.handshake,
+        _conncection_debug: settings.extra.logging.debug_groups.connection,
         _sockets_debug: settings.extra.logging.debug_groups.sockets,
         _server_gfx_debug: settings.extra.logging.debug_groups.server_gfx,
         _client_gfx_debug: settings.extra.logging.debug_groups.client_gfx,

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use alvr_audio::AudioDevice;
 use alvr_common::{
-    con_bail, debug, error,
+    con_bail, dbg_connection, debug, error,
     glam::{Quat, UVec2, Vec2, Vec3},
     info,
     parking_lot::{Condvar, Mutex, RwLock},
@@ -240,6 +240,8 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
 
 // Alternate connection trials with manual IPs and clients discovered on the local network
 pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<LifecycleState>>) {
+    dbg_connection!("handshake_loop: Begin");
+
     let mut welcome_socket = match WelcomeSocket::new() {
         Ok(socket) => socket,
         Err(e) => {
@@ -249,6 +251,8 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
     };
 
     while *lifecycle_state.read() != LifecycleState::ShuttingDown {
+        dbg_connection!("handshake_loop: Try connect to manual IPs");
+
         let available_manual_client_ips = {
             let mut manual_client_ips = HashMap::new();
             for (hostname, connection_info) in SESSION_MANAGER
@@ -283,6 +287,8 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
             .client_discovery
             .clone();
         if let Switch::Enabled(config) = discovery_config {
+            dbg_connection!("handshake_loop: Discovering clients");
+
             let clients = match welcome_socket.recv_all() {
                 Ok(clients) => clients,
                 Err(e) => {
@@ -347,10 +353,14 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
         }
     }
 
+    alvr_common::dbg_connection!("handshake_loop: Joining connection threads");
+
     // At this point, LIFECYCLE_STATE == ShuttingDown, so all threads are already terminating
     for thread in ctx.connection_threads.lock().drain(..) {
         thread.join().ok();
     }
+
+    alvr_common::dbg_connection!("handshake_loop: End");
 }
 
 fn try_connect(
@@ -358,6 +368,8 @@ fn try_connect(
     lifecycle_state: Arc<RwLock<LifecycleState>>,
     mut client_ips: HashMap<IpAddr, String>,
 ) -> ConResult {
+    dbg_connection!("try_connect: Finding client and creating control socket");
+
     let (proto_socket, client_ip) = ProtoControlSocket::connect_to(
         Duration::from_secs(1),
         PeerType::AnyClient(client_ips.keys().cloned().collect()),
@@ -366,6 +378,8 @@ fn try_connect(
     let Some(client_hostname) = client_ips.remove(&client_ip) else {
         con_bail!("unreachable");
     };
+
+    dbg_connection!("try_connect: Pushing new client connection thread");
 
     ctx.connection_threads.lock().push(thread::spawn({
         let ctx = Arc::clone(&ctx);
@@ -405,11 +419,14 @@ fn connection_pipeline(
     client_hostname: String,
     client_ip: IpAddr,
 ) -> ConResult {
+    dbg_connection!("connection_pipeline: Begin");
+
     // This session lock will make sure settings and client list cannot be changed while connecting
     // to thos client, no other client can connect until handshake is finished. It will then be
     // temporarily relocked while shutting down the threads.
     let mut session_manager_lock = SESSION_MANAGER.write();
 
+    dbg_connection!("connection_pipeline: Setting client state in session");
     session_manager_lock.update_client_list(
         client_hostname.clone(),
         ClientListAction::SetConnectionState(ConnectionState::Connecting),
@@ -421,6 +438,7 @@ fn connection_pipeline(
 
     let disconnect_notif = Arc::new(Condvar::new());
 
+    dbg_connection!("connection_pipeline: Getting client status packet");
     let connection_result = match proto_socket.recv(HANDSHAKE_ACTION_TIMEOUT) {
         Ok(r) => r,
         Err(ConnectionError::TryAgain(e)) => {
@@ -464,6 +482,8 @@ fn connection_pipeline(
     } else {
         con_bail!("Only streaming clients are supported for now");
     };
+
+    dbg_connection!("connection_pipeline: setting up negotiated streaming config");
 
     let settings = session_manager_lock.settings().clone();
 
@@ -607,6 +627,7 @@ fn connection_pipeline(
             0
         };
 
+    dbg_connection!("connection_pipeline: send streaming config");
     let stream_config_packet = alvr_packets::encode_stream_config(
         session_manager_lock.session(),
         &NegotiatedStreamingConfig {
@@ -641,6 +662,7 @@ fn connection_pipeline(
         crate::notify_restart_driver();
     }
 
+    dbg_connection!("connection_pipeline: Send StartStream packet");
     control_sender
         .send(&ServerControlPacket::StartStream)
         .to_con()?;
@@ -649,6 +671,8 @@ fn connection_pipeline(
     if !matches!(signal, ClientControlPacket::StreamReady) {
         con_bail!("Got unexpected packet waiting for stream ack");
     }
+    dbg_connection!("connection_pipeline: Got StreamReady packet");
+
     *ctx.statistics_manager.lock() = Some(StatisticsManager::new(
         settings.connection.statistics_history_size,
         Duration::from_secs_f32(1.0 / fps),
@@ -661,6 +685,7 @@ fn connection_pipeline(
 
     *ctx.bitrate_manager.lock() = BitrateManager::new(settings.video.bitrate.history_size, fps);
 
+    dbg_connection!("connection_pipeline: StreamSocket connect_to_client");
     let mut stream_socket = StreamSocketBuilder::connect_to_client(
         HANDSHAKE_ACTION_TIMEOUT,
         client_ip,
@@ -1370,6 +1395,7 @@ fn connection_pipeline(
     }
 
     if settings.extra.capture.startup_video_recording {
+        info!("Creating recording file");
         crate::create_recording_file(&ctx, session_manager_lock.settings());
     }
 
@@ -1382,7 +1408,9 @@ fn connection_pipeline(
         .send(ServerCoreEvent::ClientConnected)
         .ok();
 
+    dbg_connection!("connection_pipeline: handshake finished; unlocking streams");
     alvr_common::wait_rwlock(&disconnect_notif, &mut session_manager_lock);
+    dbg_connection!("connection_pipeline: Begin connection shutdown");
 
     // This requests shutdown from threads
     *ctx.video_channel_sender.lock() = None;
@@ -1414,6 +1442,7 @@ fn connection_pipeline(
     drop(session_manager_lock);
 
     // Ensure shutdown of threads
+    dbg_connection!("connection_pipeline: Shutdown threads");
     video_send_thread.join().ok();
     game_audio_thread.join().ok();
     microphone_thread.join().ok();
@@ -1427,6 +1456,8 @@ fn connection_pipeline(
     ctx.events_sender
         .send(ServerCoreEvent::ClientDisconnected)
         .ok();
+
+    dbg_connection!("connection_pipeline: End");
 
     Ok(())
 }

--- a/alvr/server_core/src/logging_backend.rs
+++ b/alvr/server_core/src/logging_backend.rs
@@ -1,3 +1,4 @@
+use crate::SESSION_MANAGER;
 use alvr_common::{log::LevelFilter, once_cell::sync::Lazy, LogEntry, LogSeverity};
 use alvr_events::{Event, EventType};
 use chrono::Local;
@@ -10,6 +11,14 @@ pub static LOGGING_EVENTS_SENDER: Lazy<broadcast::Sender<Event>> =
     Lazy::new(|| broadcast::channel(CHANNEL_CAPACITY).0);
 
 pub fn init_logging(session_log_path: Option<PathBuf>, crash_log_path: Option<PathBuf>) {
+    let debug_groups_config = SESSION_MANAGER
+        .read()
+        .settings()
+        .extra
+        .logging
+        .debug_groups
+        .clone();
+
     let mut log_dispatch = Dispatch::new()
         // Note: meta::target() is in the format <crate>::<module>
         .filter(|meta| !meta.target().starts_with("mdns_sd"))
@@ -18,10 +27,17 @@ pub fn init_logging(session_log_path: Option<PathBuf>, crash_log_path: Option<Pa
             let event_type = if maybe_event.starts_with('{') && maybe_event.ends_with('}') {
                 serde_json::from_str(&maybe_event).unwrap()
             } else {
-                EventType::Log(LogEntry {
-                    severity: LogSeverity::from_log_level(record.level()),
-                    content: message.to_string(),
-                })
+                let log_level = record.level();
+                if log_level <= LevelFilter::Info
+                    || alvr_common::filter_debug_groups(&maybe_event, &debug_groups_config)
+                {
+                    EventType::Log(LogEntry {
+                        severity: LogSeverity::from_log_level(record.level()),
+                        content: message.to_string(),
+                    })
+                } else {
+                    return;
+                }
             };
             let event = Event {
                 timestamp: Local::now().format("%H:%M:%S.%f").to_string(),

--- a/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
@@ -336,6 +336,7 @@ void (*LogError)(const char* stringPtr);
 void (*LogWarn)(const char* stringPtr);
 void (*LogInfo)(const char* stringPtr);
 void (*LogDebug)(const char* stringPtr);
+void (*LogEncoder)(const char* stringPtr);
 void (*LogPeriodically)(const char* tag, const char* stringPtr);
 void (*DriverReadyIdle)(bool setDefaultChaprone);
 void (*SetVideoConfigNals)(const unsigned char* configBuffer, int len, int codec);

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -113,6 +113,7 @@ extern "C" void (*LogError)(const char* stringPtr);
 extern "C" void (*LogWarn)(const char* stringPtr);
 extern "C" void (*LogInfo)(const char* stringPtr);
 extern "C" void (*LogDebug)(const char* stringPtr);
+extern "C" void (*LogEncoder)(const char* stringPtr);
 extern "C" void (*LogPeriodically)(const char* tag, const char* stringPtr);
 extern "C" void (*DriverReadyIdle)(bool setDefaultChaprone);
 extern "C" void (*SetVideoConfigNals)(const unsigned char* configBuffer, int len, int codec);

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -406,7 +406,8 @@ pub unsafe extern "C" fn HmdDriverFactory(
             LogError = Some(alvr_server_core::alvr_log_error);
             LogWarn = Some(alvr_server_core::alvr_log_warn);
             LogInfo = Some(alvr_server_core::alvr_log_info);
-            LogDebug = Some(alvr_server_core::alvr_log_debug);
+            LogDebug = Some(alvr_server_core::alvr_dbg_server_impl);
+            LogEncoder = Some(alvr_server_core::alvr_dbg_encoder);
             LogPeriodically = Some(alvr_server_core::alvr_log_periodically);
             PathStringToHash = Some(alvr_server_core::alvr_path_to_id);
             GetSerialNumber = Some(props::get_serial_number);

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -114,7 +114,7 @@ pub struct OpenvrConfig {
     pub _client_impl_debug: bool,
     pub _server_core_debug: bool,
     pub _client_core_debug: bool,
-    pub _handshake_debug: bool,
+    pub _conncection_debug: bool,
     pub _sockets_debug: bool,
     pub _server_gfx_debug: bool,
     pub _client_gfx_debug: bool,

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -110,6 +110,16 @@ pub struct OpenvrConfig {
     // these settings are not used on the C++ side, but we need them to correctly trigger a SteamVR
     // restart
     pub _controller_profile: i32,
+    pub _server_impl_debug: bool,
+    pub _client_impl_debug: bool,
+    pub _server_core_debug: bool,
+    pub _client_core_debug: bool,
+    pub _handshake_debug: bool,
+    pub _sockets_debug: bool,
+    pub _server_gfx_debug: bool,
+    pub _client_gfx_debug: bool,
+    pub _encoder_debug: bool,
+    pub _decoder_debug: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1,4 +1,7 @@
-use alvr_common::{LogSeverity, LogSeverityDefault, LogSeverityDefaultVariant};
+use alvr_common::{
+    DebugGroupsConfig, DebugGroupsConfigDefault, LogSeverity, LogSeverityDefault,
+    LogSeverityDefaultVariant,
+};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
 use settings_schema::{
@@ -1146,6 +1149,9 @@ pub struct LoggingConfig {
 
     #[schema(flag = "real-time")]
     pub log_haptics: bool,
+
+    #[schema(strings(help = "These settings enable extra spammy logs for debugging purposes."))]
+    pub debug_groups: DebugGroupsConfig,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -1709,6 +1715,19 @@ pub fn session_settings_default() -> SettingsDefault {
                 },
                 prefer_backtrace: false,
                 show_notification_tip: true,
+                debug_groups: DebugGroupsConfigDefault {
+                    gui_collapsed: true,
+                    server_impl: false,
+                    client_impl: false,
+                    server_core: false,
+                    client_core: false,
+                    handshake: false,
+                    sockets: false,
+                    server_gfx: false,
+                    client_gfx: false,
+                    encoder: false,
+                    decoder: false,
+                },
             },
             steamvr_launcher: SteamvrLauncherDefault {
                 driver_launch_action: DriverLaunchActionDefault {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1150,6 +1150,7 @@ pub struct LoggingConfig {
     #[schema(flag = "real-time")]
     pub log_haptics: bool,
 
+    #[cfg_attr(not(debug_assertions), schema(flag = "hidden"))]
     #[schema(strings(help = "These settings enable extra spammy logs for debugging purposes."))]
     pub debug_groups: DebugGroupsConfig,
 }
@@ -1716,7 +1717,6 @@ pub fn session_settings_default() -> SettingsDefault {
                 prefer_backtrace: false,
                 show_notification_tip: true,
                 debug_groups: DebugGroupsConfigDefault {
-                    gui_collapsed: true,
                     server_impl: false,
                     client_impl: false,
                     server_core: false,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1721,7 +1721,7 @@ pub fn session_settings_default() -> SettingsDefault {
                     client_impl: false,
                     server_core: false,
                     client_core: false,
-                    handshake: false,
+                    connection: false,
                     sockets: false,
                     server_gfx: false,
                     client_gfx: false,


### PR DESCRIPTION
Note: I thought about using the tracing crate, but for now there are no strong reasons to do it. Could be slightly cleaner to use attributes for function scopes. In any case the switch can be done at a later moment.