### PR TITLE
Multimodal input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["alvr/*"]
 [workspace.package]
 version = "21.0.0-dev01"
 edition = "2021"
-rust-version = "1.76"
+rust-version = "1.77"
 authors = ["alvr-org"]
 license = "MIT"
 

--- a/alvr/client_core/src/graphics/lobby.rs
+++ b/alvr/client_core/src/graphics/lobby.rs
@@ -428,7 +428,9 @@ impl LobbyRenderer {
                         );
                         transform_draw(&mut pass, view_proj * transform, 2);
                     }
-                } else if let Some(pose) = maybe_pose {
+                }
+
+                if let Some(pose) = maybe_pose {
                     let hand_transform = Mat4::from_scale_rotation_translation(
                         Vec3::ONE * 0.2,
                         pose.orientation,

--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -23,7 +23,8 @@ use alvr_common::{
     dbg_client_core, error,
     glam::{UVec2, Vec2, Vec3},
     parking_lot::{Mutex, RwLock},
-    warn, ConnectionState, DeviceMotion, LifecycleState, Pose, HEAD_ID,
+    warn, ConnectionState, DeviceMotion, LifecycleState, Pose, HAND_LEFT_ID, HAND_RIGHT_ID,
+    HEAD_ID,
 };
 use alvr_packets::{
     BatteryInfo, ButtonEntry, ClientControlPacket, FaceData, NegotiatedStreamingConfig,
@@ -270,6 +271,32 @@ impl ClientCoreContext {
                         }))
                         .ok();
                 }
+            }
+        }
+
+        // send_tracking() expects hand data in the multimodal protocol. In case multimodal protocol
+        // is not supported, convert back to legacy protocol.
+        if !self.connection_context.uses_multimodal_protocol.value() {
+            if hand_skeletons[0].is_some() {
+                device_motions.push((
+                    *HAND_LEFT_ID,
+                    DeviceMotion {
+                        pose: hand_skeletons[0].unwrap()[0],
+                        linear_velocity: Vec3::ZERO,
+                        angular_velocity: Vec3::ZERO,
+                    },
+                ));
+            }
+
+            if hand_skeletons[1].is_some() {
+                device_motions.push((
+                    *HAND_RIGHT_ID,
+                    DeviceMotion {
+                        pose: hand_skeletons[1].unwrap()[0],
+                        linear_velocity: Vec3::ZERO,
+                        angular_velocity: Vec3::ZERO,
+                    },
+                ));
             }
         }
 

--- a/alvr/client_openxr/src/extra_extensions/body_tracking_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/body_tracking_fb.rs
@@ -5,9 +5,9 @@ use openxr::{self as xr, raw, sys};
 use std::ptr;
 
 pub const META_BODY_TRACKING_FULL_BODY_EXTENSION_NAME: &str = "XR_META_body_tracking_full_body";
-pub const TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FULL_BODY_META: Lazy<xr::StructureType> =
+static TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FULL_BODY_META: Lazy<xr::StructureType> =
     Lazy::new(|| xr::StructureType::from_raw(1000274000));
-pub const BODY_JOINT_SET_FULL_BODY_META: Lazy<xr::BodyJointSetFB> =
+pub static BODY_JOINT_SET_FULL_BODY_META: Lazy<xr::BodyJointSetFB> =
     Lazy::new(|| xr::BodyJointSetFB::from_raw(1000274000));
 
 pub const FULL_BODY_JOINT_LEFT_UPPER_LEG_META: usize = 70;

--- a/alvr/client_openxr/src/extra_extensions/mod.rs
+++ b/alvr/client_openxr/src/extra_extensions/mod.rs
@@ -2,15 +2,20 @@ mod body_tracking_fb;
 mod eye_tracking_social;
 mod face_tracking2_fb;
 mod facial_tracking_htc;
+mod multimodal_input;
 
 pub use body_tracking_fb::*;
 pub use eye_tracking_social::*;
 pub use face_tracking2_fb::*;
 pub use facial_tracking_htc::*;
+pub use multimodal_input::*;
 
-use alvr_common::anyhow::{anyhow, Result};
+use alvr_common::{
+    anyhow::{anyhow, Result},
+    error,
+};
 use openxr::{self as xr, sys};
