### PR TITLE
feat: integrate adb port forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,8 +170,7 @@ version = "21.0.0-dev01"
 dependencies = [
  "anyhow",
  "const_format",
- "futures-util",
- "reqwest 0.12.8",
+ "ureq",
  "zip",
 ]
 
@@ -290,11 +289,9 @@ dependencies = [
  "cros-libva",
  "eframe",
  "env_logger",
- "futures",
  "ico",
  "nvml-wrapper",
  "rand",
- "reqwest 0.12.8",
  "serde",
  "serde_json",
  "settings-schema",
@@ -367,6 +364,7 @@ dependencies = [
 name = "alvr_server_core"
 version = "21.0.0-dev01"
 dependencies = [
+ "alvr_adb",
  "alvr_audio",
  "alvr_common",
  "alvr_events",
@@ -2915,22 +2913,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4696,7 +4678,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-tls 0.5.0",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
@@ -4710,7 +4692,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -4729,7 +4711,6 @@ checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
  "h2 0.4.5",
@@ -4738,13 +4719,11 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls",
- "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4756,9 +4735,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration 0.6.1",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -4967,9 +4944,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -5417,18 +5394,7 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -5436,16 +5402,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "alvr_packets",
  "alvr_server_io",
  "alvr_session",
+ "alvr_sockets",
  "bincode",
  "chrono",
  "cros-libva",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alvr_adb"
+version = "21.0.0-dev01"
+dependencies = [
+ "anyhow",
+ "const_format",
+ "futures-util",
+ "reqwest 0.12.8",
+ "zip",
+]
+
+[[package]]
 name = "alvr_audio"
 version = "21.0.0-dev01"
 dependencies = [
@@ -266,6 +277,7 @@ dependencies = [
 name = "alvr_dashboard"
 version = "21.0.0-dev01"
 dependencies = [
+ "alvr_adb",
  "alvr_common",
  "alvr_events",
  "alvr_filesystem",
@@ -278,9 +290,11 @@ dependencies = [
  "cros-libva",
  "eframe",
  "env_logger",
+ "futures",
  "ico",
  "nvml-wrapper",
  "rand",
+ "reqwest 0.12.8",
  "serde",
  "serde_json",
  "settings-schema",
@@ -331,7 +345,7 @@ dependencies = [
  "futures-util",
  "ico",
  "open",
- "reqwest 0.12.5",
+ "reqwest 0.12.8",
  "serde_json",
  "tar",
  "tokio",
@@ -1466,6 +1480,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2271,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2281,15 +2315,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2298,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -2332,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2343,21 +2377,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2878,6 +2912,22 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -4646,7 +4696,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -4660,7 +4710,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -4673,12 +4723,13 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
  "h2 0.4.5",
@@ -4687,11 +4738,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4703,7 +4756,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
+ "system-configuration 0.6.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -5361,8 +5416,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5370,6 +5436,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ version = "21.0.0-dev01"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
+ "alvr_server_io",
  "anyhow",
  "ureq",
  "zip",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,8 +168,8 @@ dependencies = [
 name = "alvr_adb"
 version = "21.0.0-dev01"
 dependencies = [
+ "alvr_filesystem",
  "anyhow",
- "const_format",
  "ureq",
  "zip",
 ]
@@ -1475,26 +1475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "const_format"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
 ]
 
 [[package]]
@@ -4700,7 +4680,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
@@ -4745,7 +4725,7 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg 0.52.0",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4948,7 +4928,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5371,6 +5351,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "sysinfo"
@@ -5393,7 +5376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "system-configuration-sys",
 ]
 
@@ -6556,6 +6539,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6606,6 +6600,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -6860,16 +6863,6 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
 name = "alvr_adb"
 version = "21.0.0-dev01"
 dependencies = [
+ "alvr_common",
  "alvr_filesystem",
  "anyhow",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["alvr-org"]
 license = "MIT"
 
 [workspace.dependencies]
+alvr_adb = { path = "alvr/adb" }
 alvr_audio = { path = "alvr/audio" }
 alvr_client_core = { path = "alvr/client_core" }
 alvr_common = { path = "alvr/common" }

--- a/alvr/adb/Cargo.toml
+++ b/alvr/adb/Cargo.toml
@@ -9,8 +9,5 @@ license.workspace = true
 [dependencies]
 anyhow = "1"
 const_format = "0.2"
-futures-util = "0.3"
-strum = "0.26"
-strum_macros = "0.26"
 ureq = "2.10"
 zip = "2"

--- a/alvr/adb/Cargo.toml
+++ b/alvr/adb/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+alvr_common.workspace = true
 alvr_filesystem.workspace = true
 
 anyhow = "1"

--- a/alvr/adb/Cargo.toml
+++ b/alvr/adb/Cargo.toml
@@ -10,9 +10,5 @@ license.workspace = true
 anyhow = "1"
 const_format = "0.2"
 futures-util = "0.3"
-reqwest = { version = "0.12", default-features = false, features = [
-    "rustls-tls",
-    "stream",
-    "http2",
-] }
+ureq = "2.10"
 zip = "2"

--- a/alvr/adb/Cargo.toml
+++ b/alvr/adb/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 alvr_common.workspace = true
 alvr_filesystem.workspace = true
+alvr_server_io.workspace = true
 
 anyhow = "1"
 ureq = "2.10"

--- a/alvr/adb/Cargo.toml
+++ b/alvr/adb/Cargo.toml
@@ -8,6 +8,5 @@ license.workspace = true
 
 [dependencies]
 anyhow = "1"
-const_format = "0.2"
 ureq = "2.10"
 zip = "2"

--- a/alvr/adb/Cargo.toml
+++ b/alvr/adb/Cargo.toml
@@ -7,6 +7,8 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+alvr_filesystem.workspace = true
+
 anyhow = "1"
 ureq = "2.10"
 zip = "2"

--- a/alvr/adb/Cargo.toml
+++ b/alvr/adb/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "alvr_adb"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = "1"
+const_format = "0.2"
+futures-util = "0.3"
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+    "stream",
+    "http2",
+] }
+zip = "2"

--- a/alvr/adb/Cargo.toml
+++ b/alvr/adb/Cargo.toml
@@ -10,5 +10,7 @@ license.workspace = true
 anyhow = "1"
 const_format = "0.2"
 futures-util = "0.3"
+strum = "0.26"
+strum_macros = "0.26"
 ureq = "2.10"
 zip = "2"

--- a/alvr/adb/src/connection_state.rs
+++ b/alvr/adb/src/connection_state.rs
@@ -1,0 +1,33 @@
+// https://cs.android.com/android/platform/superproject/main/+/7dbe542b9a93fb3cee6c528e16e2d02a26da7cc0:packages/modules/adb/adb.h;l=104-122
+#[derive(Debug)]
+pub enum ConnectionState {
+    Authorizing,
+    Bootloader,
+    Connecting,
+    Detached,
+    Device,
+    Host,
+    NoPermissions, // https://cs.android.com/android/platform/superproject/main/+/main:system/core/diagnose_usb/diagnose_usb.cpp;l=83-90
+    Offline,
+    Recovery,
+    Rescue,
+    Sideload,
+    Unauthorized,
+}
+
+pub fn parse(value: &str) -> Option<ConnectionState> {
+    match value {
+        "authorizing" => Some(ConnectionState::Authorizing),
+        "bootloader" => Some(ConnectionState::Bootloader),
+        "connecting" => Some(ConnectionState::Connecting),
+        "detached" => Some(ConnectionState::Detached),
+        "device" => Some(ConnectionState::Device),
+        "host" => Some(ConnectionState::Host),
+        "offline" => Some(ConnectionState::Offline),
+        "recovery" => Some(ConnectionState::Recovery),
+        "rescue" => Some(ConnectionState::Rescue),
+        "sideload" => Some(ConnectionState::Sideload),
+        "unauthorized" => Some(ConnectionState::Unauthorized),
+        _ => None,
+    }
+}

--- a/alvr/adb/src/device.rs
+++ b/alvr/adb/src/device.rs
@@ -33,19 +33,17 @@ pub fn parse(line: &str) -> Option<Device> {
     let connection_state = if remaining.starts_with("no permissions") {
         // Since the current user's name can be printed in the error message,
         // we are gambling that there's not a "]" in it.
-        if let Some((_, right)) = remaining.split_once("]") {
+        if let Some((_, right)) = remaining.split_once(']') {
             remaining = right;
             Some(ConnectionState::NoPermissions)
         } else {
             None
         }
+    } else if let Some((left, right)) = remaining.split_once(' ') {
+        remaining = right;
+        connection_state::parse(left)
     } else {
-        if let Some((left, right)) = remaining.split_once(" ") {
-            remaining = right;
-            connection_state::parse(left)
-        } else {
-            None
-        }
+        None
     };
 
     let mut slices = remaining.split_whitespace();
@@ -65,11 +63,7 @@ pub fn parse(line: &str) -> Option<Device> {
 }
 
 fn parse_pair(pair: &str) -> Option<String> {
-    let mut slice = pair.split(":");
+    let mut slice = pair.split(':');
     let _key = slice.next();
-    if let Some(value) = slice.next() {
-        Some(value.to_string())
-    } else {
-        None
-    }
+    slice.next().map(|value| value.to_string())
 }

--- a/alvr/adb/src/device.rs
+++ b/alvr/adb/src/device.rs
@@ -1,0 +1,75 @@
+use crate::{
+    connection_state::{self, ConnectionState},
+    transport_type::{self, TransportType},
+};
+
+// https://cs.android.com/android/platform/superproject/main/+/7dbe542b9a93fb3cee6c528e16e2d02a26da7cc0:packages/modules/adb/transport.cpp;l=1409
+// The serial number is printed with a "%-22s" format, meaning that it's a left-aligned space-padded string of 22 characters.
+const SERIAL_NUMBER_COLUMN_LENGTH: usize = 22;
+
+// https://cs.android.com/android/platform/superproject/main/+/7dbe542b9a93fb3cee6c528e16e2d02a26da7cc0:packages/modules/adb/transport.cpp;l=1398
+#[derive(Debug)]
+pub struct Device {
+    pub connection_state: Option<ConnectionState>,
+    pub device: Option<String>,
+    pub model: Option<String>,
+    pub product: Option<String>,
+    pub serial: Option<String>,
+    pub transport_type: Option<TransportType>,
+}
+
+pub fn parse(line: &str) -> Option<Device> {
+    if line.len() < SERIAL_NUMBER_COLUMN_LENGTH {
+        return None;
+    }
+    let (left, right) = line.split_at(SERIAL_NUMBER_COLUMN_LENGTH);
+    let serial = if left.contains("(no serial number)") {
+        None
+    } else {
+        Some(left.trim().to_owned())
+    };
+    let mut remaining = right.trim();
+
+    let connection_state = if remaining.starts_with("no permissions") {
+        // Since the current user's name can be printed in the error message,
+        // we are gambling that there's not a "]" in it.
+        if let Some((_, right)) = remaining.split_once("]") {
+            remaining = right;
+            Some(ConnectionState::NoPermissions)
+        } else {
+            None
+        }
+    } else {
+        if let Some((left, right)) = remaining.split_once(" ") {
+            remaining = right;
+            connection_state::parse(left)
+        } else {
+            None
+        }
+    };
+
+    let mut slices = remaining.split_whitespace();
+    let product = slices.next().and_then(parse_pair);
+    let model = slices.next().and_then(parse_pair);
+    let device = slices.next().and_then(parse_pair);
+    let transport_type = slices.next().and_then(transport_type::parse);
+
+    Some(Device {
+        connection_state,
+        device,
+        model,
+        product,
+        serial,
+        transport_type,
+    })
+}
+
+fn parse_pair(pair: &str) -> Option<String> {
+    let mut slice = pair.split(":");
+    let _key = slice.next();
+    if let Some(value) = slice.next() {
+        Some(value.to_string())
+    } else {
+        None
+    }
+}

--- a/alvr/adb/src/device.rs
+++ b/alvr/adb/src/device.rs
@@ -63,5 +63,6 @@ pub fn parse(line: &str) -> Option<Device> {
 fn parse_pair(pair: &str) -> Option<String> {
     let mut slice = pair.split(':');
     let _key = slice.next();
+
     slice.next().map(|value| value.to_string())
 }

--- a/alvr/adb/src/device.rs
+++ b/alvr/adb/src/device.rs
@@ -23,11 +23,9 @@ pub fn parse(line: &str) -> Option<Device> {
         return None;
     }
     let (left, right) = line.split_at(SERIAL_NUMBER_COLUMN_LENGTH);
-    let serial = if left.contains("(no serial number)") {
-        None
-    } else {
-        Some(left.trim().to_owned())
-    };
+    let serial = left
+        .contains("(no serial number)")
+        .then(|| left.trim().to_owned());
     let mut remaining = right.trim();
 
     let connection_state = if remaining.starts_with("no permissions") {

--- a/alvr/adb/src/forwarded_port.rs
+++ b/alvr/adb/src/forwarded_port.rs
@@ -10,6 +10,7 @@ pub fn parse(line: &str) -> Option<ForwardedPort> {
     let serial = slices.next();
     let local = parse_port(slices.next()?);
     let remote = parse_port(slices.next()?);
+
     if let (Some(serial), Some(local), Some(remote)) = (serial, local, remote) {
         Some(ForwardedPort {
             local,
@@ -25,5 +26,6 @@ fn parse_port(value: &str) -> Option<u16> {
     let mut slices = value.split(':');
     let _protocol = slices.next();
     let maybe_port = slices.next();
+
     maybe_port.and_then(|p| p.parse::<u16>().ok())
 }

--- a/alvr/adb/src/forwarded_port.rs
+++ b/alvr/adb/src/forwarded_port.rs
@@ -25,9 +25,5 @@ fn parse_port(value: &str) -> Option<u16> {
     let mut slices = value.split(':');
     let _protocol = slices.next();
     let maybe_port = slices.next();
-    if let Some(port) = maybe_port {
-        port.parse::<u16>().ok()
-    } else {
-        None
-    }
+    maybe_port.and_then(|p| p.parse::<u16>().ok())
 }

--- a/alvr/adb/src/forwarded_port.rs
+++ b/alvr/adb/src/forwarded_port.rs
@@ -1,0 +1,33 @@
+#[derive(Debug)]
+pub struct ForwardedPort {
+    pub local: u16,
+    pub remote: u16,
+    pub serial: String,
+}
+
+pub fn parse(line: &str) -> Option<ForwardedPort> {
+    let mut slices = line.split_whitespace();
+    let serial = slices.next();
+    let local = parse_port(slices.next()?);
+    let remote = parse_port(slices.next()?);
+    if let (Some(serial), Some(local), Some(remote)) = (serial, local, remote) {
+        Some(ForwardedPort {
+            local,
+            remote,
+            serial: serial.to_owned(),
+        })
+    } else {
+        None
+    }
+}
+
+fn parse_port(value: &str) -> Option<u16> {
+    let mut slices = value.split(":");
+    let _protocol = slices.next();
+    let maybe_port = slices.next();
+    if let Some(port) = maybe_port {
+        port.parse::<u16>().ok()
+    } else {
+        None
+    }
+}

--- a/alvr/adb/src/forwarded_port.rs
+++ b/alvr/adb/src/forwarded_port.rs
@@ -22,7 +22,7 @@ pub fn parse(line: &str) -> Option<ForwardedPort> {
 }
 
 fn parse_port(value: &str) -> Option<u16> {
-    let mut slices = value.split(":");
+    let mut slices = value.split(':');
     let _protocol = slices.next();
     let maybe_port = slices.next();
     if let Some(port) = maybe_port {

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -67,10 +67,7 @@ pub fn install_apk(adb_path: &str, device_serial: &str, apk_path: &str) -> anyho
 //////////
 // Devices
 
-pub fn list_devices<B>(adb_path: &str) -> anyhow::Result<B>
-where
-    B: FromIterator<Device>,
-{
+pub fn list_devices(adb_path: &str) -> anyhow::Result<Vec<Device>> {
     let output = Command::new(adb_path).args(["devices", "-l"]).output()?;
     let text = String::from_utf8_lossy(&output.stdout);
     let devices = text.lines().filter_map(device::parse).collect();
@@ -116,10 +113,10 @@ fn get_platform_tools_path() -> anyhow::Result<PathBuf> {
 //////////////////
 // Port forwarding
 
-pub fn list_forwarded_ports<B>(adb_path: &str, device_serial: &str) -> anyhow::Result<B>
-where
-    B: FromIterator<ForwardedPort>,
-{
+pub fn list_forwarded_ports(
+    adb_path: &str,
+    device_serial: &str,
+) -> anyhow::Result<Vec<ForwardedPort>> {
     let output = Command::new(adb_path)
         .args(["-s", &device_serial, "forward", "--list"])
         .output()?;

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -90,6 +90,7 @@ pub fn setup_wired_connection(
 pub fn teardown_wired_connection(layout: &Layout) -> Result<()> {
     let adb_path = get_adb_path(layout).context("Failed to get ADB executable path")?;
     kill_server(&adb_path)?;
+
     Ok(())
 }
 
@@ -126,6 +127,7 @@ fn download(url: &str, progress_callback: impl Fn(usize, Option<usize>)) -> Resu
         let current_size = result.len();
         (progress_callback)(current_size, maybe_expected_size);
     }
+
     Ok(result)
 }
 
@@ -150,6 +152,7 @@ pub fn get_process_id(
     let process_id = text
         .parse::<usize>()
         .context("Failed to parse process ID")?;
+
     Ok(Some(process_id))
 }
 
@@ -215,11 +218,13 @@ fn install_adb(layout: &Layout, progress_callback: impl Fn(usize, Option<usize>)
     let mut reader = Cursor::new(buffer);
     let path = get_installation_path(layout);
     ZipArchive::new(&mut reader)?.extract(path)?;
+
     Ok(())
 }
 
 fn download_adb(progress_callback: impl Fn(usize, Option<usize>)) -> Result<Vec<u8>> {
     let url = get_platform_tools_url();
+
     download(&url, progress_callback).context(format!("Failed to download ADB from {url}"))
 }
 
@@ -245,6 +250,7 @@ pub fn start_application(adb_path: &str, device_serial: &str, application_id: &s
     )
     .output()
     .context(format!("Failed to start {application_id}"))?;
+
     Ok(())
 }
 
@@ -257,6 +263,7 @@ pub fn list_devices(adb_path: &str) -> Result<Vec<Device>> {
         .context("Failed to list ADB devices")?;
     let text = String::from_utf8_lossy(&output.stdout);
     let devices = text.lines().skip(1).filter_map(device::parse).collect();
+
     Ok(devices)
 }
 
@@ -267,6 +274,7 @@ pub fn install_package(adb_path: &str, device_serial: &str, apk_path: &str) -> R
     get_command(adb_path, &["-s", device_serial, "install", "-r", apk_path])
         .output()
         .context(format!("Failed to install {apk_path}"))?;
+
     Ok(())
 }
 
@@ -280,6 +288,7 @@ pub fn is_package_installed(
             "Failed to check if package {application_id} is installed"
         ))?
         .contains(application_id);
+
     Ok(found)
 }
 
@@ -290,6 +299,7 @@ pub fn uninstall_package(adb_path: &str, device_serial: &str, application_id: &s
     )
     .output()
     .context(format!("Failed to uninstall {application_id}"))?;
+
     Ok(())
 }
 
@@ -302,6 +312,7 @@ pub fn list_installed_packages(adb_path: &str, device_serial: &str) -> Result<Ha
     .context("Failed to list installed packages")?;
     let text = String::from_utf8_lossy(&output.stdout);
     let packages = text.lines().map(|l| l.replace("package:", "")).collect();
+
     Ok(packages)
 }
 
@@ -315,11 +326,13 @@ pub fn get_adb_path(layout: &Layout) -> Option<String> {
 
 fn get_os_adb_path() -> Option<String> {
     let name = get_executable_name().to_owned();
+
     get_command(&name, &[]).output().is_ok().then_some(name)
 }
 
 fn get_local_adb_path(layout: &Layout) -> Option<String> {
     let path = get_platform_tools_path(layout).join(get_executable_name());
+
     path.try_exists()
         .is_ok_and(|e| e)
         .then(|| path.to_string_lossy().to_string())
@@ -348,6 +361,7 @@ fn list_forwarded_ports(adb_path: &str, device_serial: &str) -> Result<Vec<Forwa
         ))?;
     let text = String::from_utf8_lossy(&output.stdout);
     let forwarded_ports = text.lines().filter_map(forwarded_port::parse).collect();
+
     Ok(forwarded_ports)
 }
 
@@ -366,6 +380,7 @@ fn forward_port(adb_path: &str, device_serial: &str, port: u16) -> Result<()> {
     .context(format!(
         "Failed to forward port {port:?} of device {device_serial:?}"
     ))?;
+
     Ok(())
 }
 
@@ -376,5 +391,6 @@ pub fn kill_server(adb_path: &str) -> Result<()> {
     get_command(adb_path, &["kill-server"])
         .output()
         .context("Failed to kill ADB server")?;
+
     Ok(())
 }

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -125,7 +125,10 @@ pub fn install_apk(adb_path: &str, device_serial: &str, apk_path: &str) -> Resul
 // Devices
 
 pub fn list_devices(adb_path: &str) -> Result<Vec<Device>> {
-    let output = Command::new(adb_path).args(["devices", "-l"]).output()?;
+    let output = Command::new(adb_path)
+        .args(["devices", "-l"])
+        .output()
+        .context("Failed to list ADB devices")?;
     let text = String::from_utf8_lossy(&output.stdout);
     let devices = text.lines().skip(1).filter_map(device::parse).collect();
     Ok(devices)

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -10,7 +10,7 @@ use std::{collections::HashSet, io::Cursor, path::PathBuf, process::Command, tim
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 
-use alvr_common::debug;
+use alvr_common::{dbg_connection, debug};
 use alvr_filesystem::Layout;
 use anyhow::{anyhow, Context, Result};
 use device::Device;
@@ -47,7 +47,7 @@ pub fn setup_wired_connection(
             Some(t) => t.to_string(),
             None => "?".to_owned(),
         };
-        debug!("Downloading ADB: got {downloaded} bytes of {total_display}");
+        dbg_connection!("Downloading ADB: got {downloaded} bytes of {total_display}");
         Ok(())
     })?;
 
@@ -65,9 +65,9 @@ pub fn setup_wired_connection(
     };
 
     let ports = HashSet::from([control_port, stream_port]);
-    debug!("Forwarding ports {ports:?} of device {device_serial}...");
+    dbg_connection!("Forwarding ports {ports:?} of device {device_serial}...");
     forward_ports(&adb_path, &device_serial, &ports)?;
-    debug!("Forwarded ports {ports:?} of device {device_serial}");
+    dbg_connection!("Forwarded ports {ports:?} of device {device_serial}");
 
     if !is_activity_resumed(&adb_path, &device_serial, "alvr.client")? {
         return Ok(WiredConnectionStatus::NotReady(

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -246,9 +246,9 @@ fn get_local_adb_path() -> Option<String> {
 }
 
 fn get_installation_path() -> Result<PathBuf> {
-    let mut path = std::env::current_exe()?;
-    path.pop();
-    Ok(path)
+    let root = alvr_server_io::get_driver_dir_from_registered()?;
+    let layout = alvr_filesystem::filesystem_layout_from_openvr_driver_root_dir(&root);
+    Ok(layout.executables_dir)
 }
 
 fn get_platform_tools_path() -> Result<PathBuf> {

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -11,11 +11,6 @@ use device::Device;
 use forwarded_port::ForwardedPort;
 use zip::ZipArchive;
 
-#[cfg(not(windows))]
-const ADB_EXECUTABLE: &str = "adb";
-#[cfg(windows)]
-const ADB_EXECUTABLE: &str = "adb.exe";
-
 // https://developer.android.com/tools/releases/platform-tools#revisions
 // NOTE: At the time of writing this comment, the revisions section above
 // shows the latest version as 35.0.2, but the latest that can be downloaded
@@ -83,16 +78,16 @@ pub fn get_adb_path() -> Option<String> {
 }
 
 fn get_os_adb_path() -> Option<String> {
-    let path = ADB_EXECUTABLE.to_owned();
-    if Command::new(&path).output().is_ok() {
-        Some(path)
+    let name = get_executable_name().to_owned();
+    if Command::new(&name).output().is_ok() {
+        Some(name)
     } else {
         None
     }
 }
 
 fn get_local_adb_path() -> Option<String> {
-    let path = get_platform_tools_path().ok()?.join(ADB_EXECUTABLE);
+    let path = get_platform_tools_path().ok()?.join(get_executable_name());
     if path.try_exists().is_ok_and(|e| e) {
         Some(path.to_string_lossy().to_string())
     } else {
@@ -108,6 +103,10 @@ fn get_installation_path() -> anyhow::Result<PathBuf> {
 
 fn get_platform_tools_path() -> anyhow::Result<PathBuf> {
     Ok(get_installation_path()?.join("platform-tools"))
+}
+
+fn get_executable_name() -> String {
+    alvr_filesystem::exec_fname("adb")
 }
 
 //////////////////

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -135,7 +135,8 @@ fn get_executable_name() -> String {
 fn list_forwarded_ports(adb_path: &str, device_serial: &str) -> Result<Vec<ForwardedPort>> {
     let output = Command::new(adb_path)
         .args(["-s", &device_serial, "forward", "--list"])
-        .output()?;
+        .output()
+        .with_context(|| format!("Failed to list forwarded ports of device {device_serial:?}"))?;
     let text = String::from_utf8_lossy(&output.stdout);
     let forwarded_ports = text.lines().filter_map(forwarded_port::parse).collect();
     Ok(forwarded_ports)
@@ -162,6 +163,7 @@ fn forward_port(adb_path: &str, device_serial: &str, port: u16) -> Result<()> {
             &format!("tcp:{}", port),
             &format!("tcp:{}", port),
         ])
-        .output()?;
+        .output()
+        .with_context(|| format!("Failed to forward port {port:?} of device {device_serial:?}"))?;
     Ok(())
 }

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -35,10 +35,10 @@ type ProgressCallback = fn(u64, usize);
 pub async fn install_adb(
     client: &reqwest::Client,
     progress_callback: ProgressCallback,
-    path: PathBuf,
 ) -> anyhow::Result<()> {
     let buffer = download_adb(&client, progress_callback).await?;
     let mut reader = Cursor::new(buffer);
+    let path = get_installation_path()?;
     ZipArchive::new(&mut reader)?.extract(path)?;
     Ok(())
 }
@@ -152,8 +152,14 @@ fn get_local_adb_path() -> Option<String> {
     }
 }
 
+fn get_installation_path() -> anyhow::Result<PathBuf> {
+    let mut path = std::env::current_exe()?;
+    path.pop();
+    Ok(path)
+}
+
 fn get_platform_tools_path() -> anyhow::Result<PathBuf> {
-    Ok(std::env::current_dir()?.join("platform-tools"))
+    Ok(get_installation_path()?.join("platform-tools"))
 }
 
 //////////////////

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -10,7 +10,7 @@ use std::{collections::HashSet, io::Cursor, path::PathBuf, process::Command, tim
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 
-use alvr_common::{dbg_connection, debug};
+use alvr_common::dbg_connection;
 use alvr_filesystem::Layout;
 use anyhow::{anyhow, Context, Result};
 use device::Device;
@@ -170,18 +170,11 @@ pub fn require_adb(
     progress_callback: impl Fn(usize, Option<usize>) -> Result<()>,
 ) -> Result<String> {
     match get_adb_path(layout) {
-        Some(adb_path) => {
-            debug!("Found ADB executable at {adb_path}");
-            Ok(adb_path)
-        }
+        Some(path) => Ok(path),
         None => {
-            debug!("Couldn't find ADB, installing it...");
             install_adb(layout, progress_callback).context("Failed to install ADB")?;
-            debug!("Finished installing ADB");
-            let adb_path =
-                get_adb_path(layout).context("Failed to get ADB path after installation")?;
-            debug!("ADB installed at {adb_path:?}");
-            Ok(adb_path)
+            let path = get_adb_path(layout).context("Failed to get ADB path after installation")?;
+            Ok(path)
         }
     }
 }

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -95,6 +95,12 @@ pub fn setup_wired_connection(
     Ok(WiredConnectionStatus::Ready)
 }
 
+pub fn teardown_wired_connection(layout: &Layout) -> Result<()> {
+    let adb_path = get_adb_path(layout).context("Failed to get ADB executable path")?;
+    kill_server(&adb_path)?;
+    Ok(())
+}
+
 fn get_command(adb_path: &str, args: &[&str]) -> Command {
     let mut command = Command::new(adb_path);
     command.args(args);
@@ -377,5 +383,15 @@ fn forward_port(adb_path: &str, device_serial: &str, port: u16) -> Result<()> {
     )
     .output()
     .with_context(|| format!("Failed to forward port {port:?} of device {device_serial:?}"))?;
+    Ok(())
+}
+
+/////////
+// Server
+
+pub fn kill_server(adb_path: &str) -> Result<()> {
+    get_command(adb_path, &["kill-server"])
+        .output()
+        .with_context(|| format!("Failed to kill ADB server"))?;
     Ok(())
 }

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -7,7 +7,6 @@ pub mod transport_type;
 
 use std::{io::Cursor, path::PathBuf, process::Command, time::Duration};
 
-use const_format::formatcp;
 use device::Device;
 use forwarded_port::ForwardedPort;
 use zip::ZipArchive;
@@ -30,8 +29,6 @@ const PLATFORM_TOOLS_OS: &str = "darwin";
 #[cfg(windows)]
 const PLATFORM_TOOLS_OS: &str = "windows";
 
-const PLATFORM_TOOLS_URL: &str = formatcp!("https://dl.google.com/android/repository/platform-tools{PLATFORM_TOOLS_VERSION}-{PLATFORM_TOOLS_OS}.zip");
-
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 ///////////////////
@@ -46,12 +43,15 @@ pub fn install_adb() -> anyhow::Result<()> {
 }
 
 fn download_adb() -> anyhow::Result<Vec<u8>> {
-    let response = ureq::get(PLATFORM_TOOLS_URL)
-        .timeout(REQUEST_TIMEOUT)
-        .call()?;
+    let url = get_platform_tools_url();
+    let response = ureq::get(&url).timeout(REQUEST_TIMEOUT).call()?;
     let mut buffer = Vec::<u8>::new();
     response.into_reader().read_to_end(&mut buffer)?;
     Ok(buffer)
+}
+
+fn get_platform_tools_url() -> String {
+    format!("https://dl.google.com/android/repository/platform-tools{PLATFORM_TOOLS_VERSION}-{PLATFORM_TOOLS_OS}.zip")
 }
 
 ///////////////////

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -47,7 +47,9 @@ pub fn setup_wired_connection(
             Some(t) => t.to_string(),
             None => "?".to_owned(),
         };
-        dbg_connection!("Downloading ADB: got {downloaded} bytes of {total_display}");
+        dbg_connection!(
+            "setup_wired_connection: Downloading ADB: got {downloaded} bytes of {total_display}"
+        );
         Ok(())
     })?;
 

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -10,7 +10,7 @@ use std::{collections::HashSet, io::Cursor, path::PathBuf, process::Command, tim
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 
-use alvr_common::{dbg_connection, warn};
+use alvr_common::debug;
 use alvr_filesystem::Layout;
 use anyhow::{Context, Result};
 use device::Device;
@@ -35,23 +35,23 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 pub fn setup_wired_connection(layout: &Layout, control_port: u16, stream_port: u16) -> Result<()> {
     let adb_path = match get_adb_path(layout) {
         Some(adb_path) => {
-            dbg_connection!("Found ADB executable at {adb_path}");
+            debug!("Found ADB executable at {adb_path}");
             adb_path
         }
         None => {
-            dbg_connection!("Couldn't find ADB, installing it...");
+            debug!("Couldn't find ADB, installing it...");
             install_adb(layout, |downloaded, total| {
                 let total_display = match total {
                     Some(t) => t.to_string(),
                     None => "?".to_owned(),
                 };
-                warn!("Downloading ADB: got {downloaded} bytes of {total_display}");
+                debug!("Downloading ADB: got {downloaded} bytes of {total_display}");
             })
             .context("Failed to install ADB")?;
-            dbg_connection!("Finished installing ADB");
+            debug!("Finished installing ADB");
             let adb_path =
                 get_adb_path(layout).context("Failed to get ADB path after installation")?;
-            dbg_connection!("ADB installed at {adb_path:?}");
+            debug!("ADB installed at {adb_path:?}");
             adb_path
         }
     };
@@ -63,12 +63,12 @@ pub fn setup_wired_connection(layout: &Layout, control_port: u16, stream_port: u
     let ports = HashSet::from([control_port, stream_port]);
     for device in devices {
         let Some(device_serial) = device.serial else {
-            dbg_connection!("Skipping device without serial number");
+            debug!("Skipping device without serial number");
             continue;
         };
-        dbg_connection!("Forwarding ports {ports:?} of device {device_serial}...");
+        debug!("Forwarding ports {ports:?} of device {device_serial}...");
         forward_ports(&adb_path, &device_serial, &ports)?;
-        dbg_connection!("Forwarded ports {ports:?} of device {device_serial}");
+        debug!("Forwarded ports {ports:?} of device {device_serial}");
     }
     Ok(())
 }

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -1,0 +1,162 @@
+// https://android.googlesource.com/platform/packages/modules/adb/+/refs/heads/main/docs/user/adb.1.md
+
+use std::{io::Cursor, path::PathBuf, process::Command};
+
+use const_format::formatcp;
+use futures_util::StreamExt;
+use zip::ZipArchive;
+
+#[cfg(not(windows))]
+const ADB_EXECUTABLE: &str = "adb";
+#[cfg(windows)]
+const ADB_EXECUTABLE: &str = "adb.exe";
+
+// https://developer.android.com/tools/releases/platform-tools#revisions
+// NOTE: At the time of writing this comment, the revisions section above
+// shows the latest version as 35.0.2, but the latest that can be downloaded
+// by specifying a version is 35.0.0
+const PLATFORM_TOOLS_VERSION: &str = "-latest"; // E.g. "_r35.0.0"
+
+#[cfg(target_os = "linux")]
+const PLATFORM_TOOLS_OS: &str = "linux";
+#[cfg(target_os = "macos")]
+const PLATFORM_TOOLS_OS: &str = "darwin";
+#[cfg(windows)]
+const PLATFORM_TOOLS_OS: &str = "windows";
+
+const PLATFORM_TOOLS_URL: &str = formatcp!("https://dl.google.com/android/repository/platform-tools{PLATFORM_TOOLS_VERSION}-{PLATFORM_TOOLS_OS}.zip");
+
+///////////////////
+// ADB Installation
+
+type ProgressCallback = fn(u64, usize);
+
+/// Installs a local version of `adb` in the specified `path`, using `client` to download the "platform-tools" archive.
+pub async fn install_adb(
+    client: &reqwest::Client,
+    progress_callback: ProgressCallback,
+    path: PathBuf,
+) -> anyhow::Result<()> {
+    let buffer = download_adb(&client, progress_callback).await?;
+    let mut reader = Cursor::new(buffer);
+    ZipArchive::new(&mut reader)?.extract(path)?;
+    Ok(())
+}
+
+async fn download_adb(
+    client: &reqwest::Client,
+    progress_callback: ProgressCallback,
+) -> anyhow::Result<Vec<u8>> {
+    let response = client.get(PLATFORM_TOOLS_URL).send().await?;
+    let maybe_total_size = response.content_length();
+    let mut stream = response.bytes_stream();
+    let mut buffer = Vec::new();
+    while let Some(item) = stream.next().await {
+        buffer.extend(item?);
+        if let Some(total_size) = maybe_total_size {
+            let downloaded_size = buffer.len();
+            (progress_callback)(total_size, downloaded_size)
+        }
+    }
+    Ok(buffer)
+}
+
+///////////////////
+// APK installation
+
+pub fn install_apk(adb_path: &str, apk_path: &str) -> anyhow::Result<()> {
+    Command::new(adb_path)
+        .args(["install", "-r", &apk_path])
+        .output()?;
+    Ok(())
+}
+
+////////
+// Paths
+
+/// Returns the path of a local (i.e. installed by ALVR) or OS version of `adb` if found, `None` otherwise.
+pub fn get_adb_path() -> Option<String> {
+    get_os_adb_path().or(get_local_adb_path())
+}
+
+fn get_os_adb_path() -> Option<String> {
+    let path = ADB_EXECUTABLE.to_owned();
+    if Command::new(&path).output().is_ok() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn get_local_adb_path() -> Option<String> {
+    let path = get_platform_tools_path().ok()?.join(ADB_EXECUTABLE);
+    if path.try_exists().is_ok_and(|e| e) {
+        Some(path.to_string_lossy().to_owned().to_string())
+    } else {
+        None
+    }
+}
+
+fn get_platform_tools_path() -> anyhow::Result<PathBuf> {
+    Ok(std::env::current_dir()?.join("platform-tools"))
+}
+
+//////////////////
+// Port forwarding
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ForwardedPort {
+    serial: String,
+    local: u16,
+    remote: u16,
+}
+
+pub fn list_forwarded_ports<B>(adb_path: &str) -> anyhow::Result<B>
+where
+    B: FromIterator<ForwardedPort>,
+{
+    let output = Command::new(adb_path)
+        .args(["forward", "--list"])
+        .output()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    let forwarded_ports = text.lines().filter_map(parse_forwarded_port).collect();
+    Ok(forwarded_ports)
+}
+
+fn parse_forwarded_port(line: &str) -> Option<ForwardedPort> {
+    let mut slices = line.split_whitespace();
+    let serial = slices.next();
+    let local = parse_port_with_protocol(slices.next()?);
+    let remote = parse_port_with_protocol(slices.next()?);
+    if let (Some(serial), Some(local), Some(remote)) = (serial, local, remote) {
+        Some(ForwardedPort {
+            serial: serial.to_owned(),
+            local,
+            remote,
+        })
+    } else {
+        None
+    }
+}
+
+fn parse_port_with_protocol(value: &str) -> Option<u16> {
+    let mut slices = value.split(":");
+    let _protocol = slices.next();
+    let maybe_port = slices.next();
+    if let Some(port) = maybe_port {
+        port.parse::<u16>().ok()
+    } else {
+        None
+    }
+}
+
+pub fn forward_port(adb_path: &str, port: u16) -> anyhow::Result<()> {
+    Command::new(adb_path)
+        .args([
+            "forward",
+            &format!("tcp:{}", port),
+            &format!("tcp:{}", port),
+        ])
+        .output()?;
+    Ok(())
+}

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -73,7 +73,7 @@ pub fn setup_wired_connection(
     let process_name = "alvr.client.dev";
     #[cfg(not(debug_assertions))]
     let process_name = "alvr.client.stable";
-    if let None = get_process_id(&adb_path, &device_serial, process_name)? {
+    if get_process_id(&adb_path, &device_serial, process_name)?.is_none() {
         return Ok(WiredConnectionStatus::NotReady(
             "ALVR client is not running".to_owned(),
         ));
@@ -111,11 +111,10 @@ fn download(
         .timeout_connect(REQUEST_TIMEOUT)
         .timeout_read(REQUEST_TIMEOUT)
         .build();
-    let response = agent.get(&url).call()?;
+    let response = agent.get(url).call()?;
     let maybe_expected_size: Option<usize> = response
         .header("Content-Length")
-        .map(|l| l.parse().ok())
-        .flatten();
+        .and_then(|l| l.parse().ok());
     let mut result = match maybe_expected_size {
         Some(size) => Vec::with_capacity(size),
         None => Vec::new(),
@@ -144,15 +143,17 @@ pub fn get_process_id(
 ) -> Result<Option<usize>> {
     let output = get_command(
         adb_path,
-        &["-s", &device_serial, "shell", "pidof", process_name],
+        &["-s", device_serial, "shell", "pidof", process_name],
     )
     .output()
     .context(format!("Failed to get ID of process {process_name}"))?;
     let text = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    if text.len() == 0 {
+    if text.is_empty() {
         return Ok(None);
     }
-    let process_id = usize::from_str_radix(&text, 10).context("Failed to parse process ID")?;
+    let process_id = text
+        .parse::<usize>()
+        .context("Failed to parse process ID")?;
     Ok(Some(process_id))
 }
 
@@ -165,7 +166,7 @@ pub fn is_activity_resumed(
         adb_path,
         &[
             "-s",
-            &device_serial,
+            device_serial,
             "shell",
             "dumpsys",
             "activity",
@@ -181,10 +182,10 @@ pub fn is_activity_resumed(
         .find(|l| l.contains("mResumed"))
     {
         let (entry, _) = line
-            .split_once(" ")
+            .split_once(' ')
             .ok_or(anyhow!("Failed to split resumed state line"))?;
         let (_, value) = entry
-            .split_once("=")
+            .split_once('=')
             .ok_or(anyhow!("Failed to split resumed state entry"))?;
         match value {
             "true" => Ok(true),
@@ -226,7 +227,7 @@ fn install_adb(
 
 fn download_adb(progress_callback: impl Fn(usize, Option<usize>) -> Result<()>) -> Result<Vec<u8>> {
     let url = get_platform_tools_url();
-    download(&url, progress_callback).with_context(|| format!("Failed to download ADB from {url}"))
+    download(&url, progress_callback).context(format!("Failed to download ADB from {url}"))
 }
 
 fn get_platform_tools_url() -> String {
@@ -241,16 +242,16 @@ pub fn start_application(adb_path: &str, device_serial: &str, application_id: &s
         adb_path,
         &[
             "-s",
-            &device_serial,
+            device_serial,
             "shell",
             "monkey",
             "-p",
-            &application_id,
+            application_id,
             "1",
         ],
     )
     .output()
-    .with_context(|| format!("Failed to start {application_id}"))?;
+    .context(format!("Failed to start {application_id}"))?;
     Ok(())
 }
 
@@ -270,12 +271,9 @@ pub fn list_devices(adb_path: &str) -> Result<Vec<Device>> {
 // Packages
 
 pub fn install_package(adb_path: &str, device_serial: &str, apk_path: &str) -> Result<()> {
-    get_command(
-        adb_path,
-        &["-s", &device_serial, "install", "-r", &apk_path],
-    )
-    .output()
-    .with_context(|| format!("Failed to install {apk_path}"))?;
+    get_command(adb_path, &["-s", device_serial, "install", "-r", apk_path])
+        .output()
+        .context(format!("Failed to install {apk_path}"))?;
     Ok(())
 }
 
@@ -285,7 +283,9 @@ pub fn is_package_installed(
     application_id: &str,
 ) -> Result<bool> {
     let found = list_installed_packages(adb_path, device_serial)
-        .with_context(|| format!("Failed to check if package {application_id} is installed"))?
+        .context(format!(
+            "Failed to check if package {application_id} is installed"
+        ))?
         .contains(application_id);
     Ok(found)
 }
@@ -293,20 +293,20 @@ pub fn is_package_installed(
 pub fn uninstall_package(adb_path: &str, device_serial: &str, application_id: &str) -> Result<()> {
     get_command(
         adb_path,
-        &["-s", &device_serial, "uninstall", &application_id],
+        &["-s", device_serial, "uninstall", application_id],
     )
     .output()
-    .with_context(|| format!("Failed to uninstall {application_id}"))?;
+    .context(format!("Failed to uninstall {application_id}"))?;
     Ok(())
 }
 
 pub fn list_installed_packages(adb_path: &str, device_serial: &str) -> Result<HashSet<String>> {
     let output = get_command(
         adb_path,
-        &["-s", &device_serial, "shell", "pm", "list", "package"],
+        &["-s", device_serial, "shell", "pm", "list", "package"],
     )
     .output()
-    .with_context(|| format!("Failed to list installed packages"))?;
+    .context("Failed to list installed packages")?;
     let text = String::from_utf8_lossy(&output.stdout);
     let packages = text.lines().map(|l| l.replace("package:", "")).collect();
     Ok(packages)
@@ -354,9 +354,11 @@ fn get_executable_name() -> String {
 // Port forwarding
 
 fn list_forwarded_ports(adb_path: &str, device_serial: &str) -> Result<Vec<ForwardedPort>> {
-    let output = get_command(adb_path, &["-s", &device_serial, "forward", "--list"])
+    let output = get_command(adb_path, &["-s", device_serial, "forward", "--list"])
         .output()
-        .with_context(|| format!("Failed to list forwarded ports of device {device_serial:?}"))?;
+        .context(format!(
+            "Failed to list forwarded ports of device {device_serial:?}"
+        ))?;
     let text = String::from_utf8_lossy(&output.stdout);
     let forwarded_ports = text.lines().filter_map(forwarded_port::parse).collect();
     Ok(forwarded_ports)
@@ -367,14 +369,16 @@ fn forward_port(adb_path: &str, device_serial: &str, port: u16) -> Result<()> {
         adb_path,
         &[
             "-s",
-            &device_serial,
+            device_serial,
             "forward",
             &format!("tcp:{}", port),
             &format!("tcp:{}", port),
         ],
     )
     .output()
-    .with_context(|| format!("Failed to forward port {port:?} of device {device_serial:?}"))?;
+    .context(format!(
+        "Failed to forward port {port:?} of device {device_serial:?}"
+    ))?;
     Ok(())
 }
 
@@ -384,6 +388,6 @@ fn forward_port(adb_path: &str, device_serial: &str, port: u16) -> Result<()> {
 pub fn kill_server(adb_path: &str) -> Result<()> {
     get_command(adb_path, &["kill-server"])
         .output()
-        .with_context(|| format!("Failed to kill ADB server"))?;
+        .context("Failed to kill ADB server")?;
     Ok(())
 }

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -227,6 +227,18 @@ pub fn start_application(adb_path: &str, device_serial: &str, application_id: &s
     Ok(())
 }
 
+//////////
+// Devices
+
+pub fn list_devices(adb_path: &str) -> Result<Vec<Device>> {
+    let output = get_command(adb_path, &["devices", "-l"])
+        .output()
+        .context("Failed to list ADB devices")?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    let devices = text.lines().skip(1).filter_map(device::parse).collect();
+    Ok(devices)
+}
+
 ///////////
 // Packages
 
@@ -271,18 +283,6 @@ pub fn list_installed_packages(adb_path: &str, device_serial: &str) -> Result<Ha
     let text = String::from_utf8_lossy(&output.stdout);
     let packages = text.lines().map(|l| l.replace("package:", "")).collect();
     Ok(packages)
-}
-
-//////////
-// Devices
-
-pub fn list_devices(adb_path: &str) -> Result<Vec<Device>> {
-    let output = get_command(adb_path, &["devices", "-l"])
-        .output()
-        .context("Failed to list ADB devices")?;
-    let text = String::from_utf8_lossy(&output.stdout);
-    let devices = text.lines().skip(1).filter_map(device::parse).collect();
-    Ok(devices)
 }
 
 ////////

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -124,6 +124,18 @@ pub fn list_forwarded_ports(
     Ok(forwarded_ports)
 }
 
+pub fn forward_ports(adb_path: &str, device_serial: &str, ports: &[u16]) -> anyhow::Result<()> {
+    let forwarded_ports = list_forwarded_ports(&adb_path, &device_serial)?;
+    let ports = forwarded_ports
+        .into_iter()
+        .map(|f| f.local)
+        .filter(|p| !ports.contains(p));
+    for port in ports {
+        forward_port(&adb_path, &device_serial, port)?;
+    }
+    Ok(())
+}
+
 pub fn forward_port(adb_path: &str, device_serial: &str, port: u16) -> anyhow::Result<()> {
     Command::new(adb_path)
         .args([

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -41,7 +41,7 @@ pub fn setup_wired_connection(
     layout: &Layout,
     control_port: u16,
     stream_port: u16,
-    progress_callback: impl Fn(usize, Option<usize>) -> Result<()>,
+    progress_callback: impl Fn(usize, Option<usize>),
 ) -> Result<WiredConnectionStatus> {
     let adb_path = require_adb(layout, progress_callback)?;
 
@@ -103,10 +103,7 @@ fn get_command(adb_path: &str, args: &[&str]) -> Command {
     command
 }
 
-fn download(
-    url: &str,
-    progress_callback: impl Fn(usize, Option<usize>) -> Result<()>,
-) -> Result<Vec<u8>> {
+fn download(url: &str, progress_callback: impl Fn(usize, Option<usize>)) -> Result<Vec<u8>> {
     let agent = ureq::builder()
         .timeout_connect(REQUEST_TIMEOUT)
         .timeout_read(REQUEST_TIMEOUT)
@@ -128,7 +125,7 @@ fn download(
         }
         result.extend_from_slice(&buffer[..read_count]);
         let current_size = result.len();
-        (progress_callback)(current_size, maybe_expected_size)?;
+        (progress_callback)(current_size, maybe_expected_size);
     }
     Ok(result)
 }
@@ -202,7 +199,7 @@ pub fn is_activity_resumed(
 
 pub fn require_adb(
     layout: &Layout,
-    progress_callback: impl Fn(usize, Option<usize>) -> Result<()>,
+    progress_callback: impl Fn(usize, Option<usize>),
 ) -> Result<String> {
     match get_adb_path(layout) {
         Some(path) => Ok(path),
@@ -214,10 +211,7 @@ pub fn require_adb(
     }
 }
 
-fn install_adb(
-    layout: &Layout,
-    progress_callback: impl Fn(usize, Option<usize>) -> Result<()>,
-) -> Result<()> {
+fn install_adb(layout: &Layout, progress_callback: impl Fn(usize, Option<usize>)) -> Result<()> {
     let buffer = download_adb(progress_callback)?;
     let mut reader = Cursor::new(buffer);
     let path = get_installation_path(layout);
@@ -225,7 +219,7 @@ fn install_adb(
     Ok(())
 }
 
-fn download_adb(progress_callback: impl Fn(usize, Option<usize>) -> Result<()>) -> Result<Vec<u8>> {
+fn download_adb(progress_callback: impl Fn(usize, Option<usize>)) -> Result<Vec<u8>> {
     let url = get_platform_tools_url();
     download(&url, progress_callback).context(format!("Failed to download ADB from {url}"))
 }

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -41,17 +41,9 @@ pub fn setup_wired_connection(
     layout: &Layout,
     control_port: u16,
     stream_port: u16,
+    progress_callback: impl Fn(usize, Option<usize>) -> Result<()>,
 ) -> Result<WiredConnectionStatus> {
-    let adb_path = require_adb(layout, |downloaded, total| {
-        let total_display = match total {
-            Some(t) => t.to_string(),
-            None => "?".to_owned(),
-        };
-        dbg_connection!(
-            "setup_wired_connection: Downloading ADB: got {downloaded} bytes of {total_display}"
-        );
-        Ok(())
-    })?;
+    let adb_path = require_adb(layout, progress_callback)?;
 
     let device_serial = match list_devices(&adb_path)?
         .into_iter()

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -52,17 +52,14 @@ pub fn setup_wired_connection(
         .context("Failed to get filesystem layout")?;
     let adb_path = require_adb(layout, progress_callback)?;
 
-    let device_serial = match list_devices(&adb_path)?
+    let Some(device_serial) = list_devices(&adb_path)?
         .into_iter()
         .filter_map(|d| d.serial)
         .find(|s| !s.starts_with("127.0.0.1"))
-    {
-        None => {
-            return Ok(WiredConnectionStatus::NotReady(
-                "No wired devices found".to_owned(),
-            ))
-        }
-        Some(serial) => serial,
+    else {
+        return Ok(WiredConnectionStatus::NotReady(
+            "No wired devices found".to_owned(),
+        ));
     };
 
     let stream_port = session_manager.read().settings().connection.stream_port;

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -32,7 +32,7 @@ const PLATFORM_TOOLS_OS: &str = "windows";
 
 const PLATFORM_TOOLS_URL: &str = formatcp!("https://dl.google.com/android/repository/platform-tools{PLATFORM_TOOLS_VERSION}-{PLATFORM_TOOLS_OS}.zip");
 
-const REQUEST_TIMEOUT: Duration = Duration::from_millis(200);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 ///////////////////
 // ADB Installation

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -75,7 +75,7 @@ pub fn install_apk(adb_path: &str, apk_path: &str) -> anyhow::Result<()> {
 // Devices
 
 // https://cs.android.com/android/platform/superproject/main/+/7dbe542b9a93fb3cee6c528e16e2d02a26da7cc0:packages/modules/adb/transport.cpp;l=1398
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug)]
 pub struct Device {
     device: String,
     model: String,
@@ -159,7 +159,7 @@ fn get_platform_tools_path() -> anyhow::Result<PathBuf> {
 //////////////////
 // Port forwarding
 
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug)]
 pub struct ForwardedPort {
     serial: String,
     local: u16,

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -91,7 +91,7 @@ enum ConnectionState {
     Device,
     #[strum(serialize = "host")]
     Host,
-    // https://cs.android.com/android/platform/superproject/main/+/main:system/core/diagnose_usb/diagnose_usb.cpp;l=83-90?q=system%2Fcore%2Fdiagnose_usb%2Fdiagnose_usb.cpp%20&ss=android%2Fplatform%2Fsuperproject%2Fmain
+    // https://cs.android.com/android/platform/superproject/main/+/main:system/core/diagnose_usb/diagnose_usb.cpp;l=83-90
     NoPermissions,
     #[strum(serialize = "offline")]
     Offline,

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -97,7 +97,11 @@ pub fn install_adb(progress_callback: ProgressCallback) -> Result<()> {
 
 fn download_adb(progress_callback: ProgressCallback) -> Result<Vec<u8>> {
     let url = get_platform_tools_url();
-    let response = ureq::get(&url).timeout(REQUEST_TIMEOUT).call()?;
+    let agent = ureq::builder()
+        .timeout_connect(REQUEST_TIMEOUT)
+        .timeout_read(REQUEST_TIMEOUT)
+        .build();
+    let response = agent.get(&url).call()?;
     let maybe_expected_size: Option<usize> = response
         .header("Content-Length")
         .map(|l| l.parse().ok())

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -32,7 +32,7 @@ const PLATFORM_TOOLS_OS: &str = "windows";
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
-pub fn setup_wired_connection(layout: &Layout) -> Result<()> {
+pub fn setup_wired_connection(layout: &Layout, control_port: u16, stream_port: u16) -> Result<()> {
     let adb_path = match get_adb_path(layout) {
         Some(adb_path) => {
             dbg_connection!("Found ADB executable at {adb_path}");
@@ -60,7 +60,7 @@ pub fn setup_wired_connection(layout: &Layout) -> Result<()> {
             .as_ref()
             .is_some_and(|s| !s.starts_with("127.0.0.1"))
     });
-    let ports = HashSet::from([9943, 9944]);
+    let ports = HashSet::from([control_port, stream_port]);
     for device in devices {
         let Some(device_serial) = device.serial else {
             dbg_connection!("Skipping device without serial number");

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -239,18 +239,6 @@ pub fn is_package_installed(
     Ok(found)
 }
 
-pub fn replace_package(
-    adb_path: &str,
-    device_serial: &str,
-    application_id: &str,
-    apk_path: &str,
-) -> Result<()> {
-    if is_package_installed(adb_path, device_serial, application_id)? {
-        uninstall_package(adb_path, device_serial, application_id)?;
-    }
-    install_package(adb_path, device_serial, apk_path)
-}
-
 pub fn uninstall_package(adb_path: &str, device_serial: &str, application_id: &str) -> Result<()> {
     get_command(
         adb_path,

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -57,9 +57,9 @@ fn download_adb() -> anyhow::Result<Vec<u8>> {
 ///////////////////
 // APK installation
 
-pub fn install_apk(adb_path: &str, apk_path: &str) -> anyhow::Result<()> {
+pub fn install_apk(adb_path: &str, device_serial: &str, apk_path: &str) -> anyhow::Result<()> {
     Command::new(adb_path)
-        .args(["install", "-r", &apk_path])
+        .args(["-s", &device_serial, "install", "-r", &apk_path])
         .output()?;
     Ok(())
 }
@@ -116,21 +116,23 @@ fn get_platform_tools_path() -> anyhow::Result<PathBuf> {
 //////////////////
 // Port forwarding
 
-pub fn list_forwarded_ports<B>(adb_path: &str) -> anyhow::Result<B>
+pub fn list_forwarded_ports<B>(adb_path: &str, device_serial: &str) -> anyhow::Result<B>
 where
     B: FromIterator<ForwardedPort>,
 {
     let output = Command::new(adb_path)
-        .args(["forward", "--list"])
+        .args(["-s", &device_serial, "forward", "--list"])
         .output()?;
     let text = String::from_utf8_lossy(&output.stdout);
     let forwarded_ports = text.lines().filter_map(forwarded_port::parse).collect();
     Ok(forwarded_ports)
 }
 
-pub fn forward_port(adb_path: &str, port: u16) -> anyhow::Result<()> {
+pub fn forward_port(adb_path: &str, device_serial: &str, port: u16) -> anyhow::Result<()> {
     Command::new(adb_path)
         .args([
+            "-s",
+            &device_serial,
             "forward",
             &format!("tcp:{}", port),
             &format!("tcp:{}", port),

--- a/alvr/adb/src/lib.rs
+++ b/alvr/adb/src/lib.rs
@@ -65,7 +65,7 @@ pub fn install_apk(adb_path: &str, device_serial: &str, apk_path: &str) -> anyho
 pub fn list_devices(adb_path: &str) -> anyhow::Result<Vec<Device>> {
     let output = Command::new(adb_path).args(["devices", "-l"]).output()?;
     let text = String::from_utf8_lossy(&output.stdout);
-    let devices = text.lines().filter_map(device::parse).collect();
+    let devices = text.lines().skip(1).filter_map(device::parse).collect();
     Ok(devices)
 }
 

--- a/alvr/adb/src/transport_type.rs
+++ b/alvr/adb/src/transport_type.rs
@@ -8,9 +8,9 @@ pub enum TransportType {
 }
 
 pub fn parse(pair: &str) -> Option<TransportType> {
-    let mut slice = pair.split(":");
+    let mut slice = pair.split(':');
     let _key = slice.next();
-    if let Some(value) = slice.next()?.parse::<u8>().ok() {
+    if let Ok(value) = slice.next()?.parse::<u8>() {
         match value {
             0 => Some(TransportType::Usb),
             1 => Some(TransportType::Local),

--- a/alvr/adb/src/transport_type.rs
+++ b/alvr/adb/src/transport_type.rs
@@ -10,6 +10,7 @@ pub enum TransportType {
 pub fn parse(pair: &str) -> Option<TransportType> {
     let mut slice = pair.split(':');
     let _key = slice.next();
+
     if let Ok(value) = slice.next()?.parse::<u8>() {
         match value {
             0 => Some(TransportType::Usb),

--- a/alvr/adb/src/transport_type.rs
+++ b/alvr/adb/src/transport_type.rs
@@ -1,0 +1,24 @@
+// https://cs.android.com/android/platform/superproject/main/+/7dbe542b9a93fb3cee6c528e16e2d02a26da7cc0:packages/modules/adb/adb.h;l=95-100
+#[derive(Debug)]
+pub enum TransportType {
+    Usb,
+    Local,
+    Any,
+    Host,
+}
+
+pub fn parse(pair: &str) -> Option<TransportType> {
+    let mut slice = pair.split(":");
+    let _key = slice.next();
+    if let Some(value) = slice.next()?.parse::<u8>().ok() {
+        match value {
+            0 => Some(TransportType::Usb),
+            1 => Some(TransportType::Local),
+            2 => Some(TransportType::Any),
+            3 => Some(TransportType::Host),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}

--- a/alvr/adb/src/wired_connection.rs
+++ b/alvr/adb/src/wired_connection.rs
@@ -1,0 +1,35 @@
+use alvr_common::{dbg_connection, error};
+
+use crate::kill_server;
+
+pub struct WiredConnection {
+    pub maybe_adb_path: Option<String>,
+    pub status: WiredConnectionStatus,
+}
+
+impl Default for WiredConnection {
+    fn default() -> Self {
+        Self {
+            maybe_adb_path: Default::default(),
+            status: WiredConnectionStatus::Uninitialized,
+        }
+    }
+}
+
+impl Drop for WiredConnection {
+    fn drop(&mut self) {
+        let Some(adb_path) = &self.maybe_adb_path else {
+            return;
+        };
+        dbg_connection!("wired_connection: Killing ADB server");
+        if let Err(e) = kill_server(&adb_path) {
+            error!("{e:?}");
+        }
+    }
+}
+
+pub enum WiredConnectionStatus {
+    Uninitialized,
+    NotReady(String),
+    Ready,
+}

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -19,7 +19,7 @@ use alvr_packets::{
     StreamConfigPacket, Tracking, VideoPacketHeader, VideoStreamingCapabilities, ViewParams, AUDIO,
     HAPTICS, STATISTICS, TRACKING, VIDEO,
 };
-use alvr_session::settings_schema::Switch;
+use alvr_session::{settings_schema::Switch, SocketProtocol};
 use alvr_sockets::{
     ControlSocketSender, PeerType, ProtoControlSocket, StreamSender, StreamSocketBuilder,
     KEEPALIVE_INTERVAL, KEEPALIVE_TIMEOUT,
@@ -237,11 +237,16 @@ fn connection_pipeline(
         }
     }
 
+    let stream_protocol = match negotiated_config.wired.is_some_and(|w| w) {
+        false => settings.connection.stream_protocol,
+        true => SocketProtocol::Tcp,
+    };
+
     dbg_connection!("connection_pipeline: create StreamSocket");
     let stream_socket_builder = StreamSocketBuilder::listen_for_server(
         Duration::from_secs(1),
         settings.connection.stream_port,
-        settings.connection.stream_protocol,
+        stream_protocol,
         settings.connection.dscp,
         settings.connection.client_send_buffer_bytes,
         settings.connection.client_recv_buffer_bytes,

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -237,9 +237,10 @@ fn connection_pipeline(
         }
     }
 
-    let stream_protocol = match negotiated_config.wired.is_some_and(|w| w) {
-        false => settings.connection.stream_protocol,
-        true => SocketProtocol::Tcp,
+    let stream_protocol = if negotiated_config.wired {
+        SocketProtocol::Tcp
+    } else {
+        settings.connection.stream_protocol
     };
 
     dbg_connection!("connection_pipeline: create StreamSocket");

--- a/alvr/dashboard/Cargo.toml
+++ b/alvr/dashboard/Cargo.toml
@@ -13,6 +13,7 @@ alvr_events.workspace = true
 alvr_filesystem.workspace = true
 alvr_packets.workspace = true
 alvr_session.workspace = true
+alvr_sockets.workspace = true
 alvr_gui_common.workspace = true
 
 bincode = "1"

--- a/alvr/dashboard/Cargo.toml
+++ b/alvr/dashboard/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+alvr_adb.workspace = true
 alvr_common.workspace = true
 alvr_events.workspace = true
 alvr_filesystem.workspace = true

--- a/alvr/dashboard/src/dashboard/components/devices.rs
+++ b/alvr/dashboard/src/dashboard/components/devices.rs
@@ -149,7 +149,7 @@ impl DevicesTab {
                                 });
                             } else {
                                 requests.push(ServerRequest::UpdateClientList {
-                                    hostname: state.hostname.clone(),
+                                    hostname: state.hostname,
                                     action: ClientListAction::SetManualIps(manual_ips),
                                 });
                             }

--- a/alvr/dashboard/src/dashboard/components/devices.rs
+++ b/alvr/dashboard/src/dashboard/components/devices.rs
@@ -13,6 +13,7 @@ struct EditPopupState {
     new_devices: bool,
     hostname: String,
     ips: Vec<String>,
+    wired: bool,
 }
 
 pub struct DevicesTab {
@@ -104,6 +105,8 @@ impl DevicesTab {
                             state.new_devices,
                             TextEdit::singleline(&mut state.hostname),
                         );
+                        ui[0].label("Wired:");
+                        alvr_gui_common::switch(&mut ui[1], &mut state.wired);
                         ui[0].label("IP Addresses:");
                         for address in &mut state.ips {
                             ui[1].text_edit_singleline(address);
@@ -127,12 +130,17 @@ impl DevicesTab {
                                     action: ClientListAction::AddIfMissing {
                                         trusted: true,
                                         manual_ips,
+                                        wired: state.wired,
                                     },
                                 });
                             } else {
                                 requests.push(ServerRequest::UpdateClientList {
-                                    hostname: state.hostname,
+                                    hostname: state.hostname.clone(),
                                     action: ClientListAction::SetManualIps(manual_ips),
+                                });
+                                requests.push(ServerRequest::UpdateClientList {
+                                    hostname: state.hostname,
+                                    action: ClientListAction::SetWiredMode(state.wired),
                                 });
                             }
                         } else {
@@ -264,6 +272,7 @@ fn trusted_clients_section(
                                                     .iter()
                                                     .map(|addr| addr.to_string())
                                                     .collect::<Vec<String>>(),
+                                                wired: data.wired,
                                             });
                                         }
                                     });
@@ -277,6 +286,7 @@ fn trusted_clients_section(
                     hostname: "XXXX.client.local.".into(),
                     new_devices: true,
                     ips: Vec::new(),
+                    wired: false,
                 });
             }
         });

--- a/alvr/dashboard/src/dashboard/components/devices.rs
+++ b/alvr/dashboard/src/dashboard/components/devices.rs
@@ -165,7 +165,7 @@ fn new_clients_section(
         .show(ui, |ui| {
             ui.vertical_centered_justified(|ui| {
                 ui.add_space(5.0);
-                ui.heading("New devices");
+                ui.heading("New wireless devices");
             });
             for (hostname, _) in clients {
                 Frame::group(ui.style())
@@ -208,7 +208,7 @@ fn trusted_clients_section(
         .show(ui, |ui| {
             ui.vertical_centered_justified(|ui| {
                 ui.add_space(5.0);
-                ui.heading("Trusted devices");
+                ui.heading("Trusted wireless devices");
             });
 
             ui.vertical(|ui| {

--- a/alvr/dashboard/src/dashboard/components/devices.rs
+++ b/alvr/dashboard/src/dashboard/components/devices.rs
@@ -138,10 +138,6 @@ impl DevicesTab {
                                     hostname: state.hostname.clone(),
                                     action: ClientListAction::SetManualIps(manual_ips),
                                 });
-                                requests.push(ServerRequest::UpdateClientList {
-                                    hostname: state.hostname,
-                                    action: ClientListAction::SetWiredMode(state.wired),
-                                });
                             }
                         } else {
                             self.edit_popup_state = Some(state);

--- a/alvr/dashboard/src/dashboard/components/devices.rs
+++ b/alvr/dashboard/src/dashboard/components/devices.rs
@@ -218,16 +218,14 @@ fn wired_client_section(
                             ui.add(ProgressBar::new(progress).animate(true).show_percentage());
                         });
                         ui.end_row();
-                    } else {
-                        if let Some((_, data)) = maybe_client {
-                            ui.horizontal(|ui| {
-                                ui.label(&data.display_name);
-                            });
-                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                connection_label(ui, &data.connection_state);
-                            });
-                            ui.end_row();
-                        }
+                    } else if let Some((_, data)) = maybe_client {
+                        ui.horizontal(|ui| {
+                            ui.label(&data.display_name);
+                        });
+                        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                            connection_label(ui, &data.connection_state);
+                        });
+                        ui.end_row();
                     }
                 });
         });

--- a/alvr/dashboard/src/dashboard/components/devices.rs
+++ b/alvr/dashboard/src/dashboard/components/devices.rs
@@ -225,26 +225,7 @@ fn trusted_clients_section(
                                     ui.horizontal(|ui| {
                                         ui.with_layout(
                                             Layout::right_to_left(Align::Center),
-                                            |ui| match data.connection_state {
-                                                ConnectionState::Disconnected => {
-                                                    ui.colored_label(Color32::GRAY, "Disconnected")
-                                                }
-                                                ConnectionState::Connecting => ui.colored_label(
-                                                    log_colors::WARNING_LIGHT,
-                                                    "Connecting",
-                                                ),
-                                                ConnectionState::Connected => {
-                                                    ui.colored_label(theme::OK_GREEN, "Connected")
-                                                }
-                                                ConnectionState::Streaming => {
-                                                    ui.colored_label(theme::OK_GREEN, "Streaming")
-                                                }
-                                                ConnectionState::Disconnecting { .. } => ui
-                                                    .colored_label(
-                                                        log_colors::WARNING_LIGHT,
-                                                        "Disconnecting",
-                                                    ),
-                                            },
+                                            |ui| connection_label(ui, &data.connection_state),
                                         );
                                     });
 
@@ -292,4 +273,16 @@ fn trusted_clients_section(
         });
 
     request
+}
+
+fn connection_label(ui: &mut Ui, connection_state: &ConnectionState) {
+    match connection_state {
+        ConnectionState::Disconnected => ui.colored_label(Color32::GRAY, "Disconnected"),
+        ConnectionState::Connecting => ui.colored_label(log_colors::WARNING_LIGHT, "Connecting"),
+        ConnectionState::Connected => ui.colored_label(theme::OK_GREEN, "Connected"),
+        ConnectionState::Streaming => ui.colored_label(theme::OK_GREEN, "Streaming"),
+        ConnectionState::Disconnecting { .. } => {
+            ui.colored_label(log_colors::WARNING_LIGHT, "Disconnecting")
+        }
+    };
 }

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -150,6 +150,9 @@ impl eframe::App for Dashboard {
                 EventType::AudioDevices(list) => self.settings_tab.update_audio_devices(list),
                 #[cfg(not(target_arch = "wasm32"))]
                 EventType::DriversList(list) => self.installation_tab.update_drivers(list),
+                EventType::Adb(adb_event) => self
+                    .connections_tab
+                    .update_adb_download_progress(adb_event.download_progress),
                 _ => (),
             }
         }

--- a/alvr/events/src/lib.rs
+++ b/alvr/events/src/lib.rs
@@ -76,6 +76,11 @@ pub struct HapticsEvent {
     pub amplitude: f32,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct AdbEvent {
+    pub download_progress: f32,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "id", content = "data")]
 pub enum EventType {
@@ -90,6 +95,7 @@ pub enum EventType {
     AudioDevices(AudioDevicesList),
     DriversList(Vec<PathBuf>),
     ServerRequestsSelfRestart,
+    Adb(AdbEvent),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -117,6 +123,7 @@ impl Event {
             EventType::AudioDevices(_) => "AUDIO DEV".to_string(),
             EventType::DriversList(_) => "DRV LIST".to_string(),
             EventType::ServerRequestsSelfRestart => "RESTART".to_string(),
+            EventType::Adb(_) => "ADB".to_string(),
         }
     }
 
@@ -133,6 +140,7 @@ impl Event {
             EventType::AudioDevices(devices) => serde_json::to_string(devices).unwrap(),
             EventType::DriversList(drivers) => serde_json::to_string(drivers).unwrap(),
             EventType::ServerRequestsSelfRestart => "Request for server restart".into(),
+            EventType::Adb(adb) => serde_json::to_string(adb).unwrap(),
         }
     }
 }

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -347,7 +347,6 @@ pub enum ClientListAction {
     AddIfMissing {
         trusted: bool,
         manual_ips: Vec<IpAddr>,
-        wired: bool,
     },
     SetDisplayName(String),
     Trust,

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -131,7 +131,7 @@ pub struct NegotiatedStreamingConfig {
     pub use_multimodal_protocol: bool,
     pub encoding_gamma: f32,
     pub enable_hdr: bool,
-    pub wired: Option<bool>,
+    pub wired: bool,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -355,7 +355,6 @@ pub enum ClientListAction {
     RemoveEntry,
     UpdateCurrentIp(Option<IpAddr>),
     SetConnectionState(ConnectionState),
-    SetWiredMode(bool),
 }
 
 #[derive(Serialize, Deserialize, Default, Clone)]

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -131,6 +131,7 @@ pub struct NegotiatedStreamingConfig {
     pub use_multimodal_protocol: bool,
     pub encoding_gamma: f32,
     pub enable_hdr: bool,
+    pub wired: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -174,6 +175,7 @@ pub fn decode_stream_config(packet: &StreamConfigPacket) -> Result<StreamConfig>
         json::from_value(negotiated_json["use_multimodal_protocol"].clone()).unwrap_or(false);
     let encoding_gamma = json::from_value(negotiated_json["encoding_gamma"].clone()).unwrap_or(1.0);
     let enable_hdr = json::from_value(negotiated_json["enable_hdr"].clone()).unwrap_or(false);
+    let wired = json::from_value(negotiated_json["wired"].clone())?;
 
     Ok(StreamConfig {
         server_version: session_config.server_version,
@@ -186,6 +188,7 @@ pub fn decode_stream_config(packet: &StreamConfigPacket) -> Result<StreamConfig>
             use_multimodal_protocol,
             encoding_gamma,
             enable_hdr,
+            wired,
         },
     })
 }
@@ -344,6 +347,7 @@ pub enum ClientListAction {
     AddIfMissing {
         trusted: bool,
         manual_ips: Vec<IpAddr>,
+        wired: bool,
     },
     SetDisplayName(String),
     Trust,
@@ -351,6 +355,7 @@ pub enum ClientListAction {
     RemoveEntry,
     UpdateCurrentIp(Option<IpAddr>),
     SetConnectionState(ConnectionState),
+    SetWiredMode(bool),
 }
 
 #[derive(Serialize, Deserialize, Default, Clone)]

--- a/alvr/server_core/Cargo.toml
+++ b/alvr/server_core/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["rlib", "cdylib"]
 trace-performance = ["profiling/profile-with-tracy"]
 
 [dependencies]
+alvr_adb.workspace = true
 alvr_audio.workspace = true
 alvr_common.workspace = true
 alvr_events.workspace = true

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -24,11 +24,12 @@ use alvr_packets::{
     VideoPacketHeader, AUDIO, HAPTICS, STATISTICS, TRACKING, VIDEO,
 };
 use alvr_session::{
-    BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize, H264Profile,
-    OpenvrConfig, SessionConfig,
+    BodyTrackingConfig, BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize,
+    H264Profile, OpenvrConfig, SessionConfig, SocketProtocol,
 };
 use alvr_sockets::{
-    PeerType, ProtoControlSocket, StreamSocketBuilder, KEEPALIVE_INTERVAL, KEEPALIVE_TIMEOUT,
+    PeerType, ProtoControlSocket, StreamSocketBuilder, CONTROL_PORT, KEEPALIVE_INTERVAL,
+    KEEPALIVE_TIMEOUT,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -272,7 +273,9 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
                     }
                     Some(layout) => layout,
                 };
-                if let Err(e) = alvr_adb::setup_wired_connection(layout) {
+                let stream_port = SESSION_MANAGER.read().settings().connection.stream_port;
+                if let Err(e) = alvr_adb::setup_wired_connection(layout, CONTROL_PORT, stream_port)
+                {
                     error!("{e:?}");
                     thread::sleep(RETRY_CONNECT_MIN_INTERVAL);
                     continue;

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -285,8 +285,7 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
                     }
                 };
                 dbg_connection!("Found adb executable: {adb_path:?}");
-                let devices: Vec<alvr_adb::device::Device> = match alvr_adb::list_devices(&adb_path)
-                {
+                let devices = match alvr_adb::list_devices(&adb_path) {
                     Err(e) => {
                         error!("Failed to list adb devices: {e:?}");
                         thread::sleep(RETRY_CONNECT_MIN_INTERVAL);
@@ -300,10 +299,7 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
                         thread::sleep(RETRY_CONNECT_MIN_INTERVAL);
                         continue;
                     };
-                    match alvr_adb::list_forwarded_ports::<Vec<ForwardedPort>>(
-                        &adb_path,
-                        &device_serial,
-                    ) {
+                    match alvr_adb::list_forwarded_ports(&adb_path, &device_serial) {
                         Err(e) => error!(
                             "Failed to list forwarded ports of device {device_serial}: {e:?}"
                         ),

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -290,7 +290,11 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
                         thread::sleep(RETRY_CONNECT_MIN_INTERVAL);
                         continue;
                     }
-                    Ok(devices) => devices,
+                    Ok(devices) => devices.into_iter().filter(|d| {
+                        d.serial
+                            .as_ref()
+                            .is_some_and(|s| !s.starts_with("127.0.0.1"))
+                    }),
                 };
                 let ports = [9943, 9944];
                 for device in devices {

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -262,17 +262,10 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
                         && hostname.as_str() == WIRED_CLIENT_HOSTNAME
                 })
         {
-            let Some(layout) = FILESYSTEM_LAYOUT.get() else {
-                error!("Failed to get filesystem layout");
-                thread::sleep(RETRY_CONNECT_MIN_INTERVAL);
-                continue;
-            };
-            let stream_port = SESSION_MANAGER.read().settings().connection.stream_port;
-
             let maybe_status = alvr_adb::setup_wired_connection(
-                layout,
+                &FILESYSTEM_LAYOUT,
+                &SESSION_MANAGER,
                 CONTROL_PORT,
-                stream_port,
                 |downloaded, maybe_total| {
                     if let Some(total) = maybe_total {
                         alvr_events::send_event(EventType::Adb(alvr_events::AdbEvent {

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -268,7 +268,9 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
                     Some(path) => path,
                     None => {
                         dbg_connection!("Couldn't find adb, installing it...");
-                        if let Err(e) = alvr_adb::install_adb() {
+                        if let Err(e) = alvr_adb::install_adb(|downloaded, total| {
+                            dbg_connection!("Downloaded {downloaded:?} bytes of {total:?}");
+                        }) {
                             error!("Failed to install adb: {e:?}");
                             thread::sleep(RETRY_CONNECT_MIN_INTERVAL);
                             continue;

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -268,6 +268,7 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
                 continue;
             };
             let stream_port = SESSION_MANAGER.read().settings().connection.stream_port;
+
             let maybe_status = alvr_adb::setup_wired_connection(
                 layout,
                 CONTROL_PORT,
@@ -288,12 +289,15 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
                 }
                 Ok(status) => status,
             };
+
             adb_server_started = true;
+
             if let WiredConnectionStatus::NotReady(m) = status {
                 dbg_connection!("handshake_loop: Wired connection not ready: {m}");
                 thread::sleep(RETRY_CONNECT_MIN_INTERVAL);
                 continue;
             }
+
             let client_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
             wired_client_ips.insert(client_ip, client_hostname.to_owned());
         }

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -24,15 +24,15 @@ use alvr_packets::{
     VideoPacketHeader, AUDIO, HAPTICS, STATISTICS, TRACKING, VIDEO,
 };
 use alvr_session::{
-    BodyTrackingConfig, BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize,
-    H264Profile, OpenvrConfig, SessionConfig, SocketProtocol,
+    BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize, H264Profile,
+    OpenvrConfig, SessionConfig,
 };
 use alvr_sockets::{
     PeerType, ProtoControlSocket, StreamSocketBuilder, CONTROL_PORT, KEEPALIVE_INTERVAL,
     KEEPALIVE_TIMEOUT,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     net::{IpAddr, Ipv4Addr},
     process::Command,
     sync::{mpsc::RecvTimeoutError, Arc},

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -682,7 +682,7 @@ fn connection_pipeline(
             0
         };
 
-    let wired = Some(client_ip.is_loopback());
+    let wired = client_ip.is_loopback();
 
     dbg_connection!("connection_pipeline: send streaming config");
     let stream_config_packet = alvr_packets::encode_stream_config(

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -281,7 +281,6 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
                             download_progress: downloaded as f32 / total as f32,
                         }));
                     };
-                    Ok(())
                 },
             ) {
                 Err(e) => {

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -205,7 +205,6 @@ impl ServerSessionManager {
             ClientListAction::AddIfMissing {
                 trusted,
                 manual_ips,
-                wired,
             } => {
                 if let Entry::Vacant(new_entry) = maybe_client_entry {
                     let client_connection_desc = ClientConnectionConfig {
@@ -214,7 +213,6 @@ impl ServerSessionManager {
                         manual_ips: manual_ips.into_iter().collect(),
                         trusted,
                         connection_state: ConnectionState::Disconnected,
-                        wired,
                     };
                     new_entry.insert(client_connection_desc);
 

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -205,6 +205,7 @@ impl ServerSessionManager {
             ClientListAction::AddIfMissing {
                 trusted,
                 manual_ips,
+                wired,
             } => {
                 if let Entry::Vacant(new_entry) = maybe_client_entry {
                     let client_connection_desc = ClientConnectionConfig {
@@ -213,7 +214,7 @@ impl ServerSessionManager {
                         manual_ips: manual_ips.into_iter().collect(),
                         trusted,
                         connection_state: ConnectionState::Disconnected,
-                        cabled: false,
+                        wired,
                     };
                     new_entry.insert(client_connection_desc);
 
@@ -264,6 +265,13 @@ impl ServerSessionManager {
 
                         updated = true;
                     }
+                }
+            }
+            ClientListAction::SetWiredMode(wired) => {
+                if let Entry::Occupied(mut entry) = maybe_client_entry {
+                    entry.get_mut().wired = wired;
+
+                    updated = true;
                 }
             }
         }

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -267,13 +267,6 @@ impl ServerSessionManager {
                     }
                 }
             }
-            ClientListAction::SetWiredMode(wired) => {
-                if let Entry::Occupied(mut entry) = maybe_client_entry {
-                    entry.get_mut().wired = wired;
-
-                    updated = true;
-                }
-            }
         }
 
         if updated {

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -129,7 +129,6 @@ pub struct ClientConnectionConfig {
     pub manual_ips: HashSet<IpAddr>,
     pub trusted: bool,
     pub connection_state: ConnectionState,
-    pub wired: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -129,7 +129,7 @@ pub struct ClientConnectionConfig {
     pub manual_ips: HashSet<IpAddr>,
     pub trusted: bool,
     pub connection_state: ConnectionState,
-    pub cabled: bool,
+    pub wired: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/alvr/sockets/src/lib.rs
+++ b/alvr/sockets/src/lib.rs
@@ -23,6 +23,8 @@ pub const MDNS_SERVICE_TYPE: &str = "_alvr._tcp.local.";
 pub const MDNS_PROTOCOL_KEY: &str = "protocol";
 pub const MDNS_DEVICE_ID_KEY: &str = "device_id";
 
+pub const WIRED_CLIENT_HOSTNAME: &str = "client.wired";
+
 fn set_socket_buffers(
     socket: &socket2::Socket,
     send_buffer_bytes: SocketBufferSize,


### PR DESCRIPTION
This PR adds a toggle for wired connections in the "Devices" tab. When enabled, ALVR manages the forwarding of the required ports using `adb`. If a system installation of `adb` is present, it will be used, falling back to downloading and installing a local copy otherwise.

Closes #567, closes #2349.