### PR TITLE
fix: :bug: Fix and rework logging

### DIFF
--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -16,80 +16,82 @@ pub const ENCODER_DBG_LABEL: &str = "ENCODER";
 pub const DECODER_DBG_LABEL: &str = "DECODER";
 
 #[macro_export]
-macro_rules! _dbg_label {
-    ($label:expr, $($args:tt)*) => {{
-        #[cfg(debug_assertions)]
-        $crate::log::debug!("[{}] {}", $label, format_args!($($args)*));
-    }};
-}
-
-#[macro_export]
 macro_rules! dbg_server_impl {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::SERVER_IMPL_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::SERVER_IMPL_DBG_LABEL, $($args)*);
     };
 }
 
 #[macro_export]
 macro_rules! dbg_client_impl {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::CLIENT_IMPL_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::CLIENT_IMPL_DBG_LABEL, $($args)*);
     };
 }
 
 #[macro_export]
 macro_rules! dbg_server_core {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::SERVER_CORE_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::SERVER_CORE_DBG_LABEL, $($args)*);
     };
 }
 
 #[macro_export]
 macro_rules! dbg_client_core {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::CLIENT_CORE_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::CLIENT_CORE_DBG_LABEL, $($args)*);
     };
 }
 
 #[macro_export]
 macro_rules! dbg_connection {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::CONNECTION_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::CONNECTION_DBG_LABEL, $($args)*);
     };
 }
 
 #[macro_export]
 macro_rules! dbg_sockets {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::SOCKETS_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::SOCKETS_DBG_LABEL, $($args)*);
     };
 }
 
 #[macro_export]
 macro_rules! dbg_server_gfx {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::SERVER_GFX_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::SERVER_GFX_DBG_LABEL, $($args)*);
     };
 }
 
 #[macro_export]
 macro_rules! dbg_client_gfx {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::CLIENT_GFX_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::CLIENT_GFX_DBG_LABEL, $($args)*);
     };
 }
 
 #[macro_export]
 macro_rules! dbg_encoder {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::ENCODER_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::ENCODER_DBG_LABEL, $($args)*);
     };
 }
 
 #[macro_export]
 macro_rules! dbg_decoder {
     ($($args:tt)*) => {
-        $crate::_dbg_label!($crate::DECODER_DBG_LABEL, $($args)*);
+        #[cfg(debug_assertions)]
+        $crate::log::debug!(target: $crate::DECODER_DBG_LABEL, $($args)*);
     };
 }
 
@@ -117,30 +119,33 @@ pub struct DebugGroupsConfig {
     pub decoder: bool,
 }
 