-use std::ptr;
+use std::{mem, ptr};
 
 fn to_any(result: sys::Result) -> Result<()> {
     if result.into_raw() >= 0 {
@@ -24,13 +29,33 @@ fn to_any(result: sys::Result) -> Result<()> {
 pub struct ExtraExtensions {
     base_function_ptrs: xr::raw::Instance,
     ext_functions_ptrs: xr::InstanceExtensions,
+    resume_simultaneous_hands_and_controllers_tracking_meta:
+        Option<ResumeSimultaneousHandsAndControllersTrackingMETA>,
 }
 
 impl ExtraExtensions {
     pub fn new(instance: &xr::Instance) -> Self {
+        let resume_simultaneous_hands_and_controllers_tracking_meta = unsafe {
+            let mut resume_simultaneous_hands_and_controllers_tracking_meta = None;
+            let _ = (instance.fp().get_instance_proc_addr)(
+                instance.as_raw(),
+                c"xrResumeSimultaneousHandsAndControllersTrackingMETA".as_ptr(),
+                &mut resume_simultaneous_hands_and_controllers_tracking_meta,
+            );
+
+            resume_simultaneous_hands_and_controllers_tracking_meta
+                .map(|f| mem::transmute::<_, ResumeSimultaneousHandsAndControllersTrackingMETA>(f))
+        };
+
+        error!(
+            "resume_simultaneous_hands_and_controllers_tracking_meta: {:?}",
+            resume_simultaneous_hands_and_controllers_tracking_meta.is_some()
+        );
+
         Self {
             base_function_ptrs: instance.fp().clone(),
             ext_functions_ptrs: *instance.exts(),
+            resume_simultaneous_hands_and_controllers_tracking_meta,
         }
     }
 

--- a/alvr/client_openxr/src/extra_extensions/mod.rs
+++ b/alvr/client_openxr/src/extra_extensions/mod.rs
@@ -10,10 +10,7 @@ pub use face_tracking2_fb::*;
 pub use facial_tracking_htc::*;
 pub use multimodal_input::*;
 
-use alvr_common::{
-    anyhow::{anyhow, Result},
-    error,
-};
+use alvr_common::anyhow::{anyhow, Result};
 use openxr::{self as xr, sys};
 use std::{mem, ptr};
 
@@ -46,11 +43,6 @@ impl ExtraExtensions {
             resume_simultaneous_hands_and_controllers_tracking_meta
                 .map(|f| mem::transmute::<_, ResumeSimultaneousHandsAndControllersTrackingMETA>(f))
         };
-
-        error!(
-            "resume_simultaneous_hands_and_controllers_tracking_meta: {:?}",
-            resume_simultaneous_hands_and_controllers_tracking_meta.is_some()
-        );
 
         Self {
             base_function_ptrs: instance.fp().clone(),

--- a/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
+++ b/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
@@ -1,0 +1,77 @@
+// Code taken from:
+// https://github.com/meta-quest/Meta-OpenXR-SDK/blob/main/OpenXR/meta_openxr_preview/meta_simultaneous_hands_and_controllers.h
+
+use alvr_common::{anyhow::Result, once_cell::sync::Lazy, ToAny};
+use openxr::{self as xr, sys};
+use std::ffi::c_void;
+
+pub const META_SIMULTANEOUS_HANDS_AND_CONTROLLERS_EXTENSION_NAME: &str =
+    "XR_META_simultaneous_hands_and_controllers";
+pub const META_DETACHED_CONTROLLERS_EXTENSION_NAME: &str = "XR_META_detached_controllers";
+
+static TYPE_SYSTEM_SIMULTANEOUS_HANDS_AND_CONTROLLERS_PROPERTIES_META: Lazy<xr::StructureType> =
+    Lazy::new(|| xr::StructureType::from_raw(1000532001));
+static TYPE_SIMULTANEOUS_HANDS_AND_CONTROLLERS_TRACKING_RESUME_INFO_META: Lazy<xr::StructureType> =
+    Lazy::new(|| xr::StructureType::from_raw(1000532002));
+
+#[repr(C)]
+pub struct SystemSymultaneousHandsAndControllersPropertiesMETA {
+    ty: xr::StructureType,
+    next: *const c_void,
+    supports_simultaneous_hands_and_controllers: sys::Bool32,
+}
+
+#[repr(C)]
+pub struct SimultaneousHandsAndControllersTrackingResumeInfoMETA {
+    ty: xr::StructureType,
+    next: *const c_void,
+}
+
+pub type ResumeSimultaneousHandsAndControllersTrackingMETA =
+    unsafe extern "system" fn(
+        sys::Session,
+        *const SimultaneousHandsAndControllersTrackingResumeInfoMETA,
+    ) -> sys::Result;
+
+impl super::ExtraExtensions {
+    pub fn supports_simultaneous_hands_and_controllers(
+        &self,
+        instance: &xr::Instance,
+        system_id: xr::SystemId,
+    ) -> bool {
+        unsafe {
+            let mut properties = SystemSymultaneousHandsAndControllersPropertiesMETA {
+                ty: *TYPE_SYSTEM_SIMULTANEOUS_HANDS_AND_CONTROLLERS_PROPERTIES_META,
+                next: std::ptr::null(),
+                supports_simultaneous_hands_and_controllers: xr::sys::FALSE,
+            };
+
+            let result = (self.base_function_ptrs.get_system_properties)(
+                instance.as_raw(),
+                system_id,
+                &mut properties as *mut _ as *mut xr::sys::SystemProperties,
+            );
+
+            result == xr::sys::Result::SUCCESS
+                && properties.supports_simultaneous_hands_and_controllers == xr::sys::TRUE
+        }
+    }
+
+    pub fn resume_simultaneous_hands_and_controllers_tracking(
+        &self,
+        session: &xr::Session<xr::OpenGlEs>,
+    ) -> Result<()> {
+        let resume_info = SimultaneousHandsAndControllersTrackingResumeInfoMETA {
+            ty: *TYPE_SIMULTANEOUS_HANDS_AND_CONTROLLERS_TRACKING_RESUME_INFO_META,
+            next: std::ptr::null(),
+        };
+
+        unsafe {
+            super::to_any((self
+                .resume_simultaneous_hands_and_controllers_tracking_meta
+                .to_any()?)(session.as_raw(), &resume_info))?;
+        }
+
+        Ok(())
+    }
+}

--- a/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
+++ b/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
@@ -37,24 +37,19 @@ impl super::ExtraExtensions {
     pub fn supports_simultaneous_hands_and_controllers(
         &self,
         instance: &xr::Instance,
-        system_id: xr::SystemId,
+        system: xr::SystemId,
     ) -> bool {
-        unsafe {
-            let mut properties = SystemSymultaneousHandsAndControllersPropertiesMETA {
+        self.get_props(
+            instance,
+            system,
+            SystemSymultaneousHandsAndControllersPropertiesMETA {
                 ty: *TYPE_SYSTEM_SIMULTANEOUS_HANDS_AND_CONTROLLERS_PROPERTIES_META,
                 next: std::ptr::null(),
                 supports_simultaneous_hands_and_controllers: xr::sys::FALSE,
-            };
-
-            let result = (self.base_function_ptrs.get_system_properties)(
-                instance.as_raw(),
-                system_id,
-                &mut properties as *mut _ as *mut xr::sys::SystemProperties,
-            );
-
-            result == xr::sys::Result::SUCCESS
-                && properties.supports_simultaneous_hands_and_controllers == xr::sys::TRUE
-        }
+            },
+        )
+        .map(|props| props.supports_simultaneous_hands_and_controllers.into())
+        .unwrap_or(false)
     }
 
     pub fn resume_simultaneous_hands_and_controllers_tracking(

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -197,10 +197,16 @@ pub fn initialize_interaction(
         "/user/hand/right/output/haptic",
     ));
 
+    // Note: We cannot enable multimodal if fb body tracking is active. It would result in a
+    // ERROR_RUNTIME_FAILURE crash.
     let uses_multimodal_hands = prefer_multimodal_input
         && xr_ctx
             .extra_extensions
-            .supports_simultaneous_hands_and_controllers(&xr_ctx.instance, xr_ctx.system);
+            .supports_simultaneous_hands_and_controllers(&xr_ctx.instance, xr_ctx.system)
+        && !body_tracking_sources
+            .as_ref()
+            .map(|s| s.body_tracking_fb.enabled())
+            .unwrap_or(false);
 
     let left_detached_controller_pose_action;
     let right_detached_controller_pose_action;

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -45,6 +45,7 @@ pub struct InteractionContext {
     pub action_set: xr::ActionSet,
     pub button_actions: HashMap<u64, ButtonAction>,
     pub hands_interaction: [HandInteraction; 2],
+    pub uses_multimodal_hands: bool,
     pub face_sources: FaceSources,
     pub body_sources: BodySources,
 }
@@ -52,6 +53,7 @@ pub struct InteractionContext {
 pub fn initialize_interaction(
     xr_ctx: &XrContext,
     platform: Platform,
+    prefer_multimodal_input: bool,
     face_tracking_sources: Option<FaceTrackingSourcesConfig>,
     body_tracking_sources: Option<BodyTrackingSourcesConfig>,
 ) -> InteractionContext {
@@ -194,6 +196,48 @@ pub fn initialize_interaction(
         &right_vibration_action,
         "/user/hand/right/output/haptic",
     ));
+
+    let uses_multimodal_hands = prefer_multimodal_input
+        && xr_ctx
+            .extra_extensions
+            .supports_simultaneous_hands_and_controllers(&xr_ctx.instance, xr_ctx.system);
+
+    let left_detached_controller_pose_action;
+    let right_detached_controller_pose_action;
+    if uses_multimodal_hands {
+        xr_ctx
+            .extra_extensions
+            .resume_simultaneous_hands_and_controllers_tracking(&xr_ctx.session)
+            .ok();
+
+        // Note: when multimodal input is enabled, both controllers and hands will always be active.
+        // To be able to detect when controllers are actually held, we have to register detached
+        // controllers pose; the controller pose will be diverted to the detached controllers when
+        // they are not held. Currently the detached controllers pose is ignored
+        left_detached_controller_pose_action = action_set
+            .create_action::<xr::Posef>(
+                "left_detached_controller_pose",
+                "Left detached controller pose",
+                &[],
+            )
+            .unwrap();
+        right_detached_controller_pose_action = action_set
+            .create_action::<xr::Posef>(
+                "right_detached_controller_pose",
+                "Right detached controller pose",
+                &[],
+            )
+            .unwrap();
+
+        bindings.push(binding(
+            &left_detached_controller_pose_action,
+            "/user/detached_controller_meta/left/input/grip/pose",
+        ));
+        bindings.push(binding(
+            &right_detached_controller_pose_action,
+            "/user/detached_controller_meta/right/input/grip/pose",
+        ));
+    }
 
     // Apply bindings:
     xr_ctx
@@ -380,6 +424,7 @@ pub fn initialize_interaction(
                 skeleton_tracker: right_hand_tracker,
             },
         ],
+        uses_multimodal_hands,
         face_sources: FaceSources {
             combined_eyes_source,
             eye_tracker_fb,
@@ -407,7 +452,42 @@ pub fn get_hand_data(
     hand_source: &HandInteraction,
     last_position: &mut Vec3,
 ) -> (Option<DeviceMotion>, Option<[Pose; 26]>) {
-    if let Some(tracker) = &hand_source.skeleton_tracker {
+    let controller_motion = if hand_source
+        .grip_action
+        .is_active(xr_session, xr::Path::NULL)
+        .unwrap_or(false)
+    {
+        if let Ok((location, velocity)) = hand_source.grip_space.relate(reference_space, time) {
+            if location
+                .location_flags
+                .contains(xr::SpaceLocationFlags::ORIENTATION_VALID)
+            {
+                if location
+                    .location_flags
+                    .contains(xr::SpaceLocationFlags::POSITION_VALID)
+                {
+                    *last_position = crate::from_xr_vec3(location.pose.position);
+                }
+
+                Some(DeviceMotion {
+                    pose: Pose {
+                        orientation: crate::from_xr_quat(location.pose.orientation),
+                        position: *last_position,
+                    },
+                    linear_velocity: crate::from_xr_vec3(velocity.linear_velocity),
+                    angular_velocity: crate::from_xr_vec3(velocity.angular_velocity),
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let hand_joints = if let Some(tracker) = &hand_source.skeleton_tracker {
         if let Some(joint_locations) = reference_space
             .locate_hand_joints(tracker, time)
             .ok()
@@ -420,15 +500,6 @@ pub fn get_hand_data(
                 *last_position = crate::from_xr_vec3(joint_locations[0].pose.position);
             }
 
-            let root_motion = DeviceMotion {
-                pose: Pose {
-                    orientation: crate::from_xr_quat(joint_locations[0].pose.orientation),
-                    position: *last_position,
-                },
-                linear_velocity: Vec3::ZERO,
-                angular_velocity: Vec3::ZERO,
-            };
-
             let joints = joint_locations
                 .iter()
                 .map(|j| crate::from_xr_pose(j.pose))
@@ -436,46 +507,15 @@ pub fn get_hand_data(
                 .try_into()
                 .unwrap();
 
-            return (Some(root_motion), Some(joints));
+            Some(joints)
+        } else {
+            None
         }
-    }
-
-    if !hand_source
-        .grip_action
-        .is_active(xr_session, xr::Path::NULL)
-        .unwrap_or(false)
-    {
-        return (None, None);
-    }
-
-    let Ok((location, velocity)) = hand_source.grip_space.relate(reference_space, time) else {
-        return (None, None);
+    } else {
+        None
     };
 
-    if !location
-        .location_flags
-        .contains(xr::SpaceLocationFlags::ORIENTATION_VALID)
-    {
-        return (None, None);
-    }
-
-    if location
-        .location_flags
-        .contains(xr::SpaceLocationFlags::POSITION_VALID)
-    {
-        *last_position = crate::from_xr_vec3(location.pose.position);
-    }
-
-    let hand_motion = DeviceMotion {
-        pose: Pose {
-            orientation: crate::from_xr_quat(location.pose.orientation),
-            position: *last_position,
-        },
-        linear_velocity: crate::from_xr_vec3(velocity.linear_velocity),
-        angular_velocity: crate::from_xr_vec3(velocity.angular_velocity),
-    };
-
-    (Some(hand_motion), None)
+    (controller_motion, hand_joints)
 }
 
 pub fn update_buttons(

--- a/alvr/client_openxr/src/lobby.rs
+++ b/alvr/client_openxr/src/lobby.rs
@@ -4,7 +4,7 @@ use crate::{
     XrContext,
 };
 use alvr_client_core::graphics::{GraphicsContext, LobbyRenderer, RenderViewInput, SDR_FORMAT_GL};
-use alvr_common::glam::{UVec2, Vec3};
+use alvr_common::{glam::UVec2, Pose};
 use openxr as xr;
 use std::{rc::Rc, sync::Arc};
 
@@ -119,14 +119,16 @@ impl Lobby {
             &self.reference_space,
             predicted_display_time,
             &self.interaction_ctx.hands_interaction[0],
-            &mut Vec3::new(0.0, 0.0, 0.0),
+            &mut Pose::default(),
+            &mut Pose::default(),
         );
         let right_hand_data = interaction::get_hand_data(
             &self.xr_session,
             &self.reference_space,
             predicted_display_time,
             &self.interaction_ctx.hands_interaction[1],
-            &mut Vec3::new(0.0, 0.0, 0.0),
+            &mut Pose::default(),
+            &mut Pose::default(),
         );
 
         let body_skeleton_fb = self

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -10,8 +10,8 @@ use alvr_client_core::{
 };
 use alvr_common::{
     error,
-    glam::{UVec2, Vec2, Vec3},
-    RelaxedAtomic, HAND_LEFT_ID, HAND_RIGHT_ID,
+    glam::{UVec2, Vec2},
+    Pose, RelaxedAtomic, HAND_LEFT_ID, HAND_RIGHT_ID,
 };
 use alvr_packets::{FaceData, NegotiatedStreamingConfig, ViewParams};
 use alvr_session::{
@@ -375,7 +375,8 @@ fn stream_input_loop(
     refresh_rate: f32,
     running: Arc<RelaxedAtomic>,
 ) {
-    let mut last_hand_positions = [Vec3::ZERO; 2];
+    let mut last_controller_poses = [Pose::default(); 2];
+    let mut last_palm_poses = [Pose::default(); 2];
 
     let mut deadline = Instant::now();
     let frame_interval = Duration::from_secs_f32(1.0 / refresh_rate);
@@ -435,14 +436,16 @@ fn stream_input_loop(
             &reference_space,
             tracker_time,
             &interaction_ctx.hands_interaction[0],
-            &mut last_hand_positions[0],
+            &mut last_controller_poses[0],
+            &mut last_palm_poses[0],
         );
         let (right_hand_motion, right_hand_skeleton) = crate::interaction::get_hand_data(
             &xr_ctx.session,
             &reference_space,
             tracker_time,
             &interaction_ctx.hands_interaction[1],
-            &mut last_hand_positions[1],
+            &mut last_controller_poses[1],
+            &mut last_palm_poses[1],
         );
 
         // Note: When multimodal input is enabled, we are sure that when free hands are used

--- a/alvr/common/src/inputs.rs
+++ b/alvr/common/src/inputs.rs
@@ -54,6 +54,8 @@ devices! {
     (BODY_LEFT_FOOT, "/user/body/left_foot"),
     (BODY_RIGHT_KNEE, "/user/body/right_knee"),
     (BODY_RIGHT_FOOT, "/user/body/right_foot"),
+    (DETACHED_CONTROLLER_LEFT, "/user/detached_controller_meta/left"),
+    (DETACHED_CONTROLLER_RIGHT, "/user/detached_controller_meta/right"),
 }
 
 pub enum ButtonType {

--- a/alvr/common/src/lib.rs
+++ b/alvr/common/src/lib.rs
@@ -35,6 +35,7 @@ pub const fn lazy_mut_none<T>() -> OptLazy<T> {
 
 // Simple wrapper for AtomicBool when using Ordering::Relaxed. Deref cannot be implemented (cannot
 // return local reference)
+#[derive(Default)]
 pub struct RelaxedAtomic(AtomicBool);
 
 impl RelaxedAtomic {

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
@@ -321,7 +321,7 @@ pub fn microphone_schema(devices: Vec<String>) -> PresetSchemaNode {
 
 pub fn hand_tracking_interaction_schema() -> PresetSchemaNode {
     const HELP: &str = r"Disabled: hands cannot emulate buttons. Useful for using Joy-Cons or other non-native controllers.
-Separate trackers: create separate SteamVR devices for hand tracking. This is used for VRChat.
+SteamVR Input 2.0: create separate SteamVR devices for hand tracking.
 ALVR bindings: use ALVR hand tracking button bindings. Check the wiki for help.
 ";
 
@@ -337,7 +337,7 @@ ALVR bindings: use ALVR hand tracking button bindings. Check the wiki for help.
                 modifiers: vec![
                     bool_modifier("session_settings.headset.controllers.enabled", true),
                     bool_modifier(
-                        &format!("{PREFIX}.hand_skeleton.content.use_separate_trackers"),
+                        &format!("{PREFIX}.hand_skeleton.content.steamvr_input_2_0"),
                         false,
                     ),
                     bool_modifier(
@@ -348,12 +348,12 @@ ALVR bindings: use ALVR hand tracking button bindings. Check the wiki for help.
                 content: None,
             },
             HigherOrderChoiceOption {
-                display_name: "Separate trackers".into(),
+                display_name: "SteamVR Input 2.0".into(),
                 modifiers: vec![
                     bool_modifier("session_settings.headset.controllers.enabled", true),
                     bool_modifier(&format!("{PREFIX}.hand_skeleton.enabled"), true),
                     bool_modifier(
-                        &format!("{PREFIX}.hand_skeleton.content.use_separate_trackers"),
+                        &format!("{PREFIX}.hand_skeleton.content.steamvr_input_2_0"),
                         true,
                     ),
                     bool_modifier(
@@ -368,7 +368,7 @@ ALVR bindings: use ALVR hand tracking button bindings. Check the wiki for help.
                 modifiers: vec![
                     bool_modifier("session_settings.headset.controllers.enabled", true),
                     bool_modifier(
-                        &format!("{PREFIX}.hand_skeleton.content.use_separate_trackers"),
+                        &format!("{PREFIX}.hand_skeleton.content.steamvr_input_2_0"),
                         false,
                     ),
                     bool_modifier(&format!("{PREFIX}.hand_tracking_interaction.enabled"), true),

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -38,6 +38,7 @@ pub struct VideoStreamingCapabilities {
     pub encoder_high_profile: bool,
     pub encoder_10_bits: bool,
     pub encoder_av1: bool,
+    pub multimodal_protocol: bool,
 }
 
 // Nasty workaround to make the packet extensible, pushing the limits of protocol compatibility
@@ -92,6 +93,7 @@ pub fn decode_video_streaming_capabilities(
         encoder_high_profile: caps_json["encoder_high_profile"].as_bool().unwrap_or(true),
         encoder_10_bits: caps_json["encoder_10_bits"].as_bool().unwrap_or(true),
         encoder_av1: caps_json["encoder_av1"].as_bool().unwrap_or(true),
+        multimodal_protocol: caps_json["multimodal_protocol"].as_bool().unwrap_or(false),
     })
 }
 
@@ -113,6 +115,9 @@ pub struct NegotiatedStreamingConfig {
     pub refresh_rate_hint: f32,
     pub game_audio_sample_rate: u32,
     pub enable_foveated_encoding: bool,
+    // This is needed to detect when to use SteamVR hand trackers. This does NOT imply if multimodal
+    // input is supported
+    pub use_multimodal_protocol: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -147,6 +152,8 @@ pub fn decode_stream_config(
     let enable_foveated_encoding =
         json::from_value(negotiated_json["enable_foveated_encoding"].clone())
             .unwrap_or_else(|_| settings.video.foveated_encoding.enabled());
+    let use_multimodal_protocol =
+        json::from_value(negotiated_json["use_multimodal_protocol"].clone()).unwrap_or(false);
 
     Ok((
         settings,
@@ -155,6 +162,7 @@ pub fn decode_stream_config(
             refresh_rate_hint,
             game_audio_sample_rate,
             enable_foveated_encoding,
+            use_multimodal_protocol,
         },
     ))
 }

--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -14,7 +14,6 @@ mod web_server;
 
 pub use c_api::*;
 pub use logging_backend::init_logging;
-pub use tracking::get_hand_skeleton_offsets;
 
 use crate::connection::VideoPacket;
 use alvr_common::{

--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -228,13 +228,14 @@ bool Controller::onPoseUpdate(float predictionS, FfiHandData handData) {
     auto controllerMotion = handData.controllerMotion;
     auto handSkeleton = handData.handSkeleton;
 
-    bool enabled = handData.tracked
-        && ((handData.useHandTracker
-             && (device_id == HAND_TRACKER_LEFT_ID || device_id == HAND_TRACKER_RIGHT_ID)
-             && handData.controllerMotion == nullptr)
-            || (!handData.useHandTracker
-                && (device_id == HAND_LEFT_ID || device_id == HAND_RIGHT_ID)
-                && handData.controllerMotion != nullptr));
+    // Note: following the multimodal protocol, to make sure we want to use hand trackers we need to
+    // check controllerMotion == nullptr. handSkeleton != nullptr is not enough.
+    bool enabledAsHandTracker = handData.useHandTracker
+        && (device_id == HAND_TRACKER_LEFT_ID || device_id == HAND_TRACKER_RIGHT_ID)
+        && controllerMotion == nullptr;
+    bool enabledAsController = !handData.useHandTracker
+        && (device_id == HAND_LEFT_ID || device_id == HAND_RIGHT_ID) && controllerMotion != nullptr;
+    bool enabled = handData.tracked && (enabledAsHandTracker || enabledAsController);
 
     Debug(
         "%s %s: enabled: %d, ctrl: %d, hand: %d",

--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -230,9 +230,11 @@ bool Controller::onPoseUpdate(float predictionS, FfiHandData handData) {
 
     bool enabled = handData.tracked
         && ((handData.useHandTracker
-             && (device_id == HAND_TRACKER_LEFT_ID || device_id == HAND_TRACKER_RIGHT_ID))
+             && (device_id == HAND_TRACKER_LEFT_ID || device_id == HAND_TRACKER_RIGHT_ID)
+             && handData.controllerMotion == nullptr)
             || (!handData.useHandTracker
-                && (device_id == HAND_LEFT_ID || device_id == HAND_RIGHT_ID)));
+                && (device_id == HAND_LEFT_ID || device_id == HAND_RIGHT_ID)
+                && handData.controllerMotion != nullptr));
 
     Debug(
         "%s %s: enabled: %d, ctrl: %d, hand: %d",
@@ -299,11 +301,9 @@ bool Controller::onPoseUpdate(float predictionS, FfiHandData handData) {
     );
 
     // Early return to skip updating the skeleton
-    if (!this->isEnabled()) {
+    if (!enabled) {
         return false;
-    }
-
-    if (handSkeleton != nullptr) {
+    } else if (handSkeleton != nullptr) {
         vr::VRBoneTransform_t boneTransform[SKELETON_BONE_COUNT] = {};
 
         // NB: start from index 1 to skip the root bone

--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -220,45 +220,75 @@ void Controller::SetButton(uint64_t id, FfiButtonValue value) {
     }
 }
 
-bool Controller::onPoseUpdate(
-    float predictionS,
-    FfiDeviceMotion motion,
-    const FfiHandSkeleton* handSkeleton,
-    unsigned int controllersTracked
-) {
+bool Controller::onPoseUpdate(float predictionS, FfiHandData handData) {
     if (this->object_id == vr::k_unTrackedDeviceIndexInvalid) {
         return false;
     }
 
+    auto controllerMotion = handData.controllerMotion;
+    auto handSkeleton = handData.handSkeleton;
+
+    bool enabled = handData.tracked
+        && ((handData.useHandTracker
+             && (device_id == HAND_TRACKER_LEFT_ID || device_id == HAND_TRACKER_RIGHT_ID))
+            || (!handData.useHandTracker
+                && (device_id == HAND_LEFT_ID || device_id == HAND_RIGHT_ID)));
+
+    Debug(
+        "%s %s: enabled: %d, ctrl: %d, hand: %d",
+        (device_id == HAND_TRACKER_LEFT_ID || device_id == HAND_TRACKER_RIGHT_ID) ? "hand tracker"
+                                                                                  : "controller",
+        (device_id == HAND_TRACKER_LEFT_ID || device_id == HAND_LEFT_ID) ? "left" : "right",
+        enabled,
+        handData.controllerMotion != nullptr,
+        handData.handSkeleton != nullptr
+    );
+
     auto vr_driver_input = vr::VRDriverInput();
 
     auto pose = vr::DriverPose_t {};
-    pose.poseIsValid = controllersTracked;
-    pose.deviceIsConnected = controllersTracked;
-    pose.result
-        = controllersTracked ? vr::TrackingResult_Running_OK : vr::TrackingResult_Uninitialized;
+    pose.poseIsValid = enabled;
+    pose.deviceIsConnected = enabled;
+    pose.result = enabled ? vr::TrackingResult_Running_OK : vr::TrackingResult_Uninitialized;
 
     pose.qDriverFromHeadRotation = HmdQuaternion_Init(1, 0, 0, 0);
     pose.qWorldFromDriverRotation = HmdQuaternion_Init(1, 0, 0, 0);
 
-    pose.qRotation = HmdQuaternion_Init(
-        motion.orientation.w,
-        motion.orientation.x,
-        motion.orientation.y,
-        motion.orientation.z
-    ); // controllerRotation;
+    if (controllerMotion != nullptr) {
+        auto m = controllerMotion;
 
-    pose.vecPosition[0] = motion.position[0];
-    pose.vecPosition[1] = motion.position[1];
-    pose.vecPosition[2] = motion.position[2];
+        pose.qRotation = HmdQuaternion_Init(
+            m->orientation.w, m->orientation.x, m->orientation.y, m->orientation.z
+        );
 
-    pose.vecVelocity[0] = motion.linearVelocity[0];
-    pose.vecVelocity[1] = motion.linearVelocity[1];
-    pose.vecVelocity[2] = motion.linearVelocity[2];
+        pose.vecPosition[0] = m->position[0];
+        pose.vecPosition[1] = m->position[1];
+        pose.vecPosition[2] = m->position[2];
 
-    pose.vecAngularVelocity[0] = motion.angularVelocity[0];
-    pose.vecAngularVelocity[1] = motion.angularVelocity[1];
-    pose.vecAngularVelocity[2] = motion.angularVelocity[2];
+        pose.vecVelocity[0] = m->linearVelocity[0];
+        pose.vecVelocity[1] = m->linearVelocity[1];
+        pose.vecVelocity[2] = m->linearVelocity[2];
+
+        pose.vecAngularVelocity[0] = m->angularVelocity[0];
+        pose.vecAngularVelocity[1] = m->angularVelocity[1];
+        pose.vecAngularVelocity[2] = m->angularVelocity[2];
+    } else if (handSkeleton != nullptr) {
+        auto r = handSkeleton->jointRotations[0];
+        pose.qRotation = HmdQuaternion_Init(r.w, r.x, r.y, r.z);
+
+        auto p = handSkeleton->jointPositions[0];
+        pose.vecPosition[0] = p[0];
+        pose.vecPosition[1] = p[1];
+        pose.vecPosition[2] = p[2];
+
+        pose.vecVelocity[0] = 0;
+        pose.vecVelocity[1] = 0;
+        pose.vecVelocity[2] = 0;
+
+        pose.vecAngularVelocity[0] = 0;
+        pose.vecAngularVelocity[1] = 0;
+        pose.vecAngularVelocity[2] = 0;
+    }
 
     pose.poseTimeOffset = predictionS;
 
@@ -275,7 +305,9 @@ bool Controller::onPoseUpdate(
 
     if (handSkeleton != nullptr) {
         vr::VRBoneTransform_t boneTransform[SKELETON_BONE_COUNT] = {};
-        for (int j = 0; j < 31; j++) {
+
+        // NB: start from index 1 to skip the root bone
+        for (int j = 1; j < 31; j++) {
             boneTransform[j].orientation.w = handSkeleton->jointRotations[j].w;
             boneTransform[j].orientation.x = handSkeleton->jointRotations[j].x;
             boneTransform[j].orientation.y = handSkeleton->jointRotations[j].y;
@@ -328,7 +360,7 @@ bool Controller::onPoseUpdate(
         vr_driver_input->UpdateScalarComponent(
             m_buttonHandles[ALVR_INPUT_FINGER_PINKY], rotPinky, 0.0
         );
-    } else {
+    } else if (controllerMotion != nullptr) {
         if (m_lastThumbTouch != m_currentThumbTouch) {
             m_thumbTouchAnimationProgress += 1.f / ANIMATION_FRAME_COUNT;
             if (m_thumbTouchAnimationProgress > 1.f) {

--- a/alvr/server_openvr/cpp/alvr_server/Controller.h
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.h
@@ -37,12 +37,7 @@ public:
 
     void SetButton(uint64_t id, FfiButtonValue value);
 
-    bool onPoseUpdate(
-        float predictionS,
-        FfiDeviceMotion motion,
-        const FfiHandSkeleton* hand,
-        unsigned int controllersTracked
-    );
+    bool onPoseUpdate(float predictionS, FfiHandData handData);
 
     void GetBoneTransform(bool withController, vr::VRBoneTransform_t outBoneTransform[]);
 

--- a/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
@@ -406,57 +406,34 @@ void RequestIDR() {
 void SetTracking(
     unsigned long long targetTimestampNs,
     float controllerPoseTimeOffsetS,
-    const FfiDeviceMotion* deviceMotions,
-    int motionsCount,
-    unsigned int controllersTracked,
-    bool useLeftHandTracker,
-    bool useRightHandTracker,
-    const FfiHandSkeleton* leftHandSkeleton,
-    const FfiHandSkeleton* rightHandSkeleton,
+    FfiDeviceMotion headMotion,
+    FfiHandData leftHandData,
+    FfiHandData rightHandData,
     const FfiBodyTracker* bodyTrackers,
     int bodyTrackersCount
 ) {
-    for (int i = 0; i < motionsCount; i++) {
-        if (deviceMotions[i].deviceID == HEAD_ID && g_driver_provider.hmd) {
-            g_driver_provider.hmd->OnPoseUpdated(targetTimestampNs, deviceMotions[i]);
-        } else {
-            if (deviceMotions[i].deviceID == HAND_LEFT_ID) {
-                if (g_driver_provider.left_controller) {
-                    g_driver_provider.left_controller->onPoseUpdate(
-                        controllerPoseTimeOffsetS,
-                        deviceMotions[i],
-                        leftHandSkeleton,
-                        controllersTracked && !useLeftHandTracker
-                    );
-                }
-                if (g_driver_provider.left_hand_tracker) {
-                    g_driver_provider.left_hand_tracker->onPoseUpdate(
-                        controllerPoseTimeOffsetS,
-                        deviceMotions[i],
-                        leftHandSkeleton,
-                        controllersTracked && useLeftHandTracker
-                    );
-                }
-            } else if (deviceMotions[i].deviceID == HAND_RIGHT_ID) {
-                if (g_driver_provider.right_controller) {
-                    g_driver_provider.right_controller->onPoseUpdate(
-                        controllerPoseTimeOffsetS,
-                        deviceMotions[i],
-                        rightHandSkeleton,
-                        controllersTracked && !useRightHandTracker
-                    );
-                }
-                if (g_driver_provider.right_hand_tracker) {
-                    g_driver_provider.right_hand_tracker->onPoseUpdate(
-                        controllerPoseTimeOffsetS,
-                        deviceMotions[i],
-                        rightHandSkeleton,
-                        controllersTracked && useRightHandTracker
-                    );
-                }
-            }
-        }
+    if (g_driver_provider.hmd) {
+        g_driver_provider.hmd->OnPoseUpdated(targetTimestampNs, headMotion);
     }
+
+    if (g_driver_provider.left_hand_tracker) {
+        g_driver_provider.left_hand_tracker->onPoseUpdate(controllerPoseTimeOffsetS, leftHandData);
+    }
+
+    if (g_driver_provider.left_controller) {
+        g_driver_provider.left_controller->onPoseUpdate(controllerPoseTimeOffsetS, leftHandData);
+    }
+
+    if (g_driver_provider.right_hand_tracker) {
+        g_driver_provider.right_hand_tracker->onPoseUpdate(
+            controllerPoseTimeOffsetS, rightHandData
+        );
+    }
+
+    if (g_driver_provider.right_controller) {
+        g_driver_provider.right_controller->onPoseUpdate(controllerPoseTimeOffsetS, rightHandData);
+    }
+
     if (Settings::Instance().m_enableBodyTrackingFakeVive) {
         for (int i = 0; i < bodyTrackersCount; i++) {
             g_driver_provider.generic_trackers.at(bodyTrackers[i].trackerID)

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -27,6 +27,13 @@ struct FfiDeviceMotion {
     float angularVelocity[3];
 };
 
+struct FfiHandData {
+    unsigned int tracked;
+    const FfiDeviceMotion* controllerMotion;
+    const FfiHandSkeleton* handSkeleton;
+    bool useHandTracker;
+};
+
 struct FfiBodyTracker {
     unsigned int trackerID;
     FfiQuat orientation;
@@ -142,13 +149,9 @@ extern "C" void RequestIDR();
 extern "C" void SetTracking(
     unsigned long long targetTimestampNs,
     float controllerPoseTimeOffsetS,
-    const FfiDeviceMotion* deviceMotions,
-    int motionsCount,
-    unsigned int controllersTracked,
-    bool useLeftHandTracker,
-    bool useRightHandTracker,
-    const FfiHandSkeleton* leftHand,
-    const FfiHandSkeleton* rightHand,
+    FfiDeviceMotion headMotion,
+    FfiHandData leftHandData,
+    FfiHandData rightHandData,
     const FfiBodyTracker* bodyTrackers,
     int bodyTrackersCount
 );

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -20,6 +20,7 @@ use alvr_common::{
     parking_lot::{Mutex, RwLock},
     settings_schema::Switch,
     warn, BUTTON_INFO, HAND_LEFT_ID, HAND_RIGHT_ID, HAND_TRACKER_LEFT_ID, HAND_TRACKER_RIGHT_ID,
+    HEAD_ID,
 };
 use alvr_filesystem as afs;
 use alvr_packets::{ButtonValue, Haptics};
@@ -112,32 +113,22 @@ extern "C" fn driver_ready_idle(set_default_chap: bool) {
                     tracking,
                     controllers_pose_time_offset,
                 } => {
-                    let controllers_config;
-                    let track_body;
-                    {
-                        let headset_config = &alvr_server_core::settings().headset;
+                    let headset_config = &alvr_server_core::settings().headset;
 
-                        controllers_config = headset_config.controllers.clone().into_option();
-                        track_body = headset_config.body_tracking.enabled();
-                    };
+                    let controllers_config = headset_config.controllers.clone().into_option();
+                    let track_body = headset_config.body_tracking.enabled();
 
                     let track_controllers = controllers_config
                         .as_ref()
                         .map(|c| c.tracked)
                         .unwrap_or(false);
 
-                    let left_openvr_hand_skeleton;
-                    let right_openvr_hand_skeleton;
-                    {
-                        let headset_config = &alvr_server_core::settings().headset;
-
-                        left_openvr_hand_skeleton = tracking.hand_skeletons[0].map(|s| {
-                            tracking::to_openvr_hand_skeleton(headset_config, *HAND_LEFT_ID, s)
-                        });
-                        right_openvr_hand_skeleton = tracking.hand_skeletons[1].map(|s| {
-                            tracking::to_openvr_hand_skeleton(headset_config, *HAND_RIGHT_ID, s)
-                        });
-                    }
+                    let left_openvr_hand_skeleton = tracking.hand_skeletons[0].map(|s| {
+                        tracking::to_openvr_hand_skeleton(headset_config, *HAND_LEFT_ID, s)
+                    });
+                    let right_openvr_hand_skeleton = tracking.hand_skeletons[1].map(|s| {
+                        tracking::to_openvr_hand_skeleton(headset_config, *HAND_RIGHT_ID, s)
+                    });
 
                     let (
                         use_separate_hand_trackers,
@@ -149,7 +140,7 @@ extern "C" fn driver_ready_idle(set_default_chap: bool) {
                     }) = controllers_config
                     {
                         (
-                            hand_skeleton_config.use_separate_trackers,
+                            hand_skeleton_config.steamvr_input_2_0,
                             left_openvr_hand_skeleton.map(tracking::to_ffi_skeleton),
                             right_openvr_hand_skeleton.map(tracking::to_ffi_skeleton),
                         )
@@ -157,11 +148,65 @@ extern "C" fn driver_ready_idle(set_default_chap: bool) {
                         (false, None, None)
                     };
 
-                    let ffi_motions = tracking
+                    let use_left_hand_tracker = use_separate_hand_trackers
+                        && tracking.hand_skeletons[0].is_some()
+                        && tracking
+                            .device_motions
+                            .iter()
+                            .all(|(id, _)| *id != *HAND_TRACKER_LEFT_ID);
+                    let use_right_hand_tracker = use_separate_hand_trackers
+                        && tracking.hand_skeletons[1].is_some()
+                        && tracking
+                            .device_motions
+                            .iter()
+                            .all(|(id, _)| *id != *HAND_TRACKER_RIGHT_ID);
+
+                    let ffi_head_motion = tracking
                         .device_motions
                         .iter()
-                        .map(|(id, motion)| tracking::to_ffi_motion(*id, *motion))
-                        .collect::<Vec<_>>();
+                        .find_map(|(id, motion)| {
+                            (*id == *HEAD_ID).then(|| tracking::to_ffi_motion(*HEAD_ID, *motion))
+                        })
+                        .unwrap_or_else(FfiDeviceMotion::default);
+                    let ffi_left_controller_motion =
+                        tracking.device_motions.iter().find_map(|(id, motion)| {
+                            (*id == *HAND_LEFT_ID)
+                                .then(|| tracking::to_ffi_motion(*HAND_LEFT_ID, *motion))
+                        });
+                    let ffi_right_controller_motion =
+                        tracking.device_motions.iter().find_map(|(id, motion)| {
+                            (*id == *HAND_RIGHT_ID)
+                                .then(|| tracking::to_ffi_motion(*HAND_RIGHT_ID, *motion))
+                        });
+
+                    let left_hand_data = FfiHandData {
+                        tracked: track_controllers.into(),
+                        controllerMotion: if let Some(motion) = &ffi_left_controller_motion {
+                            motion
+                        } else {
+                            ptr::null()
+                        },
+                        handSkeleton: if let Some(skeleton) = &ffi_left_hand_skeleton {
+                            skeleton
+                        } else {
+                            ptr::null()
+                        },
+                        useHandTracker: use_left_hand_tracker,
+                    };
+                    let right_hand_data = FfiHandData {
+                        tracked: track_controllers.into(),
+                        controllerMotion: if let Some(motion) = &ffi_right_controller_motion {
+                            motion
+                        } else {
+                            ptr::null()
+                        },
+                        handSkeleton: if let Some(skeleton) = &ffi_right_hand_skeleton {
+                            skeleton
+                        } else {
+                            ptr::null()
+                        },
+                        useHandTracker: use_right_hand_tracker,
+                    };
 
                     let ffi_body_trackers =
                         tracking::to_ffi_body_trackers(&tracking.device_motions, track_body);
@@ -174,21 +219,9 @@ extern "C" fn driver_ready_idle(set_default_chap: bool) {
                         SetTracking(
                             tracking.target_timestamp.as_nanos() as _,
                             controllers_pose_time_offset.as_secs_f32(),
-                            ffi_motions.as_ptr(),
-                            ffi_motions.len() as _,
-                            track_controllers.into(),
-                            use_separate_hand_trackers && tracking.hand_skeletons[0].is_some(),
-                            use_separate_hand_trackers && tracking.hand_skeletons[1].is_some(),
-                            if let Some(skeleton) = &ffi_left_hand_skeleton {
-                                skeleton
-                            } else {
-                                ptr::null()
-                            },
-                            if let Some(skeleton) = &ffi_right_hand_skeleton {
-                                skeleton
-                            } else {
-                                ptr::null()
-                            },
+                            ffi_head_motion,
+                            left_hand_data,
+                            right_hand_data,
                             if let Some(body_trackers) = &ffi_body_trackers {
                                 body_trackers.as_ptr()
                             } else {

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -153,13 +153,13 @@ extern "C" fn driver_ready_idle(set_default_chap: bool) {
                         && tracking
                             .device_motions
                             .iter()
-                            .all(|(id, _)| *id != *HAND_TRACKER_LEFT_ID);
+                            .all(|(id, _)| *id != *HAND_LEFT_ID);
                     let use_right_hand_tracker = use_separate_hand_trackers
                         && tracking.hand_skeletons[1].is_some()
                         && tracking
                             .device_motions
                             .iter()
-                            .all(|(id, _)| *id != *HAND_TRACKER_RIGHT_ID);
+                            .all(|(id, _)| *id != *HAND_RIGHT_ID);
 
                     let ffi_head_motion = tracking
                         .device_motions

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -683,6 +683,10 @@ pub struct FaceTrackingConfig {
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
 pub struct BodyTrackingSourcesConfig {
     pub body_tracking_fb: Switch<BodyTrackingFBConfig>,
+    // todo:
+    // pub detached_controllers_as_feet: bool,
+    // unfortunately multimodal is incompatible with body tracking. To make this usable we need to
+    // at least add support for an android client as 3dof waist tracker.
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
@@ -871,7 +875,7 @@ pub struct HandSkeletonConfig {
     #[schema(strings(
         help = r"Enabling this will use separate tracker objects with the full skeletal tracking level when hand tracking is detected. This is required for VRChat hand tracking."
     ))]
-    pub use_separate_trackers: bool,
+    pub steamvr_input_2_0: bool,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -886,6 +890,11 @@ pub struct ControllersConfig {
         help = "Enabling this passes skeletal hand data (finger tracking) to SteamVR."
     ))]
     pub hand_skeleton: Switch<HandSkeletonConfig>,
+
+    #[schema(strings(
+        help = "Track hand skeleton while holding controllers. This will reduce hand tracking frequency to 30Hz."
+    ))]
+    pub multimodal_tracking: bool,
 
     #[schema(flag = "real-time")]
     #[schema(strings(
@@ -1532,9 +1541,10 @@ pub fn session_settings_default() -> SettingsDefault {
                     hand_skeleton: SwitchDefault {
                         enabled: true,
                         content: HandSkeletonConfigDefault {
-                            use_separate_trackers: true,
+                            steamvr_input_2_0: true,
                         },
                     },
+                    multimodal_tracking: false,
                     emulation_mode: ControllersEmulationModeDefault {
                         Custom: ControllersEmulationModeCustomDefault {
                             serial_number: "ALVR Controller".into(),

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -892,7 +892,8 @@ pub struct ControllersConfig {
     pub hand_skeleton: Switch<HandSkeletonConfig>,
 
     #[schema(strings(
-        help = "Track hand skeleton while holding controllers. This will reduce hand tracking frequency to 30Hz."
+        help = r"Track hand skeleton while holding controllers. This will reduce hand tracking frequency to 30Hz.
+Because of runtime limitations, this option is ignored when body tracking is active."
     ))]
     pub multimodal_tracking: bool,
 


### PR DESCRIPTION
This PR adds multimodal support on the client and adds a multimodal protocol extension. It's important to understand that multimodal support and multimodal protocol are two distinct orthogonal features.

Multimodal protocol describes how to interpret data sent by the client. without multimodal protocol, controller tracking is described by only `HAND_LEFT`/`HAND_RIGHT` devices in `device_motions`, while hand tracking requires both the hand device motions and the skeletons to be present. With multimodal protocol, only hand skeleton is required for hand tracking.
The old protocol was decided without anticipating a feature like multimodal, so now we have to negotiate multimodal protocol support and switch it on only when both client and server advertise compatibility.

Multimodal support is enabled only when supported by the headset, and controlled by the `multimodal_input` setting. Multimodal input would be enabled in the headset regardless if the server supports the multimodal protocol, but actual multimodal behavior can be used by the server only if both peers support multimodal protocol.