### PR TITLE
Zarik staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "android_logger",
  "app_dirs2",
  "bincode",
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "env_logger",
  "glow",
@@ -273,15 +273,10 @@ dependencies = [
  "alvr_session",
  "bincode",
  "chrono",
- "console_error_panic_hook",
  "cros-libva",
  "eframe",
  "env_logger",
- "ewebsock",
- "futures",
- "gloo-net",
  "ico",
- "instant",
  "nvml-wrapper",
  "rand",
  "serde",
@@ -289,10 +284,8 @@ dependencies = [
  "settings-schema",
  "statrs",
  "sysinfo",
- "tungstenite 0.23.0",
+ "tungstenite 0.24.0",
  "ureq",
- "wasm-bindgen-futures",
- "wasm-logger",
  "wgpu",
  "winres",
 ]
@@ -413,7 +406,7 @@ dependencies = [
  "alvr_server_core",
  "alvr_server_io",
  "alvr_session",
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "pkg-config",
  "walkdir",
@@ -461,7 +454,7 @@ version = "21.0.0-dev01"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "pkg-config",
  "walkdir",
@@ -1063,6 +1056,24 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.70",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1071,7 +1082,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.70",
- "which",
 ]
 
 [[package]]
@@ -1441,16 +1451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,7 +1531,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f01585027057ff5f0a5bf276174ae4c1594a2c5bde93d5f46a016d76270f5a9"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.4",
 ]
 
 [[package]]
@@ -1593,14 +1593,33 @@ dependencies = [
 
 [[package]]
 name = "cros-libva"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f75943ee30eb2f8b4f3beb8f047e69ecc1c91d098c344b34a0fdd8dd8b2614a"
+checksum = "1b1546af142fbf11a5cad3d1ee2ef64e4d7b69a28b244a79484024a1bc931c17"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "log",
  "pkg-config",
  "thiserror",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2087,21 +2106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ewebsock"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6177769715c6ec5a324acee995183b22721ea23c58e49af14a828eadec85d120"
-dependencies = [
- "document-features",
- "js-sys",
- "log",
- "tungstenite 0.21.0",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "exec"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+checksum = "c28091a37a5d09b555cb6628fd954da299b536433834f5b8e59eba78e0cbbf8a"
 dependencies = [
  "serde",
 ]
@@ -2430,40 +2434,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "gloo-net"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils",
- "http 0.2.12",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
 
 [[package]]
 name = "glow"
@@ -3023,9 +2993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3268,7 +3235,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf0d9716420364790e85cbb9d3ac2c950bde16a7dd36f3209b7dfdfc4a24d01f"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.4",
  "cc",
  "system-deps",
 ]
@@ -4275,7 +4242,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "849e188f90b1dda88fe2bfe1ad31fe5f158af2c98f80fb5d13726c44f3f01112"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.4",
  "libspa-sys",
  "system-deps",
 ]
@@ -4540,6 +4507,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -5340,16 +5327,16 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "windows 0.52.0",
+ "rayon",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -5794,28 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.1.0",
- "httparse",
- "log",
- "rand",
- "sha1",
- "thiserror",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
  "byteorder",
  "bytes",
