### PR TITLE
fix for nvenc hevc error popups - issue #2258

### DIFF
--- a/alvr/server_openvr/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -119,8 +119,8 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(
         break;
     }
 
-    if (codec_id == ALVR_CODEC_H264) { 
-        switch (settings.m_h264Profile) {           
+    if (codec_id == ALVR_CODEC_H264) {
+        switch (settings.m_h264Profile) {
         case ALVR_H264_PROFILE_BASELINE:
             av_opt_set(encoder_ctx->priv_data, "profile", "baseline", 0);
             break;
@@ -133,7 +133,7 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(
             break;
         }
     }
-    
+
     char preset[] = "p0";
     // replace 0 with preset number
     preset[1] += settings.m_nvencQualityPreset;

--- a/alvr/server_openvr/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -119,19 +119,21 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(
         break;
     }
 
-    switch (settings.m_h264Profile) {
-    case ALVR_H264_PROFILE_BASELINE:
-        av_opt_set(encoder_ctx->priv_data, "profile", "baseline", 0);
-        break;
-    case ALVR_H264_PROFILE_MAIN:
-        av_opt_set(encoder_ctx->priv_data, "profile", "main", 0);
-        break;
-    default:
-    case ALVR_H264_PROFILE_HIGH:
-        av_opt_set(encoder_ctx->priv_data, "profile", "high", 0);
-        break;
+    if (codec_id == ALVR_CODEC_H264) { 
+        switch (settings.m_h264Profile) {           
+        case ALVR_H264_PROFILE_BASELINE:
+            av_opt_set(encoder_ctx->priv_data, "profile", "baseline", 0);
+            break;
+        case ALVR_H264_PROFILE_MAIN:
+            av_opt_set(encoder_ctx->priv_data, "profile", "main", 0);
+            break;
+        default:
+        case ALVR_H264_PROFILE_HIGH:
+            av_opt_set(encoder_ctx->priv_data, "profile", "high", 0);
+            break;
+        }
     }
-
+    
     char preset[] = "p0";
     // replace 0 with preset number
     preset[1] += settings.m_nvencQualityPreset;


### PR DESCRIPTION
as suggested by @Xaphiosis  on discord
tested using flatpak builder and launcher from other pr - no error popups anymore when using hevc