### PR TITLE
feat: add nix-shell file for nvidia

### DIFF
--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -264,7 +264,7 @@ pub fn build_ffmpeg_linux(nvenc_flag: bool, deps_path: &Path) {
             ];
 
             let env_vars = format!(
-                "PKG_CONFIG_PATH='{}'",
+                "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:'{}'",
                 header_build_dir.join("lib/pkgconfig").display()
             );
             let flags_combined = flags.join(" ");

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell.override { stdenv = pkgs.cudaPackages.backendStdenv; } {
+  nativeBuildInputs = [ pkgs.pkg-config ];
+  buildInputs = [
+    pkgs.cudaPackages.cuda_nvcc
+    pkgs.cudaPackages.cuda_cudart
+    pkgs.cudaPackages.libnpp
+
+    pkgs.nasm
+
+    pkgs.vulkan-headers
+    pkgs.libva
+    pkgs.libdrm
+  ];
+
+  shellHook = ''
+    unset AS
+  '';
+}


### PR DESCRIPTION
Closes #2337 

Easy to use + low code complexity solution to be able to build alvr with nvidia support on linux for distros that have issues with cuda. Note that this currently is only supposed to supplement an environment that already provides rust and a couple other necessary things, not present a full build environment (should this be changed?). It'll also need to be documented on the wiki and should hopefully replace some more manual and unreliable methods of installing cuda featured there.