### PR TITLE
refactor(client): :recycle: Move decoder out of ClientCoreContext; fix IDR race condition

### DIFF
--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -919,7 +919,6 @@ pub extern "C" fn alvr_create_decoder(config: AlvrDecoderConfig) {
             }
         });
 
-    // *DECODER_SINK.lock() = Some(sink);
     *DECODER_SOURCE.lock() = Some(source);
 
     if let Some(context) = &*CLIENT_CORE_CONTEXT.lock() {

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::if_same_then_else)]
 
 use crate::{
-    decoder::{self, DecoderConfig, DecoderSink, DecoderSource},
     logging_backend::{LogMirrorData, LOG_CHANNEL_SENDER},
     platform,
     sockets::AnnouncerSocket,
@@ -64,8 +63,7 @@ pub struct ConnectionContext {
     pub tracking_sender: Mutex<Option<StreamSender<Tracking>>>,
     pub statistics_sender: Mutex<Option<StreamSender<ClientStatistics>>>,
     pub statistics_manager: Mutex<Option<StatisticsManager>>,
-    pub decoder_sink: Mutex<Option<DecoderSink>>,
-    pub decoder_source: Mutex<Option<DecoderSource>>,
+pub decoder_callback: Mutex<Option<Box<dyn FnMut(Duration, &[u8]) -> bool + Send>>>,
     pub head_pose_queue: RwLock<VecDeque<(Duration, Pose)>>,
     pub last_good_head_pose: RwLock<Pose>,
     pub view_params: RwLock<[ViewParams; 2]>,
@@ -274,7 +272,6 @@ fn connection_pipeline(
 
     let video_receive_thread = thread::spawn({
         let ctx = Arc::clone(&ctx);
-        let event_queue = Arc::clone(&event_queue);
         move || {
             let mut stream_corrupted = false;
             while is_streaming(&ctx) {
@@ -302,37 +299,14 @@ fn connection_pipeline(
                 }
 
                 if !stream_corrupted || !settings.connection.avoid_video_glitching {
-                    if capabilities.external_decoder {
-                        let mut head_pose = *ctx.last_good_head_pose.read();
-                        for (timestamp, pose) in &*ctx.head_pose_queue.read() {
-                            if *timestamp == header.timestamp {
-                                head_pose = *pose;
-                                break;
-                            }
-                        }
-
-                        let view_params = &ctx.view_params.read();
-                        event_queue.lock().push_back(ClientCoreEvent::FrameReady {
-                            timestamp: header.timestamp,
-                            view_params: [
-                                ViewParams {
-                                    pose: head_pose * view_params[0].pose,
-                                    fov: view_params[0].fov,
-                                },
-                                ViewParams {
-                                    pose: head_pose * view_params[1].pose,
-                                    fov: view_params[1].fov,
-                                },
-                            ],
-                            nal: nal.to_vec(),
-                        });
-                    } else if !ctx
-                        .decoder_sink
+                    let submitted = ctx
+                        .decoder_callback
                         .lock()
                         .as_mut()
-                        .map(|sink| sink.push_nal(header.timestamp, nal))
-                        .unwrap_or(false)
-                    {
+                        .map(|callback| callback(header.timestamp, nal))
+                        .unwrap_or(false);
+
+                    if !submitted {
                         stream_corrupted = true;
                         if let Some(sender) = &mut *ctx.control_sender.lock() {
                             sender.send(&ClientControlPacket::RequestIdr).ok();
@@ -490,39 +464,12 @@ fn connection_pipeline(
 
                 match maybe_packet {
                     Ok(ServerControlPacket::DecoderConfig(config)) => {
-                        if capabilities.external_decoder {
-                            event_queue
-                                .lock()
-                                .push_back(ClientCoreEvent::DecoderConfig {
-                                    codec: config.codec,
-                                    config_nal: config.config_buffer,
-                                });
-                        } else if ctx.decoder_sink.lock().is_none() {
-                            let config = DecoderConfig {
+                        event_queue
+                            .lock()
+                            .push_back(ClientCoreEvent::DecoderConfig {
                                 codec: config.codec,
-                                force_software_decoder: settings.video.force_software_decoder,
-                                max_buffering_frames: settings.video.max_buffering_frames,
-                                buffering_history_weight: settings.video.buffering_history_weight,
-                                options: settings.video.mediacodec_extra_options.clone(),
-                                config_buffer: config.config_buffer,
-                            };
-
-                            let (sink, source) = decoder::create_decoder(config, {
-                                let ctx = Arc::clone(&ctx);
-                                move |target_timestamp| {
-                                    if let Some(stats) = &mut *ctx.statistics_manager.lock() {
-                                        stats.report_frame_decoded(target_timestamp);
-                                    }
-                                }
+                                config_nal: config.config_buffer,
                             });
-
-                            *ctx.decoder_sink.lock() = Some(sink);
-                            *ctx.decoder_source.lock() = Some(source);
-
-                            if let Some(sender) = &mut *ctx.control_sender.lock() {
-                                sender.send(&ClientControlPacket::RequestIdr).ok();
-                            }
-                        }
                     }
                     Ok(ServerControlPacket::Restarting) => {
                         info!("{SERVER_RESTART_MESSAGE}");
@@ -599,9 +546,6 @@ fn connection_pipeline(
     event_queue
         .lock()
         .push_back(ClientCoreEvent::StreamingStopped);
-
-    *ctx.decoder_sink.lock() = None;
-    *ctx.decoder_source.lock() = None;
 
     // Remove lock to allow threads to properly exit:
     drop(connection_state_lock);

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -63,7 +63,7 @@ pub struct ConnectionContext {
     pub tracking_sender: Mutex<Option<StreamSender<Tracking>>>,
     pub statistics_sender: Mutex<Option<StreamSender<ClientStatistics>>>,
     pub statistics_manager: Mutex<Option<StatisticsManager>>,
-pub decoder_callback: Mutex<Option<Box<dyn FnMut(Duration, &[u8]) -> bool + Send>>>,
+    pub decoder_callback: Mutex<Option<Box<dyn FnMut(Duration, &[u8]) -> bool + Send>>>,
     pub head_pose_queue: RwLock<VecDeque<(Duration, Pose)>>,
     pub last_good_head_pose: RwLock<Pose>,
     pub view_params: RwLock<[ViewParams; 2]>,

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -273,7 +273,7 @@ fn connection_pipeline(
     let video_receive_thread = thread::spawn({
         let ctx = Arc::clone(&ctx);
         move || {
-            let mut stream_corrupted = false;
+            let mut stream_corrupted = true;
             while is_streaming(&ctx) {
                 let data = match video_receiver.recv(STREAMING_RECV_TIMEOUT) {
                     Ok(data) => data,

--- a/alvr/client_core/src/decoder.rs
+++ b/alvr/client_core/src/decoder.rs
@@ -37,13 +37,13 @@ pub struct DecoderSource {
 
 impl DecoderSource {
     /// If a frame is available, return the timestamp and the AHardwareBuffer.
-    pub fn get_frame(&mut self) -> Result<Option<(Duration, *mut std::ffi::c_void)>> {
+    pub fn get_frame(&mut self) -> Option<(Duration, *mut std::ffi::c_void)> {
         #[cfg(target_os = "android")]
         {
             self.inner.dequeue_frame()
         }
         #[cfg(not(target_os = "android"))]
-        alvr_common::anyhow::bail!("Not implemented");
+        None
     }
 }
 
@@ -51,7 +51,7 @@ impl DecoderSource {
 #[allow(unused_variables)]
 pub fn create_decoder(
     config: DecoderConfig,
-    report_frame_decoded: impl Fn(Duration) + Send + 'static,
+    report_frame_decoded: impl Fn(Result<Duration>) + Send + Sync + 'static,
 ) -> (DecoderSink, DecoderSource) {
     #[cfg(target_os = "android")]
     {

--- a/alvr/client_core/src/decoder.rs
+++ b/alvr/client_core/src/decoder.rs
@@ -2,7 +2,7 @@ use alvr_common::anyhow::Result;
 use alvr_session::{CodecType, MediacodecDataType};
 use std::time::Duration;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq)]
 pub struct DecoderConfig {
     pub codec: CodecType,
     pub force_software_decoder: bool,

--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -325,6 +325,10 @@ impl ClientCoreContext {
         dbg_client_core!("set_decoder_input_callback");
 
         *self.connection_context.decoder_callback.lock() = Some(callback);
+
+        if let Some(sender) = &mut *self.connection_context.control_sender.lock() {
+            sender.send(&ClientControlPacket::RequestIdr).ok();
+        }
     }
 
     pub fn report_frame_decoded(&self, timestamp: Duration) {

--- a/alvr/client_core/src/platform/android/decoder.rs
+++ b/alvr/client_core/src/platform/android/decoder.rs
@@ -20,7 +20,7 @@ use std::{
     ffi::c_void,
     ops::Deref,
     ptr,
-    sync::Arc,
+    sync::{Arc, Weak},
     thread::{self, JoinHandle},
     time::Duration,
 };
@@ -88,7 +88,6 @@ unsafe impl Send for QueuedImage {}
 // Access the image queue synchronously.
 pub struct VideoDecoderSource {
     running: Arc<RelaxedAtomic>,
-    error: Arc<Mutex<Option<alvr_common::anyhow::Error>>>,
     dequeue_thread: Option<JoinHandle<()>>,
     image_queue: Arc<Mutex<VecDeque<QueuedImage>>>,
     config: DecoderConfig,
@@ -99,11 +98,7 @@ unsafe impl Send for VideoDecoderSource {}
 
 impl VideoDecoderSource {
     // The application MUST finish using the returned buffer before calling this function again
-    pub fn dequeue_frame(&mut self) -> Result<Option<(Duration, *mut c_void)>> {
-        if let Some(error) = self.error.lock().take() {
-            return Err(anyhow!(error));
-        }
-
+    pub fn dequeue_frame(&mut self) -> Option<(Duration, *mut c_void)> {
         let mut image_queue_lock = self.image_queue.lock();
 
         if let Some(queued_image) = image_queue_lock.front() {
@@ -124,7 +119,7 @@ impl VideoDecoderSource {
         if let Some(queued_image) = image_queue_lock.front_mut() {
             queued_image.in_use = true;
 
-            Ok(Some((
+            Some((
                 queued_image.timestamp,
                 queued_image
                     .image
@@ -132,11 +127,11 @@ impl VideoDecoderSource {
                     .unwrap()
                     .as_ptr()
                     .cast(),
-            )))
+            ))
         } else {
             // TODO: add back when implementing proper phase sync
             //warn!("Video frame queue underflow!");
-            Ok(None)
+            None
         }
     }
 }
@@ -193,10 +188,12 @@ fn decoder_attempt_setup(
     Ok(decoder)
 }
 
+// Since we leak the ImageReader, and we pass frame_result_callback to it which contains a reference
+// to ClientCoreContext, to avoid circular references we need to use a Weak reference.
 fn decoder_lifecycle(
     config: DecoderConfig,
     csd_0: Vec<u8>,
-    dequeued_frame_callback: impl Fn(Duration) + Send + 'static,
+    frame_result_callback: Weak<impl Fn(Result<Duration>) + Send + Sync + 'static>,
     running: Arc<RelaxedAtomic>,
     decoder_sink: Arc<Mutex<Option<SharedMediaCodec>>>,
     decoder_ready_notifier: Arc<Condvar>,
@@ -220,7 +217,9 @@ fn decoder_lifecycle(
                 Ok(AcquireResult::Image(image)) => {
                     let timestamp = Duration::from_nanos(image.timestamp().unwrap() as u64);
 
-                    dequeued_frame_callback(timestamp);
+                    if let Some(callback) = frame_result_callback.upgrade() {
+                        callback(Ok(timestamp));
+                    }
 
                     image_queue_lock.push_back(QueuedImage {
                         timestamp,
@@ -337,10 +336,9 @@ fn decoder_lifecycle(
 pub fn video_decoder_split(
     config: DecoderConfig,
     csd_0: Vec<u8>,
-    dequeued_frame_callback: impl Fn(Duration) + Send + 'static,
+    frame_result_callback: impl Fn(Result<Duration>) + Send + Sync + 'static,
 ) -> Result<(VideoDecoderSink, VideoDecoderSource)> {
     let running = Arc::new(RelaxedAtomic::new(true));
-    let error = Arc::new(Mutex::new(None));
     let decoder_sink = Arc::new(Mutex::new(None::<SharedMediaCodec>));
     let decoder_ready_notifier = Arc::new(Condvar::new());
     let image_queue = Arc::new(Mutex::new(VecDeque::<QueuedImage>::new()));
@@ -348,7 +346,6 @@ pub fn video_decoder_split(
     let dequeue_thread = thread::spawn({
         let config = config.clone();
         let running = Arc::clone(&running);
-        let error = Arc::clone(&error);
         let decoder_sink = Arc::clone(&decoder_sink);
         let decoder_ready_notifier = Arc::clone(&decoder_ready_notifier);
         let image_queue = Arc::clone(&image_queue);
@@ -363,22 +360,24 @@ pub fn video_decoder_split(
             ) {
                 Ok(reader) => reader,
                 Err(e) => {
-                    *error.lock() = Some(anyhow!("{e}"));
+                    frame_result_callback(Err(anyhow!("{e}")));
                     return;
                 }
             };
 
+            let frame_result_callback = Arc::new(frame_result_callback);
+
             if let Err(e) = decoder_lifecycle(
                 config,
                 csd_0,
-                dequeued_frame_callback,
+                Arc::downgrade(&frame_result_callback),
                 running,
                 decoder_sink,
                 decoder_ready_notifier,
                 Arc::clone(&image_queue),
                 &mut image_reader,
             ) {
-                *error.lock() = Some(e);
+                frame_result_callback(Err(e));
             }
 
             image_queue.lock().clear();
@@ -403,7 +402,6 @@ pub fn video_decoder_split(
     };
     let source = VideoDecoderSource {
         running,
-        error,
         dequeue_thread: Some(dequeue_thread),
         image_queue,
         config,

--- a/alvr/client_core/src/platform/android/decoder.rs
+++ b/alvr/client_core/src/platform/android/decoder.rs
@@ -304,7 +304,7 @@ fn decoder_lifecycle(
                     error!("Decoder dequeue error: {e}");
                 }
             }
-            Ok(DequeuedOutputBufferInfoResult::TryAgainLater) => thread::yield_now(),
+            Ok(DequeuedOutputBufferInfoResult::TryAgainLater) => continue,
             Ok(i) => info!("Decoder dequeue event: {i:?}"),
             Err(e) => {
                 error!("Decoder dequeue error: {e}");

--- a/alvr/client_mock/src/main.rs
+++ b/alvr/client_mock/src/main.rs
@@ -205,7 +205,6 @@ fn client_thread(
 ) {
     let capabilities = ClientCapabilities {
         default_view_resolution: UVec2::new(1920, 1832),
-        external_decoder: true,
         refresh_rates: vec![60.0, 72.0, 80.0, 90.0, 120.0],
         foveated_encoding: false,
         encoder_high_profile: false,
@@ -269,16 +268,6 @@ fn client_thread(
                     got_decoder_config.set(true);
 
                     window_output.decoder_codec = Some(codec);
-                }
-                ClientCoreEvent::FrameReady { timestamp, .. } => {
-                    if streaming.value() && !got_decoder_config.value() {
-                        client_core_context.request_idr();
-                    }
-
-                    window_output.current_frame_timestamp = timestamp;
-
-                    thread::sleep(Duration::from_millis(input_lock.emulated_decode_ms));
-                    client_core_context.report_frame_decoded(timestamp);
                 }
             }
 

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -393,7 +393,7 @@ pub fn entry_point() {
                     }
                     ClientCoreEvent::DecoderConfig { codec, config_nal } => {
                         if let Some(stream) = &mut stream_context {
-                            stream.initialize_decoder(codec, config_nal);
+                            stream.maybe_initialize_decoder(codec, config_nal);
                         }
                     }
                 }

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -20,16 +20,8 @@ use extra_extensions::{
 };
 use lobby::Lobby;
 use openxr as xr;
-use std::{
-    path::Path,
-    rc::Rc,
-    sync::Arc,
-    thread,
-    time::{Duration, Instant},
-};
+use std::{path::Path, rc::Rc, sync::Arc, thread, time::Duration};
 use stream::StreamContext;
-
-const DECODER_MAX_TIMEOUT_MULTIPLIER: f32 = 0.8;
 
 fn from_xr_vec3(v: xr::Vector3f) -> Vec3 {
     Vec3::new(v.x, v.y, v.z)
@@ -247,7 +239,6 @@ pub fn entry_point() {
 
         let capabilities = ClientCapabilities {
             default_view_resolution,
-            external_decoder: false,
             refresh_rates,
             foveated_encoding: platform != Platform::Unknown,
             encoder_high_profile: platform != Platform::Unknown,
@@ -318,8 +309,8 @@ pub fn entry_point() {
 
                         lobby.update_reference_space();
 
-                        if let Some(context) = &mut stream_context {
-                            context.update_reference_space();
+                        if let Some(stream) = &mut stream_context {
+                            stream.update_reference_space();
                         }
                     }
                     xr::Event::PerfSettingsEXT(event) => {
@@ -370,15 +361,13 @@ pub fn entry_point() {
                                 Rc::clone(&graphics_context),
                                 Arc::clone(&interaction_context),
                                 platform,
-                                &new_config,
+                                new_config.clone(),
                             ));
 
                             parsed_stream_config = Some(new_config);
                         }
                     }
-                    ClientCoreEvent::StreamingStopped => {
-                        stream_context = None;
-                    }
+                    ClientCoreEvent::StreamingStopped => stream_context = None,
                     ClientCoreEvent::Haptics {
                         device_id,
                         duration,
@@ -402,8 +391,10 @@ pub fn entry_point() {
                             )
                             .unwrap();
                     }
-                    ClientCoreEvent::DecoderConfig { .. } | ClientCoreEvent::FrameReady { .. } => {
-                        panic!()
+                    ClientCoreEvent::DecoderConfig { codec, config_nal } => {
+                        if let Some(stream) = &mut stream_context {
+                            stream.initialize_decoder(codec, config_nal);
+                        }
                     }
                 }
             }
@@ -435,29 +426,10 @@ pub fn entry_point() {
             }
 
             // todo: allow rendering lobby and stream layers at the same time and add cross fade
-            let (layer, display_time) = if let Some(context) = &mut stream_context {
-                let frame_poll_deadline = Instant::now()
-                    + Duration::from_secs_f32(
-                        frame_interval.as_secs_f32() * DECODER_MAX_TIMEOUT_MULTIPLIER,
-                    );
-                let mut frame_result = None;
-                while frame_result.is_none() && Instant::now() < frame_poll_deadline {
-                    frame_result = core_context.get_frame();
-                    thread::yield_now();
-                }
-
-                let timestamp = frame_result
-                    .as_ref()
-                    .map(|r| r.timestamp)
-                    .unwrap_or(vsync_time);
-
-                let layer = context.render(frame_result, vsync_time);
-
-                (layer, timestamp)
+            let (layer, display_time) = if let Some(stream) = &mut stream_context {
+                stream.render(frame_interval, vsync_time)
             } else {
-                let layer = lobby.render(frame_state.predicted_display_time);
-
-                (layer, vsync_time)
+                (lobby.render(frame_state.predicted_display_time), vsync_time)
             };
 
             graphics_context.make_current();

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -4,21 +4,24 @@ use crate::{
     XrContext,
 };
 use alvr_client_core::{
+    decoder::{self, DecoderConfig, DecoderSource},
     graphics::{GraphicsContext, StreamRenderer},
-    ClientCoreContext, DecodedFrame, Platform,
+    ClientCoreContext, Platform,
 };
 use alvr_common::{
+    anyhow::Result,
     error,
     glam::{UVec2, Vec2},
     Pose, RelaxedAtomic, HAND_LEFT_ID, HAND_RIGHT_ID, HEAD_ID,
 };
 use alvr_packets::{FaceData, StreamConfig, ViewParams};
 use alvr_session::{
-    BodyTrackingSourcesConfig, ClientsideFoveationConfig, ClientsideFoveationMode, EncoderConfig,
-    FaceTrackingSourcesConfig, FoveatedEncodingConfig,
+    BodyTrackingSourcesConfig, ClientsideFoveationConfig, ClientsideFoveationMode, CodecType,
+    EncoderConfig, FaceTrackingSourcesConfig, FoveatedEncodingConfig, MediacodecDataType,
 };
 use openxr as xr;
 use std::{
+    ptr,
     rc::Rc,
     sync::Arc,
     thread::{self, JoinHandle},
@@ -27,8 +30,9 @@ use std::{
 
 // When the latency goes too high, if prediction offset is not capped tracking poll will fail.
 const MAX_PREDICTION: Duration = Duration::from_millis(70);
+const DECODER_MAX_TIMEOUT_MULTIPLIER: f32 = 0.8;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct ParsedStreamConfig {
     pub view_resolution: UVec2,
     pub refresh_rate_hint: f32,
@@ -38,6 +42,10 @@ pub struct ParsedStreamConfig {
     pub face_sources_config: Option<FaceTrackingSourcesConfig>,
     pub body_sources_config: Option<BodyTrackingSourcesConfig>,
     pub prefers_multimodal_input: bool,
+    pub force_software_decoder: bool,
+    pub max_buffering_frames: f32,
+    pub buffering_history_weight: f32,
+    pub decoder_options: Vec<(String, MediacodecDataType)>,
 }
 
 impl ParsedStreamConfig {
@@ -76,6 +84,10 @@ impl ParsedStreamConfig {
                 .as_option()
                 .map(|c| c.multimodal_tracking)
                 .unwrap_or(false),
+            force_software_decoder: config.settings.video.force_software_decoder,
+            max_buffering_frames: config.settings.video.max_buffering_frames,
+            buffering_history_weight: config.settings.video.buffering_history_weight,
+            decoder_options: config.settings.video.mediacodec_extra_options.clone(),
         }
     }
 }
@@ -86,12 +98,12 @@ pub struct StreamContext {
     interaction_context: Arc<InteractionContext>,
     reference_space: Arc<xr::Space>,
     swapchains: [xr::Swapchain<xr::OpenGlEs>; 2],
-    view_resolution: UVec2,
-    refresh_rate: f32,
     last_good_view_params: [ViewParams; 2],
     input_thread: Option<JoinHandle<()>>,
     input_thread_running: Arc<RelaxedAtomic>,
+    config: ParsedStreamConfig,
     renderer: StreamRenderer,
+    decoder_source: Option<DecoderSource>,
 }
 
 impl StreamContext {
@@ -101,7 +113,7 @@ impl StreamContext {
         gfx_ctx: Rc<GraphicsContext>,
         interaction_ctx: Arc<InteractionContext>,
         platform: Platform,
-        config: &ParsedStreamConfig,
+        config: ParsedStreamConfig,
     ) -> StreamContext {
         if xr_ctx.instance.exts().fb_display_refresh_rate.is_some() {
             xr_ctx
@@ -237,12 +249,12 @@ impl StreamContext {
             interaction_context: interaction_ctx,
             reference_space,
             swapchains,
-            view_resolution: config.view_resolution,
-            refresh_rate: config.refresh_rate_hint,
             last_good_view_params: [ViewParams::default(); 2],
             input_thread: Some(input_thread),
             input_thread_running,
+            config,
             renderer,
+            decoder_source: None,
         }
     }
 
@@ -273,7 +285,7 @@ impl StreamContext {
             let xr_ctx = self.xr_context.clone();
             let interaction_ctx = Arc::clone(&self.interaction_context);
             let reference_space = Arc::clone(&self.reference_space);
-            let refresh_rate = self.refresh_rate;
+            let refresh_rate = self.config.refresh_rate_hint;
             let running = Arc::clone(&self.input_thread_running);
             move || {
                 stream_input_loop(
@@ -288,25 +300,56 @@ impl StreamContext {
         }));
     }
 
+    pub fn initialize_decoder(&mut self, codec: CodecType, config_nal: Vec<u8>) {
+        let config = DecoderConfig {
+            codec,
+            force_software_decoder: self.config.force_software_decoder,
+            max_buffering_frames: self.config.max_buffering_frames,
+            buffering_history_weight: self.config.buffering_history_weight,
+            options: self.config.decoder_options.clone(),
+            config_buffer: config_nal,
+        };
+
+        let (mut sink, source) = decoder::create_decoder(config, {
+            let ctx = Arc::clone(&self.core_context);
+            move |maybe_timestamp: Result<Duration>| match maybe_timestamp {
+                Ok(timestamp) => ctx.report_frame_decoded(timestamp),
+                Err(e) => ctx.report_fatal_decoder_error(&e.to_string()),
+            }
+        });
+        self.decoder_source = Some(source);
+
+        self.core_context
+            .set_decoder_input_callback(Box::new(move |timestamp, buffer| -> bool {
+                sink.push_nal(timestamp, buffer)
+            }));
+    }
+
     pub fn render(
         &mut self,
-        decoded_frame: Option<DecodedFrame>,
+        frame_interval: Duration,
         vsync_time: Duration,
-    ) -> CompositionLayerBuilder {
-        let timestamp;
-        let view_params;
-        let buffer_ptr;
-        if let Some(frame) = decoded_frame {
-            timestamp = frame.timestamp;
-            view_params = frame.view_params;
-            buffer_ptr = frame.buffer_ptr;
-
-            self.last_good_view_params = frame.view_params;
-        } else {
-            timestamp = vsync_time;
-            view_params = self.last_good_view_params;
-            buffer_ptr = std::ptr::null_mut();
+    ) -> (CompositionLayerBuilder, Duration) {
+        let frame_poll_deadline = Instant::now()
+            + Duration::from_secs_f32(
+                frame_interval.as_secs_f32() * DECODER_MAX_TIMEOUT_MULTIPLIER,
+            );
+        let mut frame_result = None;
+        if let Some(source) = self.decoder_source.as_mut() {
+            while frame_result.is_none() && Instant::now() < frame_poll_deadline {
+                frame_result = source.get_frame();
+                thread::yield_now();
+            }
         }
+
+        let (timestamp, view_params, buffer_ptr) =
+            if let Some((timestamp, buffer_ptr)) = frame_result {
+                let view_params = self.core_context.report_compositor_start(timestamp);
+
+                (timestamp, view_params, buffer_ptr)
+            } else {
+                (vsync_time, self.last_good_view_params, ptr::null_mut())
+            };
 
         let left_swapchain_idx = self.swapchains[0].acquire_image().unwrap();
         let right_swapchain_idx = self.swapchains[1].acquire_image().unwrap();
@@ -336,12 +379,12 @@ impl StreamContext {
         let rect = xr::Rect2Di {
             offset: xr::Offset2Di { x: 0, y: 0 },
             extent: xr::Extent2Di {
-                width: self.view_resolution.x as _,
-                height: self.view_resolution.y as _,
+                width: self.config.view_resolution.x as _,
+                height: self.config.view_resolution.y as _,
             },
         };
 
-        CompositionLayerBuilder::new(
+        let layer = CompositionLayerBuilder::new(
             &self.reference_space,
             [
                 xr::CompositionLayerProjectionView::new()
@@ -363,7 +406,9 @@ impl StreamContext {
                             .image_rect(rect),
                     ),
             ],
-        )
+        );
+
+        (layer, timestamp)
     }
 }
 

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -338,7 +338,7 @@ impl StreamContext {
         if let Some(source) = self.decoder_source.as_mut() {
             while frame_result.is_none() && Instant::now() < frame_poll_deadline {
                 frame_result = source.get_frame();
-                thread::yield_now();
+                thread::sleep(Duration::from_micros(500));
             }
         }
 

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -276,7 +276,7 @@ CABAC produces better compression but it's significantly slower and may lead to 
     pub software: SoftwareEncodingConfig,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum MediacodecDataType {
     Float(f32),
     Int32(i32),


### PR DESCRIPTION
This PR creates a new API for using the decoder. Removed the distinction between internal and external decoder, there is only an "external" implementation. The C API had been tweaked to reflect the internal changes. A significant improvement of this refactor is zero-copy decoder integration for visionOS.

This PR also fixed one bug where the video stream might start in a corrupted state because of a race condition.