### PR TITLE
Publish tracking data through VMC Protocol

### DIFF
--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -23,7 +23,7 @@ use alvr_events::{EventType, TrackingEvent};
 use alvr_packets::{FaceData, Tracking};
 use alvr_session::{
     settings_schema::Switch, BodyTrackingConfig, HeadsetConfig, PositionRecenteringMode,
-    RotationRecenteringMode, Settings, VMCConfig, 
+    RotationRecenteringMode, Settings, VMCConfig,
 };
 use alvr_sockets::StreamReceiver;
 use std::{
@@ -331,9 +331,7 @@ pub fn tracking_loop(
         .headset
         .vmc
         .into_option()
-        .and_then(|config| {
-            VMCSink::new(config.sink).ok()
-        });
+        .and_then(|config| VMCSink::new(config.sink).ok());
 
     while is_streaming() {
         let data = match tracking_receiver.recv(STREAMING_RECV_TIMEOUT) {
@@ -488,17 +486,17 @@ pub fn tracking_loop(
         if publish_vmc {
             if let Some(sink) = &mut vmc_sink {
                 let tracking_manager_lock = ctx.tracking_manager.read();
-                let device_motions =  device_motion_keys
-                .iter()
-                .filter_map(move |id| {
-                    Some((
-                        *id,
-                        tracking_manager_lock
-                            .get_device_motion(*id, timestamp)
-                            .unwrap(),
-                    ))
-                })
-                .collect::<Vec<(u64, DeviceMotion)>>();
+                let device_motions = device_motion_keys
+                    .iter()
+                    .filter_map(move |id| {
+                        Some((
+                            *id,
+                            tracking_manager_lock
+                                .get_device_motion(*id, timestamp)
+                                .unwrap(),
+                        ))
+                    })
+                    .collect::<Vec<(u64, DeviceMotion)>>();
                 sink.send_tracking(&device_motions);
             }
         }

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -492,14 +492,14 @@ pub fn tracking_loop(
                 .iter()
                 .filter_map(move |id| {
                     Some((
-                        (*DEVICE_ID_TO_PATH.get(id)?).into(),
+                        *id,
                         tracking_manager_lock
                             .get_device_motion(*id, timestamp)
                             .unwrap(),
                     ))
                 })
-                .collect::<Vec<(String, DeviceMotion)>>();
-                sink.send_tracking(device_motions);
+                .collect::<Vec<(u64, DeviceMotion)>>();
+                sink.send_tracking(&device_motions);
             }
         }
 

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -331,7 +331,7 @@ pub fn tracking_loop(
         .headset
         .vmc
         .into_option()
-        .and_then(|config| VMCSink::new(config.sink).ok());
+        .and_then(|config| VMCSink::new(config).ok());
 
     while is_streaming() {
         let data = match tracking_receiver.recv(STREAMING_RECV_TIMEOUT) {

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -505,6 +505,13 @@ pub fn tracking_loop(
                         ))
                     })
                     .collect::<Vec<(u64, DeviceMotion)>>();
+
+                if let Some(skeleton) = tracking.hand_skeletons[0] {
+                    sink.send_hand_tracking(HandType::Left, skeleton, orientation_correction);
+                }
+                if let Some(skeleton) = tracking.hand_skeletons[1] {
+                    sink.send_hand_tracking(HandType::Right, skeleton, orientation_correction);
+                }
                 sink.send_tracking(&device_motions, orientation_correction);
             }
         }

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -484,6 +484,14 @@ pub fn tracking_loop(
             Switch::Enabled(VMCConfig { publish: true, .. })
         );
         if publish_vmc {
+            let orientation_correction = matches!(
+                SESSION_MANAGER.read().settings().headset.vmc,
+                Switch::Enabled(VMCConfig {
+                    orientation_correction: true,
+                    ..
+                })
+            );
+
             if let Some(sink) = &mut vmc_sink {
                 let tracking_manager_lock = ctx.tracking_manager.read();
                 let device_motions = device_motion_keys
@@ -497,7 +505,7 @@ pub fn tracking_loop(
                         ))
                     })
                     .collect::<Vec<(u64, DeviceMotion)>>();
-                sink.send_tracking(&device_motions);
+                sink.send_tracking(&device_motions, orientation_correction);
             }
         }
 