@@ -6074,17 +6042,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
-name = "wasm-logger"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074649a66bb306c8f2068c9016395fa65d8e08d2affcbf95acf3c24c3ab19718"
-dependencies = [
- "log",
- "wasm-bindgen",
- "web-sys",
-]
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4089,8 +4089,8 @@ dependencies = [
 
 [[package]]
 name = "openxr"
-version = "0.19.0"
-source = "git+https://github.com/Ralith/openxrs#d8ea5553d52c4bbaefe2537b8d70b8752f73694d"
+version = "0.18.0"
+source = "git+https://github.com/Ralith/openxrs?rev=9270509d23dc774b43a8b7289e8adf69fcac6828#9270509d23dc774b43a8b7289e8adf69fcac6828"
 dependencies = [
  "libc",
  "libloading 0.8.4",
@@ -4100,8 +4100,8 @@ dependencies = [
 
 [[package]]
 name = "openxr-sys"
-version = "0.11.0"
-source = "git+https://github.com/Ralith/openxrs#d8ea5553d52c4bbaefe2537b8d70b8752f73694d"
+version = "0.10.0"
+source = "git+https://github.com/Ralith/openxrs?rev=9270509d23dc774b43a8b7289e8adf69fcac6828#9270509d23dc774b43a8b7289e8adf69fcac6828"
 dependencies = [
  "libc",
 ]

--- a/alvr/client_core/Cargo.toml
+++ b/alvr/client_core/Cargo.toml
@@ -48,6 +48,6 @@ oboe = "0.6"                                                    # todo: remove o
 env_logger = "0.11"
 
 [build-dependencies]
-bindgen = "0.69"
+bindgen = "0.70"
 cc = { version = "1", features = ["parallel"] }
 walkdir = "2"

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -490,9 +490,11 @@ pub extern "C" fn alvr_send_button(path_id: u64, value: AlvrButtonValue) {
 
 /// view_params:
 /// * array of 2;
+///
 /// hand_skeleton:
 /// * outer ptr: array of 2 (can be null);
 /// * inner ptr: array of 26 (can be null if hand is absent)
+///
 /// eye_gazes:
 /// * outer ptr: array of 2 (can be null);
 /// * inner ptr: pose (can be null if eye gaze is absent)

--- a/alvr/client_core/src/graphics/stream.rs
+++ b/alvr/client_core/src/graphics/stream.rs
@@ -161,9 +161,8 @@ impl StreamRenderer {
 
             let mut view_objects = vec![];
             let mut staging_textures_gl = vec![];
-            for i in 0..2 {
-                let staging_texture =
-                    super::create_texture(&device, view_resolution, target_format);
+            for target_swapchain in &swapchain_textures {
+                let staging_texture = super::create_texture(device, view_resolution, target_format);
 
                 let staging_texture_gl = unsafe {
                     staging_texture.as_hal::<api::Gles, _, _>(|tex| {
@@ -193,7 +192,7 @@ impl StreamRenderer {
 
                 let render_target = super::create_gl_swapchain(
                     device,
-                    &swapchain_textures[i],
+                    target_swapchain,
                     view_resolution,
                     target_format,
                 );

--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -15,7 +15,7 @@ alvr_client_core.workspace = true
 alvr_packets.workspace = true
 alvr_session.workspace = true
 
-openxr = { git = "https://github.com/Ralith/openxrs" }
+openxr = { git = "https://github.com/Ralith/openxrs", rev = "9270509d23dc774b43a8b7289e8adf69fcac6828" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android-activity = { version = "0.6", features = ["native-activity"] }

--- a/alvr/client_openxr/src/extra_extensions/eye_tracking_social.rs
+++ b/alvr/client_openxr/src/extra_extensions/eye_tracking_social.rs
@@ -1,4 +1,3 @@
-use alvr_common::{anyhow::Result, ToAny};
 use openxr::{self as xr, raw, sys};
 use std::ptr;
 
@@ -8,8 +7,12 @@ pub struct EyeTrackerSocial {
 }
 
 impl EyeTrackerSocial {
-    pub fn new<G>(session: &xr::Session<G>) -> Result<Self> {
-        let ext_fns = session.instance().exts().fb_eye_tracking_social.to_any()?;
+    pub fn new<G>(session: &xr::Session<G>) -> xr::Result<Self> {
+        let ext_fns = session
+            .instance()
+            .exts()
+            .fb_eye_tracking_social
+            .ok_or(sys::Result::ERROR_EXTENSION_NOT_PRESENT)?;
 
         let mut handle = sys::EyeTrackerFB::NULL;
         let info = sys::EyeTrackerCreateInfoFB {
@@ -17,7 +20,7 @@ impl EyeTrackerSocial {
             next: ptr::null(),
         };
         unsafe {
-            super::xr_to_any((ext_fns.create_eye_tracker)(
+            super::xr_res((ext_fns.create_eye_tracker)(
                 session.as_raw(),
                 &info,
                 &mut handle,
@@ -31,7 +34,7 @@ impl EyeTrackerSocial {
         &self,
         base: &xr::Space,
         time: xr::Time,
-    ) -> Result<[Option<xr::Posef>; 2]> {
+    ) -> xr::Result<[Option<xr::Posef>; 2]> {
         let gaze_info = sys::EyeGazesInfoFB {
             ty: sys::EyeGazesInfoFB::TYPE,
             next: ptr::null(),
@@ -42,7 +45,7 @@ impl EyeTrackerSocial {
         let mut eye_gazes = sys::EyeGazesFB::out(ptr::null_mut());
 
         let eye_gazes = unsafe {
-            super::xr_to_any((self.ext_fns.get_eye_gazes)(
+            super::xr_res((self.ext_fns.get_eye_gazes)(
                 self.handle,
                 &gaze_info,
                 eye_gazes.as_mut_ptr(),

--- a/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
+++ b/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
@@ -1,4 +1,3 @@
-use alvr_common::{anyhow::Result, ToAny};
 use openxr::{self as xr, raw, sys};
 use std::ptr;
 
@@ -12,8 +11,12 @@ impl FacialTrackerHTC {
     pub fn new<G>(
         session: &xr::Session<G>,
         facial_tracking_type: xr::FacialTrackingTypeHTC,
-    ) -> Result<Self> {
-        let ext_fns = session.instance().exts().htc_facial_tracking.to_any()?;
+    ) -> xr::Result<Self> {
+        let ext_fns = session
+            .instance()
+            .exts()
+            .htc_facial_tracking
+            .ok_or(sys::Result::ERROR_EXTENSION_NOT_PRESENT)?;
 
         let mut handle = sys::FacialTrackerHTC::NULL;
         let info = sys::FacialTrackerCreateInfoHTC {
@@ -22,7 +25,7 @@ impl FacialTrackerHTC {
             facial_tracking_type,
         };
         unsafe {
-            super::xr_to_any((ext_fns.create_facial_tracker)(
+            super::xr_res((ext_fns.create_facial_tracker)(
                 session.as_raw(),
                 &info,
                 &mut handle,
@@ -42,7 +45,7 @@ impl FacialTrackerHTC {
         })
     }
 
-    pub fn get_facial_expressions(&self) -> Result<Option<Vec<f32>>> {
+    pub fn get_facial_expressions(&self) -> xr::Result<Option<Vec<f32>>> {
         let mut weights = Vec::with_capacity(self.expression_count);
 
         let mut facial_expressions = sys::FacialExpressionsHTC {
@@ -55,7 +58,7 @@ impl FacialTrackerHTC {
         };
 
         unsafe {
-            super::xr_to_any((self.ext_fns.get_facial_expressions)(
+            super::xr_res((self.ext_fns.get_facial_expressions)(
                 self.handle,
                 &mut facial_expressions,
             ))?;

--- a/alvr/client_openxr/src/extra_extensions/mod.rs
+++ b/alvr/client_openxr/src/extra_extensions/mod.rs
@@ -11,75 +11,12 @@ pub use facial_tracking_htc::*;
 pub use multimodal_input::*;
 
 use alvr_common::anyhow::{anyhow, Result};
-use openxr::{self as xr, sys};
-use std::{mem, ptr};
+use openxr::sys;
 
-fn to_any(result: sys::Result) -> Result<()> {
+fn xr_to_any(result: sys::Result) -> Result<()> {
     if result.into_raw() >= 0 {
         Ok(())
     } else {
         Err(anyhow!("OpenXR error: {:?}", result))
-    }
-}
-
-#[derive(Clone)]
-pub struct ExtraExtensions {
-    base_function_ptrs: xr::raw::Instance,
-    ext_functions_ptrs: xr::InstanceExtensions,
-    resume_simultaneous_hands_and_controllers_tracking_meta:
-        Option<ResumeSimultaneousHandsAndControllersTrackingMETA>,
-}
-
-impl ExtraExtensions {
-    pub fn new(instance: &xr::Instance) -> Self {
-        let resume_simultaneous_hands_and_controllers_tracking_meta = unsafe {
-            let mut resume_simultaneous_hands_and_controllers_tracking_meta = None;
-            let _ = (instance.fp().get_instance_proc_addr)(
-                instance.as_raw(),
-                c"xrResumeSimultaneousHandsAndControllersTrackingMETA".as_ptr(),
-                &mut resume_simultaneous_hands_and_controllers_tracking_meta,
-            );
-
-            resume_simultaneous_hands_and_controllers_tracking_meta
-                .map(|f| mem::transmute::<_, ResumeSimultaneousHandsAndControllersTrackingMETA>(f))
-        };
-
-        Self {
-            base_function_ptrs: instance.fp().clone(),
-            ext_functions_ptrs: *instance.exts(),
-            resume_simultaneous_hands_and_controllers_tracking_meta,
-        }
-    }
-
-    fn get_props<T>(
-        &self,
-        instance: &xr::Instance,
-        system: xr::SystemId,
-        default_struct: T,
-    ) -> Option<T> {
-        let mut props = default_struct;
-
-        let mut system_properties = sys::SystemProperties::out((&mut props as *mut T).cast());
-        let result = unsafe {
-            (self.base_function_ptrs.get_system_properties)(
-                instance.as_raw(),
-                system,
-                system_properties.as_mut_ptr(),
-            )
-        };
-
-        (result.into_raw() >= 0).then_some(props)
-    }
-
-    pub fn supports_eye_gaze_interaction(
-        &self,
-        instance: &xr::Instance,
-        system: xr::SystemId,
-    ) -> bool {
-        self.get_props(instance, system, unsafe {
-            sys::SystemEyeGazeInteractionPropertiesEXT::out(ptr::null_mut()).assume_init()
-        })
-        .map(|props| props.supports_eye_gaze_interaction.into())
-        .unwrap_or(false)
     }
 }

--- a/alvr/client_openxr/src/extra_extensions/mod.rs
+++ b/alvr/client_openxr/src/extra_extensions/mod.rs
@@ -10,13 +10,12 @@ pub use face_tracking2_fb::*;
 pub use facial_tracking_htc::*;
 pub use multimodal_input::*;
 
-use alvr_common::anyhow::{anyhow, Result};
-use openxr::sys;
+use openxr::{self as xr, sys};
 
-fn xr_to_any(result: sys::Result) -> Result<()> {
+fn xr_res(result: sys::Result) -> xr::Result<()> {
     if result.into_raw() >= 0 {
         Ok(())
     } else {
-        Err(anyhow!("OpenXR error: {:?}", result))
+        Err(result)
     }
 }

--- a/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
+++ b/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
@@ -2,7 +2,10 @@
 // https://github.com/meta-quest/Meta-OpenXR-SDK/blob/main/OpenXR/meta_openxr_preview/meta_simultaneous_hands_and_controllers.h
 
 use alvr_common::{anyhow::Result, once_cell::sync::Lazy, ToAny};
-use openxr::{self as xr, sys};
+use openxr::{
+    self as xr,
+    sys::{self, pfn::VoidFunction},
+};
 use std::{ffi::c_void, mem, ptr};
 
 pub const META_SIMULTANEOUS_HANDS_AND_CONTROLLERS_EXTENSION_NAME: &str =
@@ -35,7 +38,7 @@ pub fn resume_simultaneous_hands_and_controllers_tracking<G>(
             &mut resume_simultaneous_hands_and_controllers_tracking_meta,
         );
 
-        mem::transmute::<_, ResumeSimultaneousHandsAndControllersTrackingMETA>(
+        mem::transmute::<VoidFunction, ResumeSimultaneousHandsAndControllersTrackingMETA>(
             resume_simultaneous_hands_and_controllers_tracking_meta.to_any()?,
         )
     };

--- a/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
+++ b/alvr/client_openxr/src/extra_extensions/multimodal_input.rs
@@ -3,23 +3,14 @@
 
 use alvr_common::{anyhow::Result, once_cell::sync::Lazy, ToAny};
 use openxr::{self as xr, sys};
-use std::{ffi::c_void, ptr};
+use std::{ffi::c_void, mem, ptr};
 
 pub const META_SIMULTANEOUS_HANDS_AND_CONTROLLERS_EXTENSION_NAME: &str =
     "XR_META_simultaneous_hands_and_controllers";
 pub const META_DETACHED_CONTROLLERS_EXTENSION_NAME: &str = "XR_META_detached_controllers";
 
-static TYPE_SYSTEM_SIMULTANEOUS_HANDS_AND_CONTROLLERS_PROPERTIES_META: Lazy<xr::StructureType> =
-    Lazy::new(|| xr::StructureType::from_raw(1000532001));
 static TYPE_SIMULTANEOUS_HANDS_AND_CONTROLLERS_TRACKING_RESUME_INFO_META: Lazy<xr::StructureType> =
     Lazy::new(|| xr::StructureType::from_raw(1000532002));
-
-#[repr(C)]
-pub struct SystemSymultaneousHandsAndControllersPropertiesMETA {
-    ty: xr::StructureType,
-    next: *const c_void,
-    supports_simultaneous_hands_and_controllers: sys::Bool32,
-}
 
 #[repr(C)]
 pub struct SimultaneousHandsAndControllersTrackingResumeInfoMETA {
@@ -33,40 +24,33 @@ pub type ResumeSimultaneousHandsAndControllersTrackingMETA =
         *const SimultaneousHandsAndControllersTrackingResumeInfoMETA,
     ) -> sys::Result;
 
-impl super::ExtraExtensions {
-    pub fn supports_simultaneous_hands_and_controllers(
-        &self,
-        instance: &xr::Instance,
-        system: xr::SystemId,
-    ) -> bool {
-        self.get_props(
-            instance,
-            system,
-            SystemSymultaneousHandsAndControllersPropertiesMETA {
-                ty: *TYPE_SYSTEM_SIMULTANEOUS_HANDS_AND_CONTROLLERS_PROPERTIES_META,
-                next: ptr::null(),
-                supports_simultaneous_hands_and_controllers: xr::sys::FALSE,
-            },
+pub fn resume_simultaneous_hands_and_controllers_tracking<G>(
+    session: &xr::Session<G>,
+) -> Result<()> {
+    let resume_simultaneous_hands_and_controllers_tracking_meta = unsafe {
+        let mut resume_simultaneous_hands_and_controllers_tracking_meta = None;
+        let _ = (session.instance().fp().get_instance_proc_addr)(
+            session.instance().as_raw(),
+            c"xrResumeSimultaneousHandsAndControllersTrackingMETA".as_ptr(),
+            &mut resume_simultaneous_hands_and_controllers_tracking_meta,
+        );
+
+        mem::transmute::<_, ResumeSimultaneousHandsAndControllersTrackingMETA>(
+            resume_simultaneous_hands_and_controllers_tracking_meta.to_any()?,
         )
-        .map(|props| props.supports_simultaneous_hands_and_controllers.into())
-        .unwrap_or(false)
+    };
+
+    let resume_info = SimultaneousHandsAndControllersTrackingResumeInfoMETA {
+        ty: *TYPE_SIMULTANEOUS_HANDS_AND_CONTROLLERS_TRACKING_RESUME_INFO_META,
+        next: ptr::null(),
+    };
+
+    unsafe {
+        super::xr_to_any(resume_simultaneous_hands_and_controllers_tracking_meta(
+            session.as_raw(),
+            &resume_info,
+        ))?;
     }
 
-    pub fn resume_simultaneous_hands_and_controllers_tracking(
-        &self,
-        session: &xr::Session<xr::OpenGlEs>,
-    ) -> Result<()> {
-        let resume_info = SimultaneousHandsAndControllersTrackingResumeInfoMETA {
-            ty: *TYPE_SIMULTANEOUS_HANDS_AND_CONTROLLERS_TRACKING_RESUME_INFO_META,
-            next: ptr::null(),
-        };
-
-        unsafe {
-            super::to_any((self
-                .resume_simultaneous_hands_and_controllers_tracking_meta
-                .to_any()?)(session.as_raw(), &resume_info))?;
-        }
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -272,7 +272,7 @@ pub fn initialize_interaction(
                 .ok()?;
 
             let space = action
-                .create_space(&xr_ctx.session, xr::Path::NULL, xr::Posef::IDENTITY)
+                .create_space(xr_ctx.session.clone(), xr::Path::NULL, xr::Posef::IDENTITY)
                 .unwrap();
 
             Some((action, space))
@@ -282,17 +282,17 @@ pub fn initialize_interaction(
     xr_ctx.session.attach_action_sets(&[&action_set]).unwrap();
 
     let left_grip_space = left_grip_action
-        .create_space(&xr_ctx.session, xr::Path::NULL, xr::Posef::IDENTITY)
+        .create_space(xr_ctx.session.clone(), xr::Path::NULL, xr::Posef::IDENTITY)
         .unwrap();
     let right_grip_space = right_grip_action
-        .create_space(&xr_ctx.session, xr::Path::NULL, xr::Posef::IDENTITY)
+        .create_space(xr_ctx.session.clone(), xr::Path::NULL, xr::Posef::IDENTITY)
         .unwrap();
 
     let left_aim_space = left_aim_action
-        .create_space(&xr_ctx.session, xr::Path::NULL, xr::Posef::IDENTITY)
+        .create_space(xr_ctx.session.clone(), xr::Path::NULL, xr::Posef::IDENTITY)
         .unwrap();
     let right_aim_space = right_aim_action
-        .create_space(&xr_ctx.session, xr::Path::NULL, xr::Posef::IDENTITY)
+        .create_space(xr_ctx.session.clone(), xr::Path::NULL, xr::Posef::IDENTITY)
         .unwrap();
 
     let left_hand_tracker = xr_ctx.session.create_hand_tracker(xr::Hand::LEFT).ok();

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -15,8 +15,7 @@ use alvr_common::{
     info, Fov, Pose, HAND_LEFT_ID,
 };
 use extra_extensions::{
-    ExtraExtensions, META_BODY_TRACKING_FULL_BODY_EXTENSION_NAME,
-    META_DETACHED_CONTROLLERS_EXTENSION_NAME,
+    META_BODY_TRACKING_FULL_BODY_EXTENSION_NAME, META_DETACHED_CONTROLLERS_EXTENSION_NAME,
     META_SIMULTANEOUS_HANDS_AND_CONTROLLERS_EXTENSION_NAME,
 };
 use lobby::Lobby;
@@ -98,7 +97,6 @@ pub struct XrContext {
     instance: xr::Instance,
     system: xr::SystemId,
     session: xr::Session<xr::OpenGlEs>,
-    extra_extensions: ExtraExtensions,
 }
 
 fn default_view() -> xr::View {
@@ -223,7 +221,6 @@ pub fn entry_point() {
             instance: xr_instance.clone(),
             system: xr_system,
             session: xr_session.clone(),
-            extra_extensions: ExtraExtensions::new(&xr_instance),
         };
 
         let views_config = xr_instance

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -189,7 +189,6 @@ pub fn entry_point() {
                 application_version: 0,
                 engine_name: "ALVR",
                 engine_version: 0,
-                api_version: xr::Version::new(1, 0, 0),
             },
             &exts,
             &[],

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -353,7 +353,7 @@ pub fn entry_point() {
                         lobby.update_hud_message(&message);
                     }
                     ClientCoreEvent::StreamingStarted(config) => {
-                        let new_config = ParsedStreamConfig::new(&*config);
+                        let new_config = ParsedStreamConfig::new(&config);
 
                         // combined_eye_gaze is a setting that needs to be enabled at session
                         // creation. Since HTC headsets don't support session reinitialization, skip

--- a/alvr/common/Cargo.toml
+++ b/alvr/common/Cargo.toml
@@ -12,7 +12,7 @@ enable-messagebox = ["rfd"]
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 backtrace = "0.3"
-glam = { version = "0.28", features = ["serde"] }
+glam = { version = "0.29", features = ["serde"] }
 log = "0.4"
 once_cell = "1"
 parking_lot = "0.12"

--- a/alvr/dashboard/Cargo.toml
+++ b/alvr/dashboard/Cargo.toml
@@ -27,22 +27,13 @@ statrs = "0.17"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 alvr_server_io.workspace = true
-sysinfo = { version = "0.30", default-features = false }
-tungstenite = "0.23"
+sysinfo = "0.31"
+tungstenite = "0.24"
 ureq = { version = "2", features = ["json"] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = "0.1"
-ewebsock = "0.5"
-futures = "0.3"
-gloo-net = "0.5"
-instant = { version = "0.1", features = ["wasm-bindgen"] }
-wasm-bindgen-futures = "0.4"
-wasm-logger = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 wgpu = "0.20"
-libva = { package = "cros-libva", version = "0.0.6" }
+libva = { package = "cros-libva", version = "0.0.7" }
 nvml-wrapper = "0.10.0"
 
 [target.'cfg(windows)'.build-dependencies]

--- a/alvr/dashboard/src/dashboard/components/statistics.rs
+++ b/alvr/dashboard/src/dashboard/components/statistics.rs
@@ -168,7 +168,7 @@ impl StatisticsTab {
                 Grid::new("latency_tooltip").num_columns(2).show(ui, |ui| {
                     fn label(ui: &mut Ui, text: &str, value_s: f32, color: Color32) {
                         ui.colored_label(color, text);
-                        ui.colored_label(color, &format!("{:.2}ms", value_s * 1000.0));
+                        ui.colored_label(color, format!("{:.2}ms", value_s * 1000.0));
                         ui.end_row();
                     }
 
@@ -326,7 +326,7 @@ impl StatisticsTab {
                     color: Color32,
                 ) {
                     if let Some(value) = maybe_value_bps {
-                        ui.colored_label(color, &format!("{text}: {:.2} Mbps", value / 1e6));
+                        ui.colored_label(color, format!("{text}: {:.2} Mbps", value / 1e6));
                     }
                 }
 
@@ -374,43 +374,43 @@ impl StatisticsTab {
 
         ui.columns(2, |ui| {
             ui[0].label("Total packets:");
-            ui[1].label(&format!(
+            ui[1].label(format!(
                 "{} packets ({} packets/s)",
                 statistics.video_packets_total, statistics.video_packets_per_sec
             ));
 
             ui[0].label("Total sent:");
-            ui[1].label(&format!("{} MB", statistics.video_mbytes_total));
+            ui[1].label(format!("{} MB", statistics.video_mbytes_total));
 
             ui[0].label("Bitrate:");
-            ui[1].label(&format!("{:.1} Mbps", statistics.video_mbits_per_sec));
+            ui[1].label(format!("{:.1} Mbps", statistics.video_mbits_per_sec));
 
             ui[0].label("Total latency:");
-            ui[1].label(&format!("{:.0} ms", statistics.total_latency_ms));
+            ui[1].label(format!("{:.0} ms", statistics.total_latency_ms));
 
             ui[0].label("Encoder latency:");
-            ui[1].label(&format!("{:.2} ms", statistics.encode_latency_ms));
+            ui[1].label(format!("{:.2} ms", statistics.encode_latency_ms));
 
             ui[0].label("Transport latency:");
-            ui[1].label(&format!("{:.2} ms", statistics.network_latency_ms));
+            ui[1].label(format!("{:.2} ms", statistics.network_latency_ms));
 
             ui[0].label("Decoder latency:");
-            ui[1].label(&format!("{:.2} ms", statistics.decode_latency_ms));
+            ui[1].label(format!("{:.2} ms", statistics.decode_latency_ms));
 
             ui[0].label("Total packets lost:");
-            ui[1].label(&format!(
+            ui[1].label(format!(
                 "{} packets ({} packets/s)",
                 statistics.packets_lost_total, statistics.packets_lost_per_sec
             ));
 
             ui[0].label("Client FPS:");
-            ui[1].label(&format!("{} FPS", statistics.client_fps));
+            ui[1].label(format!("{} FPS", statistics.client_fps));
 
             ui[0].label("Streamer FPS:");
-            ui[1].label(&format!("{} FPS", statistics.server_fps));
+            ui[1].label(format!("{} FPS", statistics.server_fps));
 
             ui[0].label("Headset battery");
-            ui[1].label(&format!(
+            ui[1].label(format!(
                 "{}% ({})",
                 statistics.battery_hmd,
                 if statistics.hmd_plugged {

--- a/alvr/server_core/Cargo.toml
+++ b/alvr/server_core/Cargo.toml
@@ -53,4 +53,4 @@ tokio-tungstenite = "0.20"
 tokio-util = { version = "0.7", features = ["codec"] }
 serde = "1"
 serde_json = "1"
-sysinfo = { version = "0.30", default-features = false }
+sysinfo = "0.31"

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -589,6 +589,7 @@ fn connection_pipeline(
         settings.video.preferred_codec
     };
 
+    #[cfg_attr(target_os = "linux", allow(unused_variables))]
     let game_audio_sample_rate =
         if let Switch::Enabled(game_audio_config) = &settings.audio.game_audio {
             #[cfg(not(target_os = "linux"))]
@@ -731,6 +732,7 @@ fn connection_pipeline(
         }
     });
 
+    #[cfg_attr(target_os = "linux", allow(unused_variables))]
     let game_audio_thread = if let Switch::Enabled(config) = settings.audio.game_audio {
         #[cfg(windows)]
         let ctx = Arc::clone(&ctx);

--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -38,6 +38,7 @@ use statistics::StatisticsManager;
 use std::{
     collections::HashSet,
     env,
+    ffi::OsStr,
     fs::File,
     io::Write,
     sync::{
@@ -48,7 +49,7 @@ use std::{
     thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
-use sysinfo::{ProcessRefreshKind, RefreshKind};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, RefreshKind};
 use tokio::{runtime::Runtime, sync::broadcast};
 
 static FILESYSTEM_LAYOUT: OnceLock<afs::Layout> = OnceLock::new();
@@ -145,10 +146,10 @@ pub fn notify_restart_driver() {
     let mut system = sysinfo::System::new_with_specifics(
         RefreshKind::new().with_processes(ProcessRefreshKind::everything()),
     );
-    system.refresh_processes();
+    system.refresh_processes(ProcessesToUpdate::All);
 
     if system
-        .processes_by_name(afs::dashboard_fname())
+        .processes_by_name(OsStr::new(&afs::dashboard_fname()))
         .next()
         .is_some()
     {

--- a/alvr/server_openvr/Cargo.toml
+++ b/alvr/server_openvr/Cargo.toml
@@ -22,7 +22,7 @@ alvr_session.workspace = true
 
 [build-dependencies]
 alvr_filesystem = { path = "../filesystem" }
-bindgen = "0.69"
+bindgen = "0.70"
 cc = { version = "1", features = ["parallel"] }
 walkdir = "2"
 

--- a/alvr/vulkan_layer/Cargo.toml
+++ b/alvr/vulkan_layer/Cargo.toml
@@ -14,7 +14,7 @@ alvr_common.workspace = true
 alvr_filesystem.workspace = true
 
 [build-dependencies]
-bindgen = "0.69"
+bindgen = "0.70"
 cc = { version = "1", features = ["parallel"] }
 pkg-config = "0.3"
 walkdir = "2"


### PR DESCRIPTION
For some reason after upgrading openxrs, the thumbs render twisted. I've yet to identify the issue, but i've selected the last commit in openxrs that builds that doesn't have this bug.

The mock client fixes graphs by randomizing orientation instead of position. The reason it was broken before is because the server relies on orientation matching to assign the correct timestamp to a frame.