### PR TITLE
fix(server_openvr): Calculate velocities for skeleton-based controllers

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -287,8 +287,8 @@ bool Controller::onPoseUpdate(uint64_t targetTimestampNs, float predictionS, Ffi
 
         // If possible, use the last stored m_pose and timestamp
         // to calculate the velocities of the current pose.
-        double calcLinearVelocity[3] = {0.0, 0.0, 0.0};
-        vr::HmdVector3d_t calcAngularVelocity = {0.0, 0.0, 0.0};
+        double calcLinearVelocity[3] = { 0.0, 0.0, 0.0 };
+        vr::HmdVector3d_t calcAngularVelocity = { 0.0, 0.0, 0.0 };
 
         if (m_pose.poseIsValid) {
             auto start = std::chrono::nanoseconds(m_poseTargetTimestampNs);
@@ -300,7 +300,8 @@ bool Controller::onPoseUpdate(uint64_t targetTimestampNs, float predictionS, Ffi
                 calcLinearVelocity[0] = (pose.vecPosition[0] - m_pose.vecPosition[0]) / dt;
                 calcLinearVelocity[1] = (pose.vecPosition[1] - m_pose.vecPosition[1]) / dt;
                 calcLinearVelocity[2] = (pose.vecPosition[2] - m_pose.vecPosition[2]) / dt;
-                calcAngularVelocity = AngularVelocityBetweenQuats(m_pose.qRotation, pose.qRotation, dt);
+                calcAngularVelocity
+                    = AngularVelocityBetweenQuats(m_pose.qRotation, pose.qRotation, dt);
             }
         }
 

--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -290,7 +290,7 @@ bool Controller::onPoseUpdate(uint64_t targetTimestampNs, float predictionS, Ffi
         vr::HmdVector3d_t angularVelocity = { 0.0, 0.0, 0.0 };
 
         if (m_pose.poseIsValid) {
-            double dt = (double)(targetTimestampNs - m_poseTargetTimestampNs) / NS_PER_S;
+            double dt = ((double)targetTimestampNs - (double)m_poseTargetTimestampNs) / NS_PER_S;
 
             if (dt > 0.0) {
                 linearVelocity[0] = (pose.vecPosition[0] - m_pose.vecPosition[0]) / dt;

--- a/alvr/server_openvr/cpp/alvr_server/Controller.h
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.h
@@ -37,7 +37,7 @@ public:
 
     void SetButton(uint64_t id, FfiButtonValue value);
 
-    bool onPoseUpdate(float predictionS, FfiHandData handData);
+    bool onPoseUpdate(uint64_t targetTimestampNs, float predictionS, FfiHandData handData);
 
     void GetBoneTransform(bool withController, vr::VRBoneTransform_t outBoneTransform[]);
 
@@ -54,6 +54,9 @@ private:
     vr::EVRSkeletalTrackingLevel m_skeletonLevel;
 
     vr::DriverPose_t m_pose;
+    vr::DriverPose_t m_lastPose;
+    uint64_t m_poseTargetTimestampNs;
+    uint64_t m_lastPoseTargetTimestampNs;
 
     // These variables are used for controller hand animation
     // todo: move to rust

--- a/alvr/server_openvr/cpp/alvr_server/Controller.h
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.h
@@ -54,9 +54,7 @@ private:
     vr::EVRSkeletalTrackingLevel m_skeletonLevel;
 
     vr::DriverPose_t m_pose;
-    vr::DriverPose_t m_lastPose;
     uint64_t m_poseTargetTimestampNs;
-    uint64_t m_lastPoseTargetTimestampNs;
 
     // These variables are used for controller hand animation
     // todo: move to rust

--- a/alvr/server_openvr/cpp/alvr_server/Utils.h
+++ b/alvr/server_openvr/cpp/alvr_server/Utils.h
@@ -163,13 +163,13 @@ Slerp(vr::HmdQuaternionf_t& q1, vr::HmdQuaternionf_t& q2, double lambda) {
     }
 }
 
-inline vr::HmdVector3d_t AngularVelocityBetweenQuats(const vr::HmdQuaternion_t& q1, const vr::HmdQuaternion_t& q2, double dt) {
+inline vr::HmdVector3d_t AngularVelocityBetweenQuats(
+    const vr::HmdQuaternion_t& q1, const vr::HmdQuaternion_t& q2, double dt
+) {
     double r = (2.0f / dt);
-    return {
-        (q1.w*q2.x - q1.x*q2.w - q1.y*q2.z + q1.z*q2.y) * r,
-        (q1.w*q2.y + q1.x*q2.z - q1.y*q2.w - q1.z*q2.x) * r,
-        (q1.w*q2.z - q1.x*q2.y + q1.y*q2.x - q1.z*q2.w) * r
-    };
+    return { (q1.w * q2.x - q1.x * q2.w - q1.y * q2.z + q1.z * q2.y) * r,
+             (q1.w * q2.y + q1.x * q2.z - q1.y * q2.w - q1.z * q2.x) * r,
+             (q1.w * q2.z - q1.x * q2.y + q1.y * q2.x - q1.z * q2.w) * r };
 }
 
 #ifdef _WIN32

--- a/alvr/server_openvr/cpp/alvr_server/Utils.h
+++ b/alvr/server_openvr/cpp/alvr_server/Utils.h
@@ -163,6 +163,15 @@ Slerp(vr::HmdQuaternionf_t& q1, vr::HmdQuaternionf_t& q2, double lambda) {
     }
 }
 
+inline vr::HmdVector3d_t AngularVelocityBetweenQuats(const vr::HmdQuaternion_t& q1, const vr::HmdQuaternion_t& q2, double dt) {
+    double r = (2.0f / dt);
+    return {
+        (q1.w*q2.x - q1.x*q2.w - q1.y*q2.z + q1.z*q2.y) * r,
+        (q1.w*q2.y + q1.x*q2.z - q1.y*q2.w - q1.z*q2.x) * r,
+        (q1.w*q2.z - q1.x*q2.y + q1.y*q2.x - q1.z*q2.w) * r
+    };
+}
+
 #ifdef _WIN32
 typedef void(WINAPI* RtlGetVersion_FUNC)(OSVERSIONINFOEXW*);
 

--- a/alvr/server_openvr/cpp/alvr_server/Utils.h
+++ b/alvr/server_openvr/cpp/alvr_server/Utils.h
@@ -164,6 +164,7 @@ Slerp(vr::HmdQuaternionf_t& q1, vr::HmdQuaternionf_t& q2, double lambda) {
     }
 }
 
+// Sourced from https://mariogc.com/post/angular-velocity-quaternions/
 inline vr::HmdVector3d_t AngularVelocityBetweenQuats(
     const vr::HmdQuaternion_t& q1, const vr::HmdQuaternion_t& q2, double dt
 ) {

--- a/alvr/server_openvr/cpp/alvr_server/Utils.h
+++ b/alvr/server_openvr/cpp/alvr_server/Utils.h
@@ -27,6 +27,7 @@
 #include "openvr_driver.h"
 
 const float DEG_TO_RAD = (float)(M_PI / 180.);
+const double NS_PER_S = 1000000000.0;
 
 // Get elapsed time in us from Unix Epoch
 inline uint64_t GetTimestampUs() {

--- a/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
@@ -417,21 +417,27 @@ void SetTracking(
     }
 
     if (g_driver_provider.left_hand_tracker) {
-        g_driver_provider.left_hand_tracker->onPoseUpdate(controllerPoseTimeOffsetS, leftHandData);
+        g_driver_provider.left_hand_tracker->onPoseUpdate(
+            targetTimestampNs, controllerPoseTimeOffsetS, leftHandData
+        );
     }
 
     if (g_driver_provider.left_controller) {
-        g_driver_provider.left_controller->onPoseUpdate(controllerPoseTimeOffsetS, leftHandData);
+        g_driver_provider.left_controller->onPoseUpdate(
+            targetTimestampNs, controllerPoseTimeOffsetS, leftHandData
+        );
     }
 
     if (g_driver_provider.right_hand_tracker) {
         g_driver_provider.right_hand_tracker->onPoseUpdate(
-            controllerPoseTimeOffsetS, rightHandData
+            targetTimestampNs, controllerPoseTimeOffsetS, rightHandData
         );
     }
 
     if (g_driver_provider.right_controller) {
-        g_driver_provider.right_controller->onPoseUpdate(controllerPoseTimeOffsetS, rightHandData);
+        g_driver_provider.right_controller->onPoseUpdate(
+            targetTimestampNs, controllerPoseTimeOffsetS, rightHandData
+        );
     }
 
     if (Settings::Instance().m_enableBodyTrackingFakeVive) {


### PR DESCRIPTION
Calculates the hand skeleton velocity based on the controller's last sent `m_pose`; Adds an additional `targetTimestampNs` argument to the controller's `onPoseUpdate`, as well as an additional stored timestamp `m_poseTargetTimestampNs` for that pose to allow calculating the velocity of the controller. This calculation is only performed if `controllerMotion` is missing but the skeleton is present.

Fixes the waving exercise in Aperture Hand Lab, and probably throwing and other interactions in other titles.