--- a/alvr/server_core/src/tracking/vmc.rs
+++ b/alvr/server_core/src/tracking/vmc.rs
@@ -4,6 +4,8 @@ use alvr_common::{
 use rosc::{OscMessage, OscPacket, OscType};
 use std::{collections::HashMap, net::UdpSocket};
 
+use alvr_session::VMCSinkConfig;
+
 // Transform DeviceMotion into Unity HumanBodyBones
 // https://docs.unity3d.com/ScriptReference/HumanBodyBones.html
 static DEVICE_MOTIONS_VMC_MAP: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
@@ -23,21 +25,15 @@ static DEVICE_MOTIONS_VMC_MAP: Lazy<HashMap<&'static str, &'static str>> = Lazy:
 });
 
 pub struct VMCSink {
-//    config: VMCConfig,
     socket: Option<UdpSocket>,
 }
 
 impl VMCSink {
-    pub fn new(
-            //config: VMCSinkConfig
-            ) -> Result<Self> {
-
-        // TODO: Configure Target IP and Target Port (default 127.0.0.1:39540)
+    pub fn new(config: VMCSinkConfig) -> Result<Self> {
         let socket = UdpSocket::bind("0.0.0.0:0")?;
-        socket.connect("127.0.0.1:39540")?;
+        socket.connect(format!("{}:{}", config.host, config.port))?;
 
         Ok(Self {
-//            config,
             socket: Some(socket),
         })
     }

--- a/alvr/server_core/src/tracking/vmc.rs
+++ b/alvr/server_core/src/tracking/vmc.rs
@@ -6,7 +6,7 @@ use alvr_common::{
 use rosc::{OscMessage, OscPacket, OscType};
 use std::{collections::HashMap, net::UdpSocket};
 
-use alvr_session::VMCSinkConfig;
+use alvr_session::VMCConfig;
 
 // Transform DeviceMotion into Unity HumanBodyBones
 // https://docs.unity3d.com/ScriptReference/HumanBodyBones.html
@@ -31,7 +31,7 @@ pub struct VMCSink {
 }
 
 impl VMCSink {
-    pub fn new(config: VMCSinkConfig) -> Result<Self> {
+    pub fn new(config: VMCConfig) -> Result<Self> {
         let socket = UdpSocket::bind("0.0.0.0:0")?;
         socket.connect(format!("{}:{}", config.host, config.port))?;
 

--- a/alvr/server_core/src/tracking/vmc.rs
+++ b/alvr/server_core/src/tracking/vmc.rs
@@ -54,10 +54,7 @@ impl VMCSink {
         }
     }
 
-    pub fn send_tracking(
-        &mut self,
-        device_motions: &[(u64, DeviceMotion)],
-    ) {
+    pub fn send_tracking(&mut self, device_motions: &[(u64, DeviceMotion)]) {
         for (id, motion) in device_motions {
             if DEVICE_MOTIONS_VMC_MAP.contains_key(id) {
                 self.send_osc_message(

--- a/alvr/server_core/src/tracking/vmc.rs
+++ b/alvr/server_core/src/tracking/vmc.rs
@@ -1,0 +1,82 @@
+use alvr_common::{
+    anyhow::Result, once_cell::sync::Lazy, DeviceMotion
+};
+use rosc::{OscMessage, OscPacket, OscType};
+use std::{collections::HashMap, net::UdpSocket};
+
+// Transform DeviceMotion into Unity HumanBodyBones
+// https://docs.unity3d.com/ScriptReference/HumanBodyBones.html
+static DEVICE_MOTIONS_VMC_MAP: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+    HashMap::from([
+        ("/user/hand/left", "LeftHand"),
+        ("/user/hand/right", "RightHand"),
+        ("/user/body/chest", "Chest"),
+        ("/user/body/waist", "Hips"), //???
+        ("/user/body/left_elbow", "LeftLowerArm"),
+        ("/user/body/right_elbow", "RightLowerArm"),
+        ("/user/body/left_knee", "LeftLowerLeg"),
+        ("/user/body/right_knee", "RightLowerLeg"),
+        ("/user/body/left_foot", "LeftFoot"),
+        ("/user/body/right_foot", "RightFoot"),
+        ("/user/head", "Head"),
+    ])
+});
+
+pub struct VMCSink {
+//    config: VMCConfig,
+    socket: Option<UdpSocket>,
+}
+
+impl VMCSink {
+    pub fn new(
+            //config: VMCSinkConfig
+            ) -> Result<Self> {
+
+        // TODO: Configure Target IP and Target Port (default 127.0.0.1:39540)
+        let socket = UdpSocket::bind("0.0.0.0:0")?;
+        socket.connect("127.0.0.1:39540")?;
+
+        Ok(Self {
+//            config,
+            socket: Some(socket),
+        })
+    }
+
+    fn send_osc_message(&self, path: &str, args: Vec<OscType>) {
+        if let Some(socket) = &self.socket {
+            socket
+                .send(
+                    &rosc::encoder::encode(&OscPacket::Message(OscMessage {
+                        addr: path.into(),
+                        args,
+                    }))
+                    .unwrap(),
+                )
+                .ok();
+        }
+    }
+
+    pub fn send_tracking(
+        &mut self,
+        device_motions: Vec<(String, DeviceMotion)>,
+    ) {
+        for (id, motion) in device_motions {
+            let sid = id.as_str();
+            if DEVICE_MOTIONS_VMC_MAP.contains_key(sid) {
+                self.send_osc_message(
+                    "/VMC/Ext/Bone/Pos",
+                    vec![
+                        OscType::String(DEVICE_MOTIONS_VMC_MAP.get(sid).unwrap().to_string()),
+                        OscType::Float(motion.pose.position.x),
+                        OscType::Float(motion.pose.position.y),
+                        OscType::Float(motion.pose.position.z),
+                        OscType::Float(motion.pose.orientation.x),
+                        OscType::Float(motion.pose.orientation.y),
+                        OscType::Float(motion.pose.orientation.z),
+                        OscType::Float(motion.pose.orientation.w),
+                    ],
+                );
+            }
+        }
+    }
+}

--- a/alvr/server_core/src/tracking/vmc.rs
+++ b/alvr/server_core/src/tracking/vmc.rs
@@ -32,75 +32,39 @@ static DEVICE_MOTIONS_ROTATION_MAP: Lazy<HashMap<u64, Quat>> = Lazy::new(|| {
     HashMap::from([
         (
             *HAND_LEFT_ID,
-            Quat::from_xyzw(
-                -6.213430570750633e-08,
-                -1.7979416426202113e-07,
-                0.7071067411992601,
-                0.7071065897770331,
-            ),
+            Quat::from_xyzw(-0.03538, 0.25483, -0.00000, -0.96634),
         ),
         (
             *HAND_RIGHT_ID,
-            Quat::from_xyzw(
-                0.3219087189747184,
-                0.7288832784221684,
-                0.3392694392278636,
-                -0.4999999512887856,
-            ),
+            Quat::from_xyzw(-0.05859, -0.20524, -0.00000, 0.97696),
         ),
         (
             *BODY_CHEST_ID,
-            Quat::from_xyzw(
-                -0.48548752779498533,
-                0.5137675867233772,
-                -0.5131288074683715,
-                -0.4868713724975375,
-            ),
+            Quat::from_xyzw(-0.49627, 0.49516, -0.43469, -0.56531),
         ),
         (
             *BODY_HIPS_ID,
-            Quat::from_xyzw(
-                -0.38920734358587283,
-                0.4731761921254787,
-                -0.25037835650145845,
-                -0.7496216673275858,
-            ),
+            Quat::from_xyzw(-0.49274, 0.49568, -0.42416, -0.57584),
+        ),
+        (
+            *BODY_RIGHT_ELBOW_ID,
+            Quat::from_xyzw(-0.63465, -0.11567, 0.00000, 0.76410),
         ),
         (
             *BODY_LEFT_KNEE_ID,
-            Quat::from_xyzw(
-                0.42592041950463216,
-                0.5417784481730453,
-                0.3880448422573891,
-                -0.6119550893141193,
-            ),
+            Quat::from_xyzw(0.51049, 0.47862, 0.42815, -0.57185),
         ),
         (
             *BODY_LEFT_FOOT_ID,
-            Quat::from_xyzw(
-                -0.15405857492497116,
-                0.6901198926998461,
-                -2.2748115460768936e-08,
-                -0.7071068140641757,
-            ),
+            Quat::from_xyzw(-0.59103, 0.38818, 0.00000, -0.70711),
         ),
         (
             *BODY_RIGHT_KNEE_ID,
-            Quat::from_xyzw(
-                -0.4650211913041333,
-                0.5058610693118244,
-                -0.6180250915435218,
-                -0.381974687482609,
-            ),
+            Quat::from_xyzw(-0.52823, 0.45434, -0.58530, -0.41470),
         ),
         (
             *BODY_RIGHT_FOOT_ID,
-            Quat::from_xyzw(
-                0.6815561983146281,
-                -0.18836473838436454,
-                0.7071065841771154,
-                5.6213965690665724e-08,
-            ),
+            Quat::from_xyzw(0.70228, -0.08246, 0.70711, 0.00000),
         ),
     ])
 });
@@ -110,24 +74,8 @@ static HAND_SKELETON_VMC_MAP: Lazy<[[(usize, &'static str); 1]; 2]> =
 
 static HAND_SKELETON_ROTATIONS: Lazy<[HashMap<usize, Quat>; 2]> = Lazy::new(|| {
     [
-        HashMap::from([(
-            0,
-            Quat::from_xyzw(
-                -6.213430570750633e-08,
-                -1.7979416426202113e-07,
-                0.7071067411992601,
-                0.7071065897770331,
-            ),
-        )]),
-        HashMap::from([(
-            0,
-            Quat::from_xyzw(
-                0.3219087189747184,
-                0.7288832784221684,
-                0.3392694392278636,
-                -0.4999999512887856,
-            ),
-        )]),
+        HashMap::from([(0, Quat::from_xyzw(-0.03566, 0.25481, 0.00000, -0.96633))]),
+        HashMap::from([(0, Quat::from_xyzw(-0.05880, -0.20574, -0.00000, 0.97684))]),
     ]
 });
 
@@ -162,7 +110,7 @@ impl VMCSink {
     pub fn send_hand_tracking(
         &mut self,
         hand_type: HandType,
-        mut skeleton: [Pose; 26],
+        skeleton: [Pose; 26],
         orientation_correction: bool,
     ) {
         let hand_id = hand_type as usize;

--- a/alvr/server_core/src/tracking/vmc.rs
+++ b/alvr/server_core/src/tracking/vmc.rs
@@ -131,12 +131,16 @@ impl VMCSink {
         }
     }
 
-    pub fn send_tracking(&mut self, device_motions: &[(u64, DeviceMotion)]) {
+    pub fn send_tracking(
+        &mut self,
+        device_motions: &[(u64, DeviceMotion)],
+        orientation_correction: bool,
+    ) {
         for (id, motion) in device_motions {
             if DEVICE_MOTIONS_VMC_MAP.contains_key(id) {
                 let corrected_orientation = {
                     let mut q = motion.pose.orientation;
-                    if true {
+                    if orientation_correction {
                         if DEVICE_MOTIONS_ROTATION_MAP.contains_key(id) {
                             q *= *DEVICE_MOTIONS_ROTATION_MAP.get(id).unwrap();
                         }

--- a/alvr/server_core/src/tracking/vmc.rs
+++ b/alvr/server_core/src/tracking/vmc.rs
@@ -56,7 +56,7 @@ static DEVICE_MOTIONS_ROTATION_MAP: Lazy<HashMap<u64, Quat>> = Lazy::new(|| {
         ),
         (
             *BODY_LEFT_FOOT_ID,
-            Quat::from_xyzw(-0.59103, 0.38818, 0.00000, -0.70711),
+            Quat::from_xyzw(-0.59103, 0.38818, 0.00000, -0.7071100),
         ),
         (
             *BODY_RIGHT_KNEE_ID,
@@ -64,7 +64,7 @@ static DEVICE_MOTIONS_ROTATION_MAP: Lazy<HashMap<u64, Quat>> = Lazy::new(|| {
         ),
         (
             *BODY_RIGHT_FOOT_ID,
-            Quat::from_xyzw(0.70228, -0.08246, 0.70711, 0.00000),
+            Quat::from_xyzw(0.70228, -0.08246, 0.7071100, 0.00000),
         ),
     ])
 });

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -740,16 +740,11 @@ pub struct BodyTrackingConfig {
     pub tracked: bool,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
-pub struct VMCSinkConfig {
-    pub host: String,
-    pub port: u16,
-}
-
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 #[schema(collapsible)]
 pub struct VMCConfig {
-    pub sink: VMCSinkConfig,
+    pub host: String,
+    pub port: u16,
     #[schema(strings(help = "Turn this off to temporarily pause sending data."))]
     #[schema(flag = "real-time")]
     pub publish: bool,
@@ -1588,10 +1583,8 @@ pub fn session_settings_default() -> SettingsDefault {
                 enabled: false,
                 content: VMCConfigDefault {
                     gui_collapsed: true,
-                    sink: VMCSinkConfigDefault {
-                        host: "127.0.0.1".into(),
-                        port: 39540,
-                    },
+                    host: "127.0.0.1".into(),
+                    port: 39540,
                     publish: true,
                 },
             },

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -740,6 +740,21 @@ pub struct BodyTrackingConfig {
     pub tracked: bool,
 }
 
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
+pub struct VMCSinkConfig {
+    pub host: String,
+    pub port: u16,
+}
+
+#[derive(SettingsSchema, Serialize, Deserialize, Clone)]
+#[schema(collapsible)]
+pub struct VMCConfig {
+    pub sink: VMCSinkConfig,
+    #[schema(strings(help = "Turn this off to temporarily pause sending data."))]
+    #[schema(flag = "real-time")]
+    pub publish: bool,
+}
+
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum ControllersEmulationMode {
     #[schema(strings(display_name = "Rift S Touch"))]
@@ -1037,6 +1052,10 @@ Tilted: the world gets tilted when long pressing the oculus button. This is usef
 
     #[schema(flag = "steamvr-restart")]
     pub body_tracking: Switch<BodyTrackingConfig>,
+
+    #[schema(flag = "steamvr-restart")]
+    #[schema(strings(display_name = "VMC"))]
+    pub vmc: Switch<VMCConfig>,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, Copy)]
@@ -1563,6 +1582,17 @@ pub fn session_settings_default() -> SettingsDefault {
                         variant: BodyTrackingSinkConfigDefaultVariant::FakeViveTracker,
                     },
                     tracked: true,
+                },
+            },
+            vmc: SwitchDefault {
+                enabled: false,
+                content: VMCConfigDefault {
+                    gui_collapsed: true,
+                    sink: VMCSinkConfigDefault {
+                        host: "127.0.0.1".into(),
+                        port: 39540,
+                    },
+                    publish: true,
                 },
             },
             controllers: SwitchDefault {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1586,7 +1586,7 @@ pub fn session_settings_default() -> SettingsDefault {
                 content: VMCConfigDefault {
                     gui_collapsed: true,
                     host: "127.0.0.1".into(),
-                    port: 39540,
+                    port: 39539,
                     publish: true,
                     orientation_correction: true,
                 },

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -748,6 +748,8 @@ pub struct VMCConfig {
     #[schema(strings(help = "Turn this off to temporarily pause sending data."))]
     #[schema(flag = "real-time")]
     pub publish: bool,
+    #[schema(flag = "real-time")]
+    pub orientation_correction: bool,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -1586,6 +1588,7 @@ pub fn session_settings_default() -> SettingsDefault {
                     host: "127.0.0.1".into(),
                     port: 39540,
                     publish: true,
+                    orientation_correction: true,
                 },
             },
             controllers: SwitchDefault {


### PR DESCRIPTION
The [VMC Protocol](https://protocol.vmc.info/english.html) is a protocol to send motion tracking data through OSC for avatar motion applications. It's implemented in software like [VSeeFace](https://www.vseeface.icu/#vmc-protocol-support) and [others](https://protocol.vmc.info/Reference).

Here is a test of it being used through the inochi-session app 

https://github.com/user-attachments/assets/30a7f535-a077-46f8-857e-924c8bf60ed5