### PR TITLE
Create iptables folder during firewall set up if it doesn't exist.

### DIFF
--- a/alvr/xtask/firewall/alvr_fw_config.sh
+++ b/alvr/xtask/firewall/alvr_fw_config.sh
@@ -60,6 +60,10 @@ iptables_cfg() {
     second_port_match_count=$(iptables -S | grep -c '9944')
     if [ "${1}" == 'add' ]; then
         if [ "$first_port_match_count" == "0" ] || [ "$second_port_match_count" == "0" ]; then
+            if [ ! -d '/etc/iptables' ]; then
+                mkdir '/etc/iptables'
+            fi
+
             iptables -I OUTPUT -p tcp --sport 9943 -j ACCEPT
             iptables -I INPUT -p tcp --dport 9943 -j ACCEPT
             iptables -I OUTPUT -p udp --sport 9943 -j ACCEPT


### PR DESCRIPTION
The /etc/iptables doesn't always exist (like in Pop_OS! for me). Create it if necessary. 