### PR TITLE
feat: :sparkles: Allow overwriting fs layout; rename SERVER_DATA_MANAGER to SESSION_MANAGER

### DIFF
--- a/alvr/dashboard/src/main.rs
+++ b/alvr/dashboard/src/main.rs
@@ -34,9 +34,9 @@ fn main() {
     logging_backend::init_logging(server_events_sender.clone());
 
     {
-        let mut data_manager = data_sources::get_local_data_source();
+        let mut session_manager = data_sources::get_local_session_source();
 
-        data_manager.clean_client_list();
+        session_manager.clean_client_list();
 
         #[cfg(target_os = "linux")]
         {
@@ -51,7 +51,7 @@ fn main() {
             .any(|adapter| adapter.get_info().vendor == 0x10de);
 
             if has_nvidia {
-                data_manager
+                session_manager
                     .session_mut()
                     .session_settings
                     .extra
@@ -60,14 +60,14 @@ fn main() {
             }
         }
 
-        if data_manager.session().server_version != *ALVR_VERSION {
-            let mut session_ref = data_manager.session_mut();
+        if session_manager.session().server_version != *ALVR_VERSION {
+            let mut session_ref = session_manager.session_mut();
             session_ref.server_version = ALVR_VERSION.clone();
             session_ref.client_connections.clear();
             session_ref.session_settings.extra.open_setup_wizard = true;
         }
 
-        if data_manager
+        if session_manager
             .settings()
             .extra
             .steamvr_launcher

--- a/alvr/dashboard/src/steamvr_launcher/mod.rs
+++ b/alvr/dashboard/src/steamvr_launcher/mod.rs
@@ -73,7 +73,7 @@ impl Launcher {
         #[cfg(target_os = "linux")]
         linux_steamvr::linux_hardware_checks();
 
-        let mut data_source = data_sources::get_local_data_source();
+        let mut data_source = data_sources::get_local_session_source();
 
         let launch_action = &data_source
             .settings()

--- a/alvr/filesystem/src/lib.rs
+++ b/alvr/filesystem/src/lib.rs
@@ -78,7 +78,7 @@ pub fn dashboard_fname() -> &'static str {
 }
 
 // Layout of the ALVR installation. All paths are absolute
-#[derive(Clone)]
+#[derive(Clone, Default, Debug)]
 pub struct Layout {
     // directory containing the dashboard executable
     pub executables_dir: PathBuf,

--- a/alvr/server_core/src/web_server.rs
+++ b/alvr/server_core/src/web_server.rs
@@ -1,6 +1,6 @@
 use crate::{
     logging_backend::LOGGING_EVENTS_SENDER, ConnectionContext, ServerCoreEvent, FILESYSTEM_LAYOUT,
-    SERVER_DATA_MANAGER,
+    SESSION_MANAGER,
 };
 use alvr_common::{
     anyhow::{self, Result},
@@ -12,7 +12,7 @@ use bytes::Buf;
 use futures::SinkExt;
 use headers::HeaderMapExt;
 use hyper::{
-    header::{self, HeaderValue, ACCESS_CONTROL_ALLOW_ORIGIN, CACHE_CONTROL, CONTENT_TYPE},
+    header::{self, HeaderValue, ACCESS_CONTROL_ALLOW_ORIGIN, CACHE_CONTROL},
     service, Body, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
@@ -20,7 +20,6 @@ use serde_json as json;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::broadcast::{self, error::RecvError};
 use tokio_tungstenite::{tungstenite::protocol, WebSocketStream};
-use tokio_util::codec::{BytesCodec, FramedRead};
 
 pub const WS_BROADCAST_CAPACITY: usize = 256;
 
@@ -102,22 +101,22 @@ async fn http_api(
                     }
                     ServerRequest::GetSession => {
                         alvr_events::send_event(EventType::Session(Box::new(
-                            SERVER_DATA_MANAGER.read().session().clone(),
+                            crate::SESSION_MANAGER.read().session().clone(),
                         )));
                     }
                     ServerRequest::UpdateSession(session) => {
-                        *SERVER_DATA_MANAGER.write().session_mut() = *session
+                        *SESSION_MANAGER.write().session_mut() = *session
                     }
                     ServerRequest::SetValues(descs) => {
-                        SERVER_DATA_MANAGER.write().set_values(descs).ok();
+                        SESSION_MANAGER.write().set_values(descs).ok();
                     }
                     ServerRequest::UpdateClientList {
                         hostname,
                         mut action,
                     } => {
-                        let mut data_manager = SERVER_DATA_MANAGER.write();
+                        let mut session_manager = SESSION_MANAGER.write();
                         if matches!(action, ClientListAction::RemoveEntry) {
-                            if let Some(entry) = data_manager.client_list().get(&hostname) {
+                            if let Some(entry) = session_manager.client_list().get(&hostname) {
                                 if entry.connection_state != ConnectionState::Disconnected {
                                     connection_context
                                         .clients_to_be_removed
@@ -131,10 +130,10 @@ async fn http_api(
                             }
                         }
 
-                        data_manager.update_client_list(hostname, action);
+                        session_manager.update_client_list(hostname, action);
                     }
                     ServerRequest::GetAudioDevices => {
-                        if let Ok(list) = SERVER_DATA_MANAGER.read().get_audio_devices_list() {
+                        if let Ok(list) = crate::SESSION_MANAGER.read().get_audio_devices_list() {
                             alvr_events::send_event(EventType::AudioDevices(list));
                         }
                     }
@@ -152,7 +151,7 @@ async fn http_api(
                     }
                     ServerRequest::StartRecording => crate::create_recording_file(
                         connection_context,
-                        SERVER_DATA_MANAGER.read().settings(),
+                        crate::SESSION_MANAGER.read().settings(),
                     ),
                     ServerRequest::StopRecording => {
                         *connection_context.video_recording_file.lock() = None
@@ -166,7 +165,11 @@ async fn http_api(
                     }
                     ServerRequest::RegisterAlvrDriver => {
                         alvr_server_io::driver_registration(
-                            &[FILESYSTEM_LAYOUT.openvr_driver_root_dir.clone()],
+                            &[FILESYSTEM_LAYOUT
+                                .get()
+                                .unwrap()
+                                .openvr_driver_root_dir
+                                .clone()],
                             true,
                         )
                         .ok();
@@ -267,37 +270,7 @@ async fn http_api(
                 .body(latency.to_string().into())?
         }
         "/api/ping" => reply(StatusCode::OK)?,
-        other_uri => {
-            if other_uri.contains("..") {
-                // Attempted tree traversal
-                reply(StatusCode::FORBIDDEN)?
-            } else {
-                let path_branch = match other_uri {
-                    "/" => "/index.html",
-                    other_path => other_path,
-                };
-
-                let maybe_file = tokio::fs::File::open(format!(
-                    "{}{path_branch}",
-                    FILESYSTEM_LAYOUT.dashboard_dir().to_string_lossy(),
-                ))
-                .await;
-
-                if let Ok(file) = maybe_file {
-                    let mut builder = Response::builder();
-                    if other_uri.ends_with(".js") {
-                        builder = builder.header(CONTENT_TYPE, "text/javascript");
-                    }
-                    if other_uri.ends_with(".wasm") {
-                        builder = builder.header(CONTENT_TYPE, "application/wasm");
-                    }
-
-                    builder.body(Body::wrap_stream(FramedRead::new(file, BytesCodec::new())))?
-                } else {
-                    reply(StatusCode::NOT_FOUND)?
-                }
-            }
-        }
+        _ => reply(StatusCode::NOT_FOUND)?,
     };
 
     response.headers_mut().insert(
@@ -312,7 +285,7 @@ async fn http_api(
 }
 
 pub async fn web_server(connection_context: Arc<ConnectionContext>) -> Result<()> {
-    let web_server_port = SERVER_DATA_MANAGER
+    let web_server_port = crate::SESSION_MANAGER
         .read()
         .settings()
         .connection

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -377,7 +377,14 @@ pub unsafe extern "C" fn HmdDriverFactory(
 ) -> *mut c_void {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
-        alvr_server_core::init_logging();
+        alvr_server_core::initialize_environment(FILESYSTEM_LAYOUT.clone());
+
+        let log_to_disk = alvr_server_core::settings().extra.logging.log_to_disk;
+
+        alvr_server_core::init_logging(
+            log_to_disk.then(|| FILESYSTEM_LAYOUT.session_log()),
+            Some(FILESYSTEM_LAYOUT.crash_log()),
+        );
 
         unsafe {
             g_sessionPath = CString::new(FILESYSTEM_LAYOUT.session().to_string_lossy().to_string())


### PR DESCRIPTION
This PR is required for Monado support, as in that case the FILESYSTEM_LAYOUT should not be initialized using the openvr config.
Furthermore this PR allows ServerCore to be initialized without requiring fs I/O, so it can be easily integrated in unit tests.