### PR TITLE
fix(client_openxr): :bug: Fix crash on Focus 3 with 0 timestamp

### DIFF
--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -443,13 +443,15 @@ pub fn entry_point() {
                 let time = to_xr_time(display_time);
                 error!("End frame failed! {e}, timestamp: {display_time:?}, time: {time:?}");
 
-                xr_frame_stream
-                    .end(
-                        frame_state.predicted_display_time,
-                        xr::EnvironmentBlendMode::OPAQUE,
-                        &[],
-                    )
-                    .unwrap();
+                if !platform.is_vive() {
+                    xr_frame_stream
+                        .end(
+                            frame_state.predicted_display_time,
+                            xr::EnvironmentBlendMode::OPAQUE,
+                            &[],
+                        )
+                        .unwrap();
+                }
             }
         }
     }

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -353,6 +353,10 @@ impl StreamContext {
             if let Some((timestamp, buffer_ptr)) = frame_result {
                 let view_params = self.core_context.report_compositor_start(timestamp);
 
+                // Avoid passing invalid timestamp to runtime
+                let timestamp =
+                    Duration::max(timestamp, vsync_time.saturating_sub(Duration::from_secs(1)));
+
                 (timestamp, view_params, buffer_ptr)
             } else {
                 (vsync_time, self.last_good_view_params, ptr::null_mut())


### PR DESCRIPTION
This PR implement two fixes which independently fix a crash when the stream timestamp is 0. The `xr_frame_stream.end()` retry fallback apparently does not work on the Focus 3, or somehow some internal variables are already changed and we don't need another successful call. 