### PR TITLE
Support Meta Quest 3 native resolution

### DIFF
--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -53,6 +53,9 @@ pub struct VideoPacket {
     pub payload: Vec<u8>,
 }
 
+fn align16(value: f32) -> u32 {
+    ((value / 16.).floor() * 16.) as u32
+}
 fn align32(value: f32) -> u32 {
     ((value / 32.).floor() * 32.) as u32
 }
@@ -499,7 +502,7 @@ fn connection_pipeline(
             }
         };
 
-        UVec2::new(align32(res.x), align32(res.y))
+        UVec2::new(align16(res.x), align16(res.y))
     }
 
     let stream_view_resolution = get_view_res(

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -502,7 +502,7 @@ fn connection_pipeline(
             }
         };
 
-        UVec2::new(align16(res.x), align16(res.y))
+        UVec2::new(align16(res.x), align32(res.y))
     }
 
     let stream_view_resolution = get_view_res(

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -19,7 +19,7 @@ pub enum FrameSize {
     Absolute {
         #[schema(gui(slider(min = 32, max = 8192, step = 16)))]
         width: u32,
-        #[schema(gui(slider(min = 32, max = 8192, step = 16)))]
+        #[schema(gui(slider(min = 32, max = 8192, step = 32)))]
         height: Option<u32>,
     },
 }

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -17,9 +17,9 @@ pub enum FrameSize {
     Scale(#[schema(gui(slider(min = 0.25, max = 2.0, step = 0.01)))] f32),
 
     Absolute {
-        #[schema(gui(slider(min = 32, max = 8192, step = 32)))]
+        #[schema(gui(slider(min = 32, max = 8192, step = 16)))]
         width: u32,
-        #[schema(gui(slider(min = 32, max = 8192, step = 32)))]
+        #[schema(gui(slider(min = 32, max = 8192, step = 16)))]
         height: Option<u32>,
     },
 }


### PR DESCRIPTION
Meta Quest 3 has LCD panels with per eye resolution of 2064 x 2208. Setting this resolution is currently impossible as it gets rounded down to 2048 x 2208. This pull request relaxes resolution alignment from 32 to 16 pixels.