### PR TITLE
zarik staging

### DIFF
--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1301,7 +1301,7 @@ pub fn session_settings_default() -> SettingsDefault {
                     variant: BitrateModeDefaultVariant::ConstantMbps,
                 },
                 adapt_to_framerate: SwitchDefault {
-                    enabled: true,
+                    enabled: false,
                     content: BitrateAdaptiveFramerateConfigDefault {
                         framerate_reset_threshold_multiplier: 2.0,
                     },


### PR DESCRIPTION
`adapt_to_framerate` is used to correct the bitrate calculation when the framerate is lower (or more rarely higher) than expected. In this way, games that run bad can benefit at least from slightly better image quality frame-wise. The problem with this is that it may be sensitive to oscillations in the framerate, and may create an offset between the requested user requested bitrate and the bitrate that is requested to the encoder, even when the framerate normalizes (needs to be investigated).