### PR TITLE
fix(linux): Fix idr reporting from x264

### DIFF
--- a/alvr/server_openvr/cpp/platform/linux/EncodePipelineSW.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/EncodePipelineSW.cpp
@@ -104,6 +104,7 @@ void alvr::EncodePipelineSW::PushFrame(uint64_t targetTimestampNs, bool idr) {
 
     picture.i_type = idr ? X264_TYPE_IDR : X264_TYPE_AUTO;
     pts = picture.i_pts = targetTimestampNs;
+    is_idr = idr;
 
     int nnal = 0;
     nal_size = x264_encoder_encode(enc, &nal, &nnal, &picture, &picture_out);
@@ -119,6 +120,7 @@ bool alvr::EncodePipelineSW::GetEncoded(FramePacket& packet) {
     packet.size = nal_size;
     packet.data = nal[0].p_payload;
     packet.pts = pts;
+    packet.isIDR = is_idr;
     return packet.size > 0;
 }
 

--- a/alvr/server_openvr/cpp/platform/linux/EncodePipelineSW.h
+++ b/alvr/server_openvr/cpp/platform/linux/EncodePipelineSW.h
@@ -26,6 +26,7 @@ private:
     x264_nal_t* nal = nullptr;
     int nal_size = 0;
     int64_t pts = 0;
+    bool is_idr = false;
     FormatConverter* rgbtoyuv = nullptr;
 };
 }


### PR DESCRIPTION
This could be related to the issue originally encountered with the idr scheduler improvement (#2403). Idr state wasn't being set by the encode pipeline and was defaulting to `true` according to my testing.

Note that I haven't actually tested this