### PR TITLE
fix(client_core): :bug: Fix stream on Focus 3 with FFE off

### DIFF
--- a/alvr/client_core/src/graphics/staging.rs
+++ b/alvr/client_core/src/graphics/staging.rs
@@ -99,6 +99,7 @@ impl StagingRenderer {
     #[allow(unused_variables)]
     pub unsafe fn render(&self, hardware_buffer: *mut c_void) {
         let gl = &self.context.gl_context;
+        self.context.make_current();
 
         self.context.render_ahardwarebuffer_using_texture(
             hardware_buffer,
@@ -112,6 +113,7 @@ impl StagingRenderer {
 
                 ck!(gl.active_texture(gl::TEXTURE0));
                 ck!(gl.bind_texture(GL_TEXTURE_EXTERNAL_OES, Some(self.surface_texture)));
+                ck!(gl.bind_sampler(0, None));
                 ck!(gl.draw_arrays(gl::TRIANGLE_STRIP, 0, 4));
             },
         );
@@ -121,6 +123,8 @@ impl StagingRenderer {
 impl Drop for StagingRenderer {
     fn drop(&mut self) {
         let gl = &self.context.gl_context;
+        self.context.make_current();
+
         unsafe {
             ck!(gl.delete_program(self.program));
             ck!(gl.delete_texture(self.surface_texture));

--- a/alvr/client_core/src/graphics/stream.rs
+++ b/alvr/client_core/src/graphics/stream.rs
@@ -261,6 +261,8 @@ impl StreamRenderer {
 
             self.context.queue.submit(iter::once(encoder.finish()));
         } else {
+            self.context.make_current();
+
             #[cfg(all(target_os = "android", feature = "use-cpp"))]
             super::opengl::renderStreamNative(hardware_buffer, swapchain_indices.as_ptr());
         }
@@ -269,6 +271,8 @@ impl StreamRenderer {
 
 impl Drop for StreamRenderer {
     fn drop(&mut self) {
+        self.context.make_current();
+
         #[cfg(all(target_os = "android", feature = "use-cpp"))]
         if self.render_objects.is_none() {
             unsafe { super::opengl::destroyStream() };


### PR DESCRIPTION
The main fix is the line `gl.bind_sampler(0, None)`. wgpu binds a sampler object and doesn't unbind it. I also add some more `make_current()` calls for correctness.