### PR TITLE
Stop requesting high frequency hand tracking mode to reduce jitter

### DIFF
--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -129,9 +129,6 @@ value = "all"
 name = "com.oculus.vr.focusaware"
 value = "true"
 [[package.metadata.android.application.meta_data]]
-name = "com.oculus.handtracking.frequency"
-value = "HIGH"
-[[package.metadata.android.application.meta_data]]
 name = "com.oculus.handtracking.version"
 value = "V2.0"
 


### PR DESCRIPTION
Switching to low frequency hand tracking mode on meta/oculus headsets seems to greatly reduce jitter/shake. This likely comes at the cost of higher latency, as I imagine the OS takes fewer samples and interpolates between them. However on my Quest Pro the considerable jitter in the high frequency mode makes this difficult to compare.

I followed [the official documentation](https://developer.oculus.com/documentation/native/android/mobile-hand-tracking/) which suggests adding (thus conversely removing) the manifest entry as the way to set the frequency mode. This allows the headset to choose instead of the app specifically asking for high frequency mode.

The positive results from low frequency mode has only been observed on my Quest Pro thus far. As such I would love if someone could test, especially with a Quest 3, and report back if there are any drawbacks to switching to low frequency mode before anyone merges this. From comparing with other software (Steam Link, Virtual Desktop), they appear to be using low frequency mode (or default) already. It's possible too, that Quest 3 simply defaults to high frequency, and thus this commit will make no change. You can easily test different modes easily by switching it in your Quest system settings under Settings -> Developer -> Hand Tracking Frequency Override.