### PR TITLE
fix(client_openxr): :bug: Fix crash caused by undefined behavior

### DIFF
--- a/alvr/client_openxr/src/extra_extensions/eye_tracking_social.rs
+++ b/alvr/client_openxr/src/extra_extensions/eye_tracking_social.rs
@@ -8,9 +8,15 @@ impl super::ExtraExtensions {
         instance: &xr::Instance,
         system: xr::SystemId,
     ) -> bool {
-        self.get_props(instance, system, unsafe {
-            sys::SystemEyeTrackingPropertiesFB::out(ptr::null_mut()).assume_init()
-        })
+        self.get_props(
+            instance,
+            system,
+            sys::SystemEyeTrackingPropertiesFB {
+                ty: sys::SystemEyeTrackingPropertiesFB::TYPE,
+                next: ptr::null_mut(),
+                supports_eye_tracking: sys::FALSE,
+            },
+        )
         .map(|props| props.supports_eye_tracking.into())
         .unwrap_or(false)
     }

--- a/alvr/client_openxr/src/extra_extensions/face_tracking2_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/face_tracking2_fb.rs
@@ -2,17 +2,22 @@ use alvr_common::{anyhow::Result, ToAny};
 use openxr::{self as xr, raw, sys};
 use std::ptr;
 
+const DEFAULT_PROPS: sys::SystemFaceTrackingProperties2FB = sys::SystemFaceTrackingProperties2FB {
+    ty: sys::SystemFaceTrackingProperties2FB::TYPE,
+    next: ptr::null_mut(),
+    supports_visual_face_tracking: sys::FALSE,
+    supports_audio_face_tracking: sys::FALSE,
+};
+
 impl super::ExtraExtensions {
     pub fn supports_fb_visual_face_tracking(
         &self,
         instance: &xr::Instance,
         system: xr::SystemId,
     ) -> bool {
-        self.get_props(instance, system, unsafe {
-            sys::SystemFaceTrackingProperties2FB::out(ptr::null_mut()).assume_init()
-        })
-        .map(|props| props.supports_visual_face_tracking.into())
-        .unwrap_or(false)
+        self.get_props(instance, system, DEFAULT_PROPS)
+            .map(|props| props.supports_visual_face_tracking.into())
+            .unwrap_or(false)
     }
 
     pub fn supports_fb_audio_face_tracking(
@@ -20,11 +25,9 @@ impl super::ExtraExtensions {
         instance: &xr::Instance,
         system: xr::SystemId,
     ) -> bool {
-        self.get_props(instance, system, unsafe {
-            sys::SystemFaceTrackingProperties2FB::out(ptr::null_mut()).assume_init()
-        })
-        .map(|props| props.supports_audio_face_tracking.into())
-        .unwrap_or(false)
+        self.get_props(instance, system, DEFAULT_PROPS)
+            .map(|props| props.supports_audio_face_tracking.into())
+            .unwrap_or(false)
     }
 
     pub fn create_face_tracker2_fb<G>(

--- a/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
+++ b/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
@@ -2,17 +2,23 @@ use alvr_common::{anyhow::Result, ToAny};
 use openxr::{self as xr, raw, sys};
 use std::ptr;
 
+const DEFAULT_PROPS: sys::SystemFacialTrackingPropertiesHTC =
+    sys::SystemFacialTrackingPropertiesHTC {
+        ty: sys::SystemFacialTrackingPropertiesHTC::TYPE,
+        next: ptr::null_mut(),
+        support_eye_facial_tracking: sys::FALSE,
+        support_lip_facial_tracking: sys::FALSE,
+    };
+
 impl super::ExtraExtensions {
     pub fn supports_htc_eye_facial_tracking(
         &self,
         instance: &xr::Instance,
         system: xr::SystemId,
     ) -> bool {
-        self.get_props(instance, system, unsafe {
-            sys::SystemFacialTrackingPropertiesHTC::out(ptr::null_mut()).assume_init()
-        })
-        .map(|props| props.support_eye_facial_tracking.into())
-        .unwrap_or(false)
+        self.get_props(instance, system, DEFAULT_PROPS)
+            .map(|props| props.support_eye_facial_tracking.into())
+            .unwrap_or(false)
     }
 
     pub fn supports_htc_lip_facial_tracking(
@@ -20,11 +26,9 @@ impl super::ExtraExtensions {
         instance: &xr::Instance,
         system: xr::SystemId,
     ) -> bool {
-        self.get_props(instance, system, unsafe {
-            sys::SystemFacialTrackingPropertiesHTC::out(ptr::null_mut()).assume_init()
-        })
-        .map(|props| props.support_lip_facial_tracking.into())
-        .unwrap_or(false)
+        self.get_props(instance, system, DEFAULT_PROPS)
+            .map(|props| props.support_lip_facial_tracking.into())
+            .unwrap_or(false)
     }
 
     pub fn create_facial_tracker_htc<G>(

--- a/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
+++ b/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
@@ -3,7 +3,7 @@
 
 use alvr_common::{anyhow::Result, once_cell::sync::Lazy, ToAny};
 use openxr::{self as xr, sys};
-use std::ffi::c_void;
+use std::{ffi::c_void, ptr};
 
 pub const META_SIMULTANEOUS_HANDS_AND_CONTROLLERS_EXTENSION_NAME: &str =
     "XR_META_simultaneous_hands_and_controllers";
@@ -44,7 +44,7 @@ impl super::ExtraExtensions {
             system,
             SystemSymultaneousHandsAndControllersPropertiesMETA {
                 ty: *TYPE_SYSTEM_SIMULTANEOUS_HANDS_AND_CONTROLLERS_PROPERTIES_META,
-                next: std::ptr::null(),
+                next: ptr::null(),
                 supports_simultaneous_hands_and_controllers: xr::sys::FALSE,
             },
         )
@@ -58,7 +58,7 @@ impl super::ExtraExtensions {
     ) -> Result<()> {
         let resume_info = SimultaneousHandsAndControllersTrackingResumeInfoMETA {
             ty: *TYPE_SIMULTANEOUS_HANDS_AND_CONTROLLERS_TRACKING_RESUME_INFO_META,
-            next: std::ptr::null(),
+            next: ptr::null(),
         };
 
         unsafe {


### PR DESCRIPTION
This PR attempts to fix a crash reported when enabling face tracking on the Quest Pro.

This PR fixes undefined behavior using a specific solution. Before we were calling `System<props>::out()` which returns a `MaybeUninit`, and immediately call `assume_uninit()`. Doing so only the corresponding `BaseOutStructure` fields are initialized, that is `ty` and `next`. The other fields are filled with random values. Beside this, calling `assume_uninit()` after attempting to get the properties with `get_system_properties` is not enough. The OpenXR spec doesn't say to return an error if the `next` pointer is populated with an unknown structure. So after the `get_system_properties` call, the `System<props>` struct might still contain random values. Because of this we should ditch the `out()` method and manually initialize the structure. The upstream `openxrs` crate suffers from the same bug, but only concerning the hand tracking extension. That instance of the bug hasn't surfaced yet.