### PR TITLE
feat(client): :sparkles: Expose server version from client_core

### DIFF
--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -190,16 +190,15 @@ fn connection_pipeline(
         proto_control_socket.recv::<StreamConfigPacket>(HANDSHAKE_ACTION_TIMEOUT)?;
     dbg_connection!("connection_pipeline: stream config received");
 
-    let (settings, negotiated_config) =
-        alvr_packets::decode_stream_config(&config_packet).to_con()?;
+    let stream_config = alvr_packets::decode_stream_config(&config_packet).to_con()?;
 
     ctx.uses_multimodal_protocol
-        .set(negotiated_config.use_multimodal_protocol);
+        .set(stream_config.negotiated_config.use_multimodal_protocol);
 
-    let streaming_start_event = ClientCoreEvent::StreamingStarted {
-        settings: Box::new(settings.clone()),
-        negotiated_config: negotiated_config.clone(),
-    };
+    let streaming_start_event = ClientCoreEvent::StreamingStarted(Box::new(stream_config.clone()));
+
+    let settings = stream_config.settings;
+    let negotiated_config = stream_config.negotiated_config;
 
     *ctx.statistics_manager.lock() = Some(StatisticsManager::new(
         settings.connection.statistics_history_size,

--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -27,10 +27,10 @@ use alvr_common::{
     HEAD_ID,
 };
 use alvr_packets::{
-    BatteryInfo, ButtonEntry, ClientControlPacket, FaceData, NegotiatedStreamingConfig,
-    ReservedClientControlPacket, Tracking, ViewParams, ViewsConfig,
+    BatteryInfo, ButtonEntry, ClientControlPacket, FaceData, ReservedClientControlPacket,
+    StreamConfig, Tracking, ViewParams, ViewsConfig,
 };
-use alvr_session::{CodecType, Settings};
+use alvr_session::CodecType;
 use connection::ConnectionContext;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -56,10 +56,7 @@ pub fn platform() -> Platform {
 #[derive(Serialize, Deserialize)]
 pub enum ClientCoreEvent {
     UpdateHudMessage(String),
-    StreamingStarted {
-        settings: Box<Settings>,
-        negotiated_config: NegotiatedStreamingConfig,
-    },
+    StreamingStarted(Box<StreamConfig>),
     StreamingStopped,
     Haptics {
         device_id: u64,

--- a/alvr/client_mock/src/main.rs
+++ b/alvr/client_mock/src/main.rs
@@ -264,12 +264,10 @@ fn client_thread(
                 ClientCoreEvent::UpdateHudMessage(message) => {
                     window_output.hud_message = message;
                 }
-                ClientCoreEvent::StreamingStarted {
-                    negotiated_config, ..
-                } => {
-                    window_output.fps = negotiated_config.refresh_rate_hint;
+                ClientCoreEvent::StreamingStarted(config) => {
+                    window_output.fps = config.negotiated_config.refresh_rate_hint;
                     window_output.connected = true;
-                    window_output.resolution = negotiated_config.view_resolution;
+                    window_output.resolution = config.negotiated_config.view_resolution;
 
                     let context = Arc::clone(&client_core_context);
                     let streaming = Arc::clone(&streaming);
@@ -278,7 +276,7 @@ fn client_thread(
                         tracking_thread(
                             context,
                             streaming,
-                            negotiated_config.refresh_rate_hint,
+                            config.negotiated_config.refresh_rate_hint,
                             input,
                         )
                     }));

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1011,7 +1011,7 @@ Tilted: the world gets tilted when long pressing the oculus button. This is usef
     pub body_tracking: Switch<BodyTrackingConfig>,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone)]
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, Copy)]
 #[schema(gui = "button_group")]
 pub enum SocketProtocol {
     #[schema(strings(display_name = "UDP"))]
@@ -1028,7 +1028,7 @@ pub struct DiscoveryConfig {
     pub auto_trust_clients: bool,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone)]
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, Copy)]
 pub enum SocketBufferSize {
     Default,
     Maximum,
@@ -1099,7 +1099,7 @@ This could happen on TCP. A IDR frame is requested in this case."#
     pub dscp: Option<DscpTos>,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone)]
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, Copy)]
 #[repr(u8)]
 #[schema(gui = "button_group")]
 pub enum DropProbability {
@@ -1108,7 +1108,7 @@ pub enum DropProbability {
     High = 0x11,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone)]
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, Copy)]
 pub enum DscpTos {
     BestEffort,
 


### PR DESCRIPTION
The new C API is `alvr_get_server_version` which works similarly to `alvr_get_settings_json`. The value can be obtained only after server connection, and the string length can be obtained by passing a null buffer.