### PR TITLE
fix(client_core): :bug: Workaround for blank right eye view

### DIFF
--- a/alvr/client_core/resources/staging_vertex.glsl
+++ b/alvr/client_core/resources/staging_vertex.glsl
@@ -1,8 +1,11 @@
 #version 300 es
 
+uniform int view_idx;
+
 out vec2 uv;
 
 void main() {
-    uv = vec2(gl_VertexID & 1, gl_VertexID >> 1);
-    gl_Position = vec4((uv - 0.5f) * 2.f, 0, 1);
+    vec2 screen_uv = vec2(gl_VertexID & 1, gl_VertexID >> 1);
+    gl_Position = vec4((screen_uv - 0.5f) * 2.f, 0, 1);
+    uv = vec2((screen_uv.x + float(view_idx)) / 2.f, screen_uv.y);
 }

--- a/alvr/client_core/resources/stream.wgsl
+++ b/alvr/client_core/resources/stream.wgsl
@@ -12,8 +12,6 @@ override FIX_LIMITED_RANGE: bool;
 override ENABLE_SRGB_CORRECTION: bool;
 override ENCODING_GAMMA: f32;
 
-var<push_constant> view_idx: u32;
-
 struct VertexOutput {
     @builtin(position) position: vec4f,
     @location(0) uv: vec2f,
@@ -27,8 +25,8 @@ fn vertex_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     var result: VertexOutput;
 
     let screen_uv = vec2f(f32(vertex_index & 1), f32(vertex_index >> 1));
-    result.position = vec4f((screen_uv - vec2f(0.5, 0.5)) * 2.0, 0.0, 1.0);
-    result.uv = vec2f((screen_uv.x + f32(view_idx)) / 2.0, screen_uv.y);
+    result.position = vec4f((screen_uv - 0.5) * 2.0, 0.0, 1.0);
+    result.uv = vec2f(screen_uv.x, screen_uv.y);
 
     return result;
 }


### PR DESCRIPTION
This is a workaround for a weird graphics bug. It seems the staging framebuffer cannot write to more than the size of the stream framebuffer, even if they have nothing to do with each other. The fix is to split the staging texture into two so each staging framebuffer has the same size as the stream framebuffers.

This bug has been investigated extensively .This is not a problem with shaders or viewports. The root cause is still unknown.