-pub fn filter_debug_groups(message: &str, config: &DebugGroupsConfig) -> bool {
-    if message.starts_with(&format!("[{SERVER_IMPL_DBG_LABEL}]")) {
-        config.server_impl
-    } else if message.starts_with(&format!("[{CLIENT_IMPL_DBG_LABEL}]")) {
-        config.client_impl
-    } else if message.starts_with(&format!("[{SERVER_CORE_DBG_LABEL}]")) {
-        config.server_core
-    } else if message.starts_with(&format!("[{CLIENT_CORE_DBG_LABEL}]")) {
-        config.client_core
-    } else if message.starts_with(&format!("[{CONNECTION_DBG_LABEL}]")) {
-        config.connection
-    } else if message.starts_with(&format!("[{SOCKETS_DBG_LABEL}]")) {
-        config.sockets
-    } else if message.starts_with(&format!("[{SERVER_GFX_DBG_LABEL}]")) {
-        config.server_gfx
-    } else if message.starts_with(&format!("[{CLIENT_GFX_DBG_LABEL}]")) {
-        config.client_gfx
-    } else if message.starts_with(&format!("[{ENCODER_DBG_LABEL}]")) {
-        config.encoder
-    } else if message.starts_with(&format!("[{DECODER_DBG_LABEL}]")) {
-        config.decoder
-    } else {
-        true
+pub fn filter_debug_groups(target: &str, config: &DebugGroupsConfig) -> bool {
+    match target {
+        SERVER_IMPL_DBG_LABEL => config.server_impl,
+        CLIENT_IMPL_DBG_LABEL => config.client_impl,
+        SERVER_CORE_DBG_LABEL => config.server_core,
+        CLIENT_CORE_DBG_LABEL => config.client_core,
+        CONNECTION_DBG_LABEL => config.connection,
+        SOCKETS_DBG_LABEL => config.sockets,
+        SERVER_GFX_DBG_LABEL => config.server_gfx,
+        CLIENT_GFX_DBG_LABEL => config.client_gfx,
+        ENCODER_DBG_LABEL => config.encoder,
+        DECODER_DBG_LABEL => config.decoder,
+        _ => true,
     }
+}
+
+pub fn is_enabled_debug_group(target: &str, config: &DebugGroupsConfig) -> bool {
+    (config.server_impl && target == SERVER_IMPL_DBG_LABEL)
+        || (config.client_impl && target == CLIENT_IMPL_DBG_LABEL)
+        || (config.server_core && target == SERVER_CORE_DBG_LABEL)
+        || (config.client_core && target == CLIENT_CORE_DBG_LABEL)
+        || (config.connection && target == CONNECTION_DBG_LABEL)
+        || (config.sockets && target == SOCKETS_DBG_LABEL)
+        || (config.server_gfx && target == SERVER_GFX_DBG_LABEL)
+        || (config.client_gfx && target == CLIENT_GFX_DBG_LABEL)
+        || (config.encoder && target == ENCODER_DBG_LABEL)
+        || (config.decoder && target == DECODER_DBG_LABEL)
 }
 
 #[derive(

--- a/alvr/dashboard/src/data_sources.rs
+++ b/alvr/dashboard/src/data_sources.rs
@@ -231,7 +231,6 @@ impl DataSources {
                         match ws.read() {
                             Ok(tungstenite::Message::Text(json_string)) => {
                                 if let Ok(event) = serde_json::from_str(&json_string) {
-                                    debug!("Server event received: {:?}", event);
                                     events_sender
                                         .send(PolledEvent {
                                             inner: event,

--- a/alvr/dashboard/src/logging_backend.rs
+++ b/alvr/dashboard/src/logging_backend.rs
@@ -21,7 +21,7 @@ pub fn init_logging(event_sender: mpsc::Sender<PolledEvent>) {
             LevelFilter::Info
         })
         .format(move |f, record| {
-            let timestamp = chrono::Local::now().format("%H:%M:%S.%f").to_string();
+            let timestamp = chrono::Local::now().format("%H:%M:%S.%3f").to_string();
 
             event_sender
                 .lock()

--- a/alvr/server_core/src/c_api.rs
+++ b/alvr/server_core/src/c_api.rs
@@ -200,7 +200,7 @@ pub unsafe extern "C" fn alvr_path_to_id(path_string: *const c_char) -> u64 {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn alvr_log_error(string_ptr: *const c_char) {
+pub unsafe extern "C" fn alvr_error(string_ptr: *const c_char) {
     alvr_common::show_e(CStr::from_ptr(string_ptr).to_string_lossy());
 }
 
@@ -209,28 +209,23 @@ pub unsafe fn log(level: log::Level, string_ptr: *const c_char) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn alvr_log_warn(string_ptr: *const c_char) {
+pub unsafe extern "C" fn alvr_warn(string_ptr: *const c_char) {
     log(log::Level::Warn, string_ptr);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn alvr_log_info(string_ptr: *const c_char) {
+pub unsafe extern "C" fn alvr_info(string_ptr: *const c_char) {
     log(log::Level::Info, string_ptr);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn alvr_log_debug(string_ptr: *const c_char) {
-    log(log::Level::Debug, string_ptr);
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn alvr_dbg_server_impl(string_ptr: *const c_char) {
-    alvr_common::dbg_server_impl!("{}", CStr::from_ptr(string_ptr).to_str().unwrap());
+    alvr_common::dbg_server_impl!("{}", CStr::from_ptr(string_ptr).to_string_lossy());
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn alvr_dbg_encoder(string_ptr: *const c_char) {
-    alvr_common::dbg_encoder!("{}", CStr::from_ptr(string_ptr).to_str().unwrap());
+    alvr_common::dbg_encoder!("{}", CStr::from_ptr(string_ptr).to_string_lossy());
 }
 
 // Should not be used in production

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -683,6 +683,8 @@ fn connection_pipeline(
         },
     ));
 
+    debug!(target: "server_core", "Connection established with {client_hostname}");
+
     *ctx.bitrate_manager.lock() = BitrateManager::new(settings.video.bitrate.history_size, fps);
 
     dbg_connection!("connection_pipeline: StreamSocket connect_to_client");

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -683,8 +683,6 @@ fn connection_pipeline(
         },
     ));
 
-    debug!(target: "server_core", "Connection established with {client_hostname}");
-
     *ctx.bitrate_manager.lock() = BitrateManager::new(settings.video.bitrate.history_size, fps);
 
     dbg_connection!("connection_pipeline: StreamSocket connect_to_client");

--- a/alvr/server_core/src/logging_backend.rs
+++ b/alvr/server_core/src/logging_backend.rs
@@ -21,29 +21,41 @@ pub fn init_logging(session_log_path: Option<PathBuf>, crash_log_path: Option<Pa
 
     let mut log_dispatch = Dispatch::new()
         // Note: meta::target() is in the format <crate>::<module>
-        .filter(|meta| !meta.target().starts_with("mdns_sd"))
+        .filter({
+            let debug_groups_config = debug_groups_config.clone();
+            move |meta| {
+                !meta.target().starts_with("mdns_sd")
+                    && (meta.level() <= LevelFilter::Info
+                        || alvr_common::filter_debug_groups(meta.target(), &debug_groups_config))
+            }
+        })
         .format(move |out, message, record| {
             let maybe_event = format!("{message}");
             let event_type = if maybe_event.starts_with('{') && maybe_event.ends_with('}') {
                 serde_json::from_str(&maybe_event).unwrap()
-            } else {
-                let log_level = record.level();
-                if log_level <= LevelFilter::Info
-                    || alvr_common::filter_debug_groups(&maybe_event, &debug_groups_config)
-                {
-                    EventType::Log(LogEntry {
-                        severity: LogSeverity::from_log_level(record.level()),
-                        content: message.to_string(),
-                    })
-                } else {
-                    return;
+            } else if record.level() == LevelFilter::Debug
+                && alvr_common::is_enabled_debug_group(record.target(), &debug_groups_config)
+            {
+                EventType::DebugGroup {
+                    group: record.target().to_string(),
+                    message: message.to_string(),
                 }
+            } else {
+                EventType::Log(LogEntry {
+                    severity: LogSeverity::from_log_level(record.level()),
+                    content: message.to_string(),
+                })
             };
             let event = Event {
-                timestamp: Local::now().format("%H:%M:%S.%f").to_string(),
+                timestamp: Local::now().format("%H:%M:%S.%3f").to_string(),
                 event_type,
             };
-            out.finish(format_args!("{}", serde_json::to_string(&event).unwrap()));
+            out.finish(format_args!(
+                "{} [{}] {}",
+                event.timestamp,
+                event.event_type_string(),
+                event.message(),
+            ));
 
             LOGGING_EVENTS_SENDER.send(event).ok();
         });

--- a/alvr/server_core/src/web_server.rs
+++ b/alvr/server_core/src/web_server.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use alvr_common::{
     anyhow::{self, Result},
-    error, info, log, warn, ConnectionState,
+    error, info, log, ConnectionState,
 };
 use alvr_events::{ButtonEvent, EventType};
 use alvr_packets::{ButtonEntry, ClientListAction, ServerRequest};
@@ -58,9 +58,7 @@ async fn websocket<T: Clone + Send + 'static>(
 
                                 ws.flush().await.ok();
                             }
-                            Err(RecvError::Lagged(_)) => {
-                                warn!("Some log lines have been lost because the buffer is full");
-                            }
+                            Err(RecvError::Lagged(_)) => (),
                             Err(RecvError::Closed) => break,
                         }
                     }

--- a/alvr/server_openvr/build.rs
+++ b/alvr/server_openvr/build.rs
@@ -79,8 +79,8 @@ fn main() {
         build.define("__APPLE__", None);
     }
 
-    // #[cfg(debug_assertions)]
-    // build.define("ALVR_DEBUG_LOG", None);
+    #[cfg(debug_assertions)]
+    build.define("ALVR_DEBUG_LOG", None);
 
     let gpl_or_linux = cfg!(feature = "gpl") || cfg!(target_os = "linux");
 

--- a/alvr/server_openvr/cpp/alvr_server/ChaperoneUpdater.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/ChaperoneUpdater.cpp
@@ -17,6 +17,8 @@ std::mutex chaperone_mutex;
 bool isOpenvrInit = false;
 
 void InitOpenvrClient() {
+    Debug("InitOpenvrClient");
+
 #ifndef __APPLE__
     std::unique_lock<std::mutex> lock(chaperone_mutex);
 
@@ -37,6 +39,8 @@ void InitOpenvrClient() {
 }
 
 void ShutdownOpenvrClient() {
+    Debug("ShutdownOpenvrClient");
+
 #ifndef __APPLE__
     std::unique_lock<std::mutex> lock(chaperone_mutex);
 
@@ -52,6 +56,8 @@ void ShutdownOpenvrClient() {
 bool IsOpenvrClientReady() { return isOpenvrInit; }
 
 void _SetChaperoneArea(float areaWidth, float areaHeight) {
+    Debug("SetChaperoneArea");
+
 #ifndef __APPLE__
     std::unique_lock<std::mutex> lock(chaperone_mutex);
 
@@ -95,6 +101,8 @@ void _SetChaperoneArea(float areaWidth, float areaHeight) {
 
 #ifdef __linux__
 std::unique_ptr<vr::HmdMatrix34_t> GetInvZeroPose() {
+    Debug("GetInvZeroPose");
+
     std::unique_lock<std::mutex> lock(chaperone_mutex);
     if (!isOpenvrInit) {
         return nullptr;

--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -17,7 +17,7 @@ vr::ETrackedDeviceClass Controller::getControllerDeviceClass() {
 Controller::Controller(uint64_t deviceID, vr::EVRSkeletalTrackingLevel skeletonLevel)
     : TrackedDevice(deviceID)
     , m_skeletonLevel(skeletonLevel) {
-    Debug("Controller::constructor");
+    Debug("Controller::constructor deviceID=%llu", deviceID);
 
     m_pose = vr::DriverPose_t {};
     m_pose.poseIsValid = false;
@@ -34,7 +34,7 @@ Controller::Controller(uint64_t deviceID, vr::EVRSkeletalTrackingLevel skeletonL
 //
 
 vr::EVRInitError Controller::Activate(vr::TrackedDeviceIndex_t unObjectId) {
-    Debug("Controller::Activate");
+    Debug("Controller::Activate deviceID=%llu", this->device_id);
 
     auto vr_properties = vr::VRProperties();
     auto vr_driver_input = vr::VRDriverInput();
@@ -124,14 +124,18 @@ vr::EVRInitError Controller::Activate(vr::TrackedDeviceIndex_t unObjectId) {
 }
 
 void Controller::Deactivate() {
-    Debug("Controller::Deactivate");
+    Debug("Controller::Deactivate deviceID=%llu", this->device_id);
     this->object_id = vr::k_unTrackedDeviceIndexInvalid;
 }
 
 void Controller::EnterStandby() { }
 
 void* Controller::GetComponent(const char* pchComponentNameAndVersion) {
-    Debug("Controller::GetComponent. Name=%hs", pchComponentNameAndVersion);
+    Debug(
+        "Controller::GetComponent deviceID=%llu Name=%hs",
+        this->device_id,
+        pchComponentNameAndVersion
+    );
 
     return NULL;
 }
@@ -151,7 +155,7 @@ vr::DriverPose_t Controller::GetPose() { return m_pose; }
 vr::VRInputComponentHandle_t Controller::getHapticComponent() { return m_compHaptic; }
 
 void Controller::RegisterButton(uint64_t id) {
-    Debug("Controller::RegisterButton");
+    Debug("Controller::RegisterButton deviceID=%llu", this->device_id);
 
     ButtonInfo buttonInfo;
     if (device_id == HAND_LEFT_ID) {
@@ -184,7 +188,7 @@ void Controller::RegisterButton(uint64_t id) {
 }
 
 void Controller::SetButton(uint64_t id, FfiButtonValue value) {
-    Debug("Controller::RegisterButton id=%llu", id);
+    Debug("Controller::SetButton deviceID=%llu buttonID=%llu", this->device_id, id);
 
     if (!this->isEnabled()) {
         return;

--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -17,6 +17,8 @@ vr::ETrackedDeviceClass Controller::getControllerDeviceClass() {
 Controller::Controller(uint64_t deviceID, vr::EVRSkeletalTrackingLevel skeletonLevel)
     : TrackedDevice(deviceID)
     , m_skeletonLevel(skeletonLevel) {
+    Debug("Controller::constructor");
+
     m_pose = vr::DriverPose_t {};
     m_pose.poseIsValid = false;
     m_pose.deviceIsConnected = false;
@@ -32,7 +34,7 @@ Controller::Controller(uint64_t deviceID, vr::EVRSkeletalTrackingLevel skeletonL
 //
 
 vr::EVRInitError Controller::Activate(vr::TrackedDeviceIndex_t unObjectId) {
-    Debug("RemoteController::Activate. objectId=%d\n", unObjectId);
+    Debug("Controller::Activate");
 
     auto vr_properties = vr::VRProperties();
     auto vr_driver_input = vr::VRDriverInput();
@@ -122,14 +124,14 @@ vr::EVRInitError Controller::Activate(vr::TrackedDeviceIndex_t unObjectId) {
 }
 
 void Controller::Deactivate() {
-    Debug("RemoteController::Deactivate\n");
+    Debug("Controller::Deactivate");
     this->object_id = vr::k_unTrackedDeviceIndexInvalid;
 }
 
 void Controller::EnterStandby() { }
 
 void* Controller::GetComponent(const char* pchComponentNameAndVersion) {
-    Debug("RemoteController::GetComponent. Name=%hs\n", pchComponentNameAndVersion);
+    Debug("Controller::GetComponent. Name=%hs", pchComponentNameAndVersion);
 
     return NULL;
 }
@@ -149,6 +151,8 @@ vr::DriverPose_t Controller::GetPose() { return m_pose; }
 vr::VRInputComponentHandle_t Controller::getHapticComponent() { return m_compHaptic; }
 
 void Controller::RegisterButton(uint64_t id) {
+    Debug("Controller::RegisterButton");
+
     ButtonInfo buttonInfo;
     if (device_id == HAND_LEFT_ID) {
         buttonInfo = LEFT_CONTROLLER_BUTTON_MAPPING[id];
@@ -180,6 +184,8 @@ void Controller::RegisterButton(uint64_t id) {
 }
 
 void Controller::SetButton(uint64_t id, FfiButtonValue value) {
+    Debug("Controller::RegisterButton id=%llu", id);
+
     if (!this->isEnabled()) {
         return;
     }

--- a/alvr/server_openvr/cpp/alvr_server/FakeViveTracker.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/FakeViveTracker.cpp
@@ -1,6 +1,7 @@
 #include "FakeViveTracker.h"
 #include "Settings.h"
 
+#include "Logger.h"
 #include "Utils.h"
 #include "bindings.h"
 #include <cassert>
@@ -13,6 +14,8 @@ FakeViveTracker::FakeViveTracker(std::string name)
 vr::DriverPose_t FakeViveTracker::GetPose() { return m_pose; }
 
 vr::EVRInitError FakeViveTracker::Activate(vr::TrackedDeviceIndex_t unObjectId) {
+    Debug("FakeViveTracker::Activate");
+
     auto vr_properties = vr::VRProperties();
 
     m_unObjectId = unObjectId;

--- a/alvr/server_openvr/cpp/alvr_server/HMD.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/HMD.cpp
@@ -35,6 +35,8 @@ Hmd::Hmd()
     : TrackedDevice(HEAD_ID)
     , m_baseComponentsInitialized(false)
     , m_streamComponentsInitialized(false) {
+    Debug("Hmd::constructor");
+
     auto dummy_fov = FfiFov { -1.0, 1.0, 1.0, -1.0 };
 
     this->views_config = FfiViewsConfig {};
@@ -66,12 +68,10 @@ Hmd::Hmd()
             Warn("Failed to register Vive tracker");
         }
     }
-
-    Debug("CRemoteHmd successfully initialized.\n");
 }
 
 Hmd::~Hmd() {
-    // ShutdownRuntime();
+    Debug("Hmd::destructor");
 
     if (m_encoder) {
         Debug("Hmd::~Hmd(): Stopping encoder...\n");
@@ -88,7 +88,7 @@ Hmd::~Hmd() {
 }
 
 vr::EVRInitError Hmd::Activate(vr::TrackedDeviceIndex_t unObjectId) {
-    Debug("CRemoteHmd Activate %d\n", unObjectId);
+    Debug("Hmd::Activate");
 
     auto vr_properties = vr::VRProperties();
 
@@ -182,11 +182,15 @@ vr::EVRInitError Hmd::Activate(vr::TrackedDeviceIndex_t unObjectId) {
 }
 
 void Hmd::Deactivate() {
+    Debug("Hmd::Deactivate");
+
     this->object_id = vr::k_unTrackedDeviceIndexInvalid;
     this->prop_container = vr::k_ulInvalidPropertyContainer;
 }
 
 void* Hmd::GetComponent(const char* component_name_and_version) {
+    Debug("Hmd::GetComponent %s", component_name_and_version);
+
     // NB: "this" pointer needs to be statically cast to point to the correct vtable
 
     auto name_and_vers = std::string(component_name_and_version);
@@ -206,6 +210,8 @@ void* Hmd::GetComponent(const char* component_name_and_version) {
 vr::DriverPose_t Hmd::GetPose() { return m_pose; }
 
 void Hmd::OnPoseUpdated(uint64_t targetTimestampNs, FfiDeviceMotion motion) {
+    Debug("Hmd::OnPoseUpdated");
+
     if (this->object_id == vr::k_unTrackedDeviceIndexInvalid) {
         return;
     }
@@ -251,6 +257,8 @@ void Hmd::OnPoseUpdated(uint64_t targetTimestampNs, FfiDeviceMotion motion) {
 }
 
 void Hmd::StartStreaming() {
+    Debug("Hmd::StartStreaming");
+
     vr::VRDriverInput()->UpdateBooleanComponent(m_proximity, true, 0.0);
 
     if (m_streamComponentsInitialized) {
@@ -288,9 +296,15 @@ void Hmd::StartStreaming() {
     m_streamComponentsInitialized = true;
 }
 
-void Hmd::StopStreaming() { vr::VRDriverInput()->UpdateBooleanComponent(m_proximity, false, 0.0); }
+void Hmd::StopStreaming() {
+    Debug("Hmd::StopStreaming");
+
+    vr::VRDriverInput()->UpdateBooleanComponent(m_proximity, false, 0.0);
+}
 
 void Hmd::SetViewsConfig(FfiViewsConfig config) {
+    Debug("Hmd::SetViewsConfig");
+
     this->views_config = config;
 
     auto left_transform = MATRIX_IDENTITY;
@@ -312,12 +326,13 @@ void Hmd::SetViewsConfig(FfiViewsConfig config) {
 
 void Hmd::GetWindowBounds(int32_t* pnX, int32_t* pnY, uint32_t* pnWidth, uint32_t* pnHeight) {
     Debug(
-        "GetWindowBounds %dx%d - %dx%d\n",
+        "Hmd::GetWindowBounds %dx%d - %dx%d\n",
         0,
         0,
         Settings::Instance().m_renderWidth,
         Settings::Instance().m_renderHeight
     );
+
     *pnX = 0;
     *pnY = 0;
     *pnWidth = Settings::Instance().m_renderWidth;
@@ -335,7 +350,7 @@ bool Hmd::IsDisplayRealDisplay() {
 void Hmd::GetRecommendedRenderTargetSize(uint32_t* pnWidth, uint32_t* pnHeight) {
     *pnWidth = Settings::Instance().m_recommendedTargetWidth / 2;
     *pnHeight = Settings::Instance().m_recommendedTargetHeight;
-    Debug("GetRecommendedRenderTargetSize %dx%d\n", *pnWidth, *pnHeight);
+    Debug("Hmd::GetRecommendedRenderTargetSize %dx%d\n", *pnWidth, *pnHeight);
 }
 
 void Hmd::GetEyeOutputViewport(
@@ -350,7 +365,8 @@ void Hmd::GetEyeOutputViewport(
     } else {
         *pnX = Settings::Instance().m_renderWidth / 2;
     }
-    Debug("GetEyeOutputViewport Eye=%d %dx%d %dx%d\n", eEye, *pnX, *pnY, *pnWidth, *pnHeight);
+
+    Debug("Hmd::GetEyeOutputViewport Eye=%d %dx%d %dx%d\n", eEye, *pnX, *pnY, *pnWidth, *pnHeight);
 }
 
 void Hmd::GetProjectionRaw(vr::EVREye eye, float* left, float* right, float* top, float* bottom) {
@@ -359,6 +375,8 @@ void Hmd::GetProjectionRaw(vr::EVREye eye, float* left, float* right, float* top
     *right = proj.vBottomRight.v[0];
     *top = proj.vTopLeft.v[1];
     *bottom = proj.vBottomRight.v[1];
+
+    Debug("Hmd::GetProjectionRaw Eye=%d %f %f %f %f\n", eye, *left, *right, *top, *bottom);
 }
 
 vr::DistortionCoordinates_t Hmd::ComputeDistortion(vr::EVREye, float u, float v) {

--- a/alvr/server_openvr/cpp/alvr_server/Logger.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Logger.cpp
@@ -15,10 +15,7 @@ void _log(const char* format, va_list args, void (*logFn)(const char*), bool dri
 
     logFn(buf);
 
-    // TODO: driver logger should concider current log level
-#ifndef ALVR_DEBUG_LOG
     if (driverLog)
-#endif
         DriverLog(buf);
 }
 
@@ -54,7 +51,6 @@ void Info(const char* format, ...) {
 }
 
 void Debug(const char* format, ...) {
-// Use our define instead of _DEBUG - see build.rs for details.
 #ifdef ALVR_DEBUG_LOG
     va_list args;
     va_start(args, format);

--- a/alvr/server_openvr/cpp/alvr_server/PoseHistory.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/PoseHistory.cpp
@@ -63,6 +63,8 @@ PoseHistory::GetBestPoseMatch(const vr::HmdMatrix34_t& pose) const {
     if (minIt != m_poseBuffer.end()) {
         return *minIt;
     }
+
+    Debug("PoseHistory::GetBestPoseMatch: No pose matched.");
     return {};
 }
 
@@ -73,6 +75,8 @@ std::optional<PoseHistory::TrackingHistoryFrame> PoseHistory::GetPoseAt(uint64_t
         if (it->targetTimestampNs == timestampNs)
             return *it;
     }
+
+    Debug("PoseHistory::GetPoseAt: No pose matched.");
     return {};
 }
 

--- a/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
@@ -88,6 +88,8 @@ public:
     std::map<uint64_t, TrackedDevice*> tracked_devices;
 
     virtual vr::EVRInitError Init(vr::IVRDriverContext* pContext) override {
+        Debug("DriverProvider::Init");
+
         VR_INIT_SERVER_DRIVER_CONTEXT(pContext);
         InitDriverLog(vr::VRDriverLog());
 
@@ -246,6 +248,8 @@ public:
         return vr::VRInitError_None;
     }
     virtual void Cleanup() override {
+        Debug("DriverProvider::Cleanup");
+
         this->left_hand_tracker.reset();
         this->right_hand_tracker.reset();
         this->left_controller.reset();
@@ -264,6 +268,8 @@ public:
         vr::VREvent_t event;
         while (vr::VRServerDriverHost()->PollNextEvent(&event, sizeof(vr::VREvent_t))) {
             if (event.eventType == vr::VREvent_Input_HapticVibration) {
+                Debug("DriverProvider: Received HapticVibration event");
+
                 vr::VREvent_HapticVibration_t haptics = event.data.hapticVibration;
 
                 uint64_t id = 0;
@@ -296,13 +302,15 @@ public:
 #endif
         }
         if (vr::VRServerDriverHost()->IsExiting() && !shutdown_called) {
+            Debug("DriverProvider: Received shutdown event");
+
             shutdown_called = true;
             ShutdownRuntime();
         }
     }
     virtual bool ShouldBlockStandbyMode() override { return false; }
-    virtual void EnterStandby() override { }
-    virtual void LeaveStandby() override { }
+    virtual void EnterStandby() override { Debug("DriverProvider::EnterStandby"); }
+    virtual void LeaveStandby() override { Debug("DriverProvider::LeaveStandby"); }
 } g_driver_provider;
 
 // bindigs for Rust

--- a/alvr/server_openvr/cpp/platform/win32/VideoEncoderSW.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/VideoEncoderSW.cpp
@@ -18,11 +18,11 @@ VideoEncoderSW::VideoEncoderSW(std::shared_ptr<CD3DRender> d3dRender, int width,
     , m_renderWidth(width)
     , m_renderHeight(height)
     , m_bitrateInMBits(30) {
-#ifdef ALVR_DEBUG_LOG
-    av_log_set_level(AV_LOG_DEBUG);
-    av_log_set_callback(LibVALog);
-    Debug("Set FFMPEG/LibAV to debug logging");
-#endif
+    // #ifdef ALVR_DEBUG_LOG
+    //     av_log_set_level(AV_LOG_DEBUG);
+    //     av_log_set_callback(LibVALog);
+    //     Debug("Set FFMPEG/LibAV to debug logging");
+    // #endif
 }
 
 VideoEncoderSW::~VideoEncoderSW() { }

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -403,9 +403,9 @@ pub unsafe extern "C" fn HmdDriverFactory(
         graphics::initialize_shaders();
 
         unsafe {
-            LogError = Some(alvr_server_core::alvr_log_error);
-            LogWarn = Some(alvr_server_core::alvr_log_warn);
-            LogInfo = Some(alvr_server_core::alvr_log_info);
+            LogError = Some(alvr_server_core::alvr_error);
+            LogWarn = Some(alvr_server_core::alvr_warn);
+            LogInfo = Some(alvr_server_core::alvr_info);
             LogDebug = Some(alvr_server_core::alvr_dbg_server_impl);
             LogEncoder = Some(alvr_server_core::alvr_dbg_encoder);
             LogPeriodically = Some(alvr_server_core::alvr_log_periodically);


### PR DESCRIPTION
This PR achieves multiple things:
* Fix debug group filter not actually filtering logs to file or stdout
* Use log target instead of message prefix to filter debug groups
* Make debug groups separate events
* Make logging to dashboard or file more legible
* Add server impl (SteamVR) group logs