### PR TITLE
feat-fix(server_openvr): Add timewarped compositing to Windows OpenVR compositor

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/HMD.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/HMD.cpp
@@ -322,7 +322,9 @@ void Hmd::SetViewsConfig(FfiViewsConfig config) {
     vr::VRServerDriverHost()->SetDisplayProjectionRaw(object_id, left_proj, right_proj);
 
 #ifdef _WIN32
-    m_directModeComponent->SetViewsConfig(left_proj, left_transform, right_proj, right_transform);
+    if (m_encoder) {
+        m_encoder->SetViewsConfig(left_proj, left_transform, right_proj, right_transform);
+    }
 #endif
 
     // todo: check if this is still needed

--- a/alvr/server_openvr/cpp/alvr_server/HMD.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/HMD.cpp
@@ -321,7 +321,9 @@ void Hmd::SetViewsConfig(FfiViewsConfig config) {
 
     vr::VRServerDriverHost()->SetDisplayProjectionRaw(object_id, left_proj, right_proj);
 
+#ifdef _WIN32
     m_directModeComponent->SetViewsConfig(left_proj, left_transform, right_proj, right_transform);
+#endif
 
     // todo: check if this is still needed
     vr::VRServerDriverHost()->VendorSpecificEvent(

--- a/alvr/server_openvr/cpp/alvr_server/HMD.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/HMD.cpp
@@ -307,6 +307,9 @@ void Hmd::SetViewsConfig(FfiViewsConfig config) {
 
     this->views_config = config;
 
+    // The OpenXR spec defines the HMD position as the midpoint
+    // between the eyes, so conversion to this is handled by the
+    // client.
     auto left_transform = MATRIX_IDENTITY;
     left_transform.m[0][3] = -config.ipd_m / 2.0;
     auto right_transform = MATRIX_IDENTITY;
@@ -317,6 +320,8 @@ void Hmd::SetViewsConfig(FfiViewsConfig config) {
     auto right_proj = fov_to_projection(config.fov[1]);
 
     vr::VRServerDriverHost()->SetDisplayProjectionRaw(object_id, left_proj, right_proj);
+
+    m_directModeComponent->SetViewsConfig(left_proj, left_transform, right_proj, right_transform);
 
     // todo: check if this is still needed
     vr::VRServerDriverHost()->VendorSpecificEvent(

--- a/alvr/server_openvr/cpp/platform/win32/CEncoder.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/CEncoder.cpp
@@ -80,6 +80,9 @@ void CEncoder::Initialize(std::shared_ptr<CD3DRender> d3dRender) {
 bool CEncoder::CopyToStaging(
     ID3D11Texture2D* pTexture[][2],
     vr::VRTextureBounds_t bounds[][2],
+    vr::HmdMatrix34_t poses[][2],
+    vr::HmdRect2_t viewProj[2],
+    vr::HmdMatrix34_t eyeToHead[2],
     int layerCount,
     bool recentering,
     uint64_t presentationTime,
@@ -91,7 +94,7 @@ bool CEncoder::CopyToStaging(
     m_targetTimestampNs = targetTimestampNs;
     m_FrameRender->Startup();
 
-    m_FrameRender->RenderFrame(pTexture, bounds, layerCount, recentering, message, debugText);
+    m_FrameRender->RenderFrame(pTexture, bounds, poses, viewProj, eyeToHead, layerCount, recentering, message, debugText);
     return true;
 }
 

--- a/alvr/server_openvr/cpp/platform/win32/CEncoder.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/CEncoder.cpp
@@ -77,12 +77,19 @@ void CEncoder::Initialize(std::shared_ptr<CD3DRender> d3dRender) {
 #endif
 }
 
+void CEncoder::SetViewsConfig(
+    vr::HmdRect2_t projLeft,
+    vr::HmdMatrix34_t eyeToHeadLeft,
+    vr::HmdRect2_t projRight,
+    vr::HmdMatrix34_t eyeToHeadRight
+) {
+    m_FrameRender->SetViewsConfig(projLeft, eyeToHeadLeft, projRight, eyeToHeadRight);
+}
+
 bool CEncoder::CopyToStaging(
     ID3D11Texture2D* pTexture[][2],
     vr::VRTextureBounds_t bounds[][2],
     vr::HmdMatrix34_t poses[],
-    vr::HmdRect2_t viewProj[2],
-    vr::HmdMatrix34_t eyeToHead[2],
     int layerCount,
     bool recentering,
     uint64_t presentationTime,
@@ -95,7 +102,7 @@ bool CEncoder::CopyToStaging(
     m_FrameRender->Startup();
 
     m_FrameRender->RenderFrame(
-        pTexture, bounds, poses, viewProj, eyeToHead, layerCount, recentering, message, debugText
+        pTexture, bounds, poses, layerCount, recentering, message, debugText
     );
     return true;
 }

--- a/alvr/server_openvr/cpp/platform/win32/CEncoder.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/CEncoder.cpp
@@ -80,7 +80,7 @@ void CEncoder::Initialize(std::shared_ptr<CD3DRender> d3dRender) {
 bool CEncoder::CopyToStaging(
     ID3D11Texture2D* pTexture[][2],
     vr::VRTextureBounds_t bounds[][2],
-    vr::HmdMatrix34_t poses[][2],
+    vr::HmdMatrix34_t poses[],
     vr::HmdRect2_t viewProj[2],
     vr::HmdMatrix34_t eyeToHead[2],
     int layerCount,
@@ -94,7 +94,9 @@ bool CEncoder::CopyToStaging(
     m_targetTimestampNs = targetTimestampNs;
     m_FrameRender->Startup();
 
-    m_FrameRender->RenderFrame(pTexture, bounds, poses, viewProj, eyeToHead, layerCount, recentering, message, debugText);
+    m_FrameRender->RenderFrame(
+        pTexture, bounds, poses, viewProj, eyeToHead, layerCount, recentering, message, debugText
+    );
     return true;
 }
 

--- a/alvr/server_openvr/cpp/platform/win32/CEncoder.h
+++ b/alvr/server_openvr/cpp/platform/win32/CEncoder.h
@@ -36,6 +36,9 @@ public:
     bool CopyToStaging(
         ID3D11Texture2D* pTexture[][2],
         vr::VRTextureBounds_t bounds[][2],
+        vr::HmdMatrix34_t poses[][2],
+        vr::HmdRect2_t viewProj[2],
+        vr::HmdMatrix34_t eyeToHead[2],
         int layerCount,
         bool recentering,
         uint64_t presentationTime,

--- a/alvr/server_openvr/cpp/platform/win32/CEncoder.h
+++ b/alvr/server_openvr/cpp/platform/win32/CEncoder.h
@@ -33,12 +33,17 @@ public:
 
     void Initialize(std::shared_ptr<CD3DRender> d3dRender);
 
+    void SetViewsConfig(
+        vr::HmdRect2_t projLeft,
+        vr::HmdMatrix34_t eyeToHeadLeft,
+        vr::HmdRect2_t projRight,
+        vr::HmdMatrix34_t eyeToHeadRight
+    );
+
     bool CopyToStaging(
         ID3D11Texture2D* pTexture[][2],
         vr::VRTextureBounds_t bounds[][2],
         vr::HmdMatrix34_t poses[],
-        vr::HmdRect2_t viewProj[2],
-        vr::HmdMatrix34_t eyeToHead[2],
         int layerCount,
         bool recentering,
         uint64_t presentationTime,

--- a/alvr/server_openvr/cpp/platform/win32/CEncoder.h
+++ b/alvr/server_openvr/cpp/platform/win32/CEncoder.h
@@ -36,7 +36,7 @@ public:
     bool CopyToStaging(
         ID3D11Texture2D* pTexture[][2],
         vr::VRTextureBounds_t bounds[][2],
-        vr::HmdMatrix34_t poses[][2],
+        vr::HmdMatrix34_t poses[],
         vr::HmdRect2_t viewProj[2],
         vr::HmdMatrix34_t eyeToHead[2],
         int layerCount,

--- a/alvr/server_openvr/cpp/platform/win32/FrameRender.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/FrameRender.cpp
@@ -713,8 +713,6 @@ bool FrameRender::RenderFrame(
         DirectX::XMFLOAT4 vertsL[4];
         DirectX::XMFLOAT4 vertsR[4];
 
-        // Debugging quad if 0, useful for sorting out issues
-#if 1
         DirectX::XMVECTORF32 vertsL_VF32[4]
             = { { { { -1.0f * -viewProj[0].vTopLeft.v[0] * depth * m,
                       1.0f * -viewProj[0].vTopLeft.v[1] * depth * m,
@@ -732,21 +730,13 @@ bool FrameRender::RenderFrame(
                       -1.0f * viewProj[0].vBottomRight.v[1] * depth * m,
                       -depth,
                       1.0f } } } };
-#else
-        DirectX::XMVECTORF32 vertsL_VF32[4]
-            = { { { { -1.0f * depth * m, 1.0f * depth * m, -depth, 1.0f } } },
-                { { { 1.0f * depth * m, -1.0f * depth * m, -depth, 1.0f } } },
-                { { { 1.0f * depth * m, 1.0f * depth * m, -depth, 1.0f } } },
-                { { { -1.0f * depth * m, -1.0f * depth * m, -depth, 1.0f } } } };
-#endif
+
         for (int i = 0; i < 4; i++) {
             DirectX::XMStoreFloat4(
                 &vertsL[i], DirectX::XMVector3Transform(vertsL_VF32[i], transformMatL)
             );
         }
 
-        // Debugging quad if 0, useful for sorting out issues
-#if 1
         DirectX::XMVECTORF32 vertsR_VF32[4]
             = { { { { -1.0f * -viewProj[1].vTopLeft.v[0] * depth * m,
                       1.0f * -viewProj[1].vTopLeft.v[1] * depth * m,
@@ -764,13 +754,7 @@ bool FrameRender::RenderFrame(
                       -1.0f * viewProj[1].vBottomRight.v[1] * depth * m,
                       -depth,
                       1.0f } } } };
-#else
-        DirectX::XMVECTORF32 vertsR_VF32[4]
-            = { { { { -1.0f * depth * m, 1.0f * depth * m, -depth, 1.0f } } },
-                { { { 1.0f * depth * m, -1.0f * depth * m, -depth, 1.0f } } },
-                { { { 1.0f * depth * m, 1.0f * depth * m, -depth, 1.0f } } },
-                { { { -1.0f * depth * m, -1.0f * depth * m, -depth, 1.0f } } } };
-#endif
+
         for (int i = 0; i < 4; i++) {
             DirectX::XMStoreFloat4(
                 &vertsR[i], DirectX::XMVector3Transform(vertsR_VF32[i], transformMatR)

--- a/alvr/server_openvr/cpp/platform/win32/FrameRender.h
+++ b/alvr/server_openvr/cpp/platform/win32/FrameRender.h
@@ -48,6 +48,9 @@ public:
     bool RenderFrame(
         ID3D11Texture2D* pTexture[][2],
         vr::VRTextureBounds_t bounds[][2],
+        vr::HmdMatrix34_t poses[][2],
+        vr::HmdRect2_t viewProj[2],
+        vr::HmdMatrix34_t eyeToHead[2],
         int layerCount,
         bool recentering,
         const std::string& message,
@@ -74,6 +77,7 @@ private:
     ComPtr<ID3D11Texture2D> m_pDepthStencil;
     ComPtr<ID3D11RenderTargetView> m_pRenderTargetView;
     ComPtr<ID3D11DepthStencilView> m_pDepthStencilView;
+    ComPtr<ID3D11DepthStencilState> m_depthStencilState;
 
     ComPtr<ID3D11BlendState> m_pBlendStateFirst;
     ComPtr<ID3D11BlendState> m_pBlendState;
@@ -84,7 +88,7 @@ private:
     ComPtr<ID3D11ShaderResourceView> m_messageBGResourceView;
 
     struct SimpleVertex {
-        DirectX::XMFLOAT3 Pos;
+        DirectX::XMFLOAT4 Pos;
         DirectX::XMFLOAT2 Tex;
         uint32_t View;
     };

--- a/alvr/server_openvr/cpp/platform/win32/FrameRender.h
+++ b/alvr/server_openvr/cpp/platform/win32/FrameRender.h
@@ -48,7 +48,7 @@ public:
     bool RenderFrame(
         ID3D11Texture2D* pTexture[][2],
         vr::VRTextureBounds_t bounds[][2],
-        vr::HmdMatrix34_t poses[][2],
+        vr::HmdMatrix34_t poses[],
         vr::HmdRect2_t viewProj[2],
         vr::HmdMatrix34_t eyeToHead[2],
         int layerCount,
@@ -74,10 +74,11 @@ private:
 
     ComPtr<ID3D11SamplerState> m_pSamplerLinear;
 
-    ComPtr<ID3D11Texture2D> m_pDepthStencil;
     ComPtr<ID3D11RenderTargetView> m_pRenderTargetView;
-    ComPtr<ID3D11DepthStencilView> m_pDepthStencilView;
     ComPtr<ID3D11DepthStencilState> m_depthStencilState;
+
+    D3D11_VIEWPORT m_viewportL, m_viewportR, m_viewport;
+    D3D11_RECT m_scissorL, m_scissorR, m_scissor;
 
     ComPtr<ID3D11BlendState> m_pBlendStateFirst;
     ComPtr<ID3D11BlendState> m_pBlendState;

--- a/alvr/server_openvr/cpp/platform/win32/FrameRender.h
+++ b/alvr/server_openvr/cpp/platform/win32/FrameRender.h
@@ -45,12 +45,16 @@ public:
     virtual ~FrameRender();
 
     bool Startup();
+    void SetViewsConfig(
+        vr::HmdRect2_t projLeft,
+        vr::HmdMatrix34_t eyeToHeadLeft,
+        vr::HmdRect2_t projRight,
+        vr::HmdMatrix34_t eyeToHeadRight
+    );
     bool RenderFrame(
         ID3D11Texture2D* pTexture[][2],
         vr::VRTextureBounds_t bounds[][2],
         vr::HmdMatrix34_t poses[],
-        vr::HmdRect2_t viewProj[2],
-        vr::HmdMatrix34_t eyeToHead[2],
         int layerCount,
         bool recentering,
         const std::string& message,
@@ -87,6 +91,9 @@ private:
     ComPtr<ID3D11ShaderResourceView> m_recenterResourceView;
     ComPtr<ID3D11Resource> m_messageBGTexture;
     ComPtr<ID3D11ShaderResourceView> m_messageBGResourceView;
+
+    vr::HmdRect2_t m_viewProj[2];
+    vr::HmdMatrix34_t m_eyeToHead[2];
 
     struct SimpleVertex {
         DirectX::XMFLOAT4 Pos;

--- a/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
@@ -173,8 +173,8 @@ void OvrDirectModeComponent::SubmitLayer(const SubmitLayerPerEye_t (&perEye)[2])
 
     m_presentMutex.lock();
 
-    // mHmdPose is the same pose for both eyes, getting the view pose requires
-    // some records keeping, unfortunately (m_eyeToHead)
+    // mHmdPose is the same pose for both eyes, getting the eye view pose
+    //  requires some records keeping, unfortunately (m_eyeToHead)
     auto pPose = &perEye[0].mHmdPose;
 
     if (m_submitLayer == 0) {

--- a/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
@@ -5,27 +5,10 @@ OvrDirectModeComponent::OvrDirectModeComponent(
 )
     : m_pD3DRender(pD3DRender)
     , m_poseHistory(poseHistory)
-    , m_submitLayer(0) {
-    HmdMatrix_SetIdentity(&m_eyeToHead[0]);
-    HmdMatrix_SetIdentity(&m_eyeToHead[1]);
-    m_viewProj[0] = { -1.0f, 1.0f, 1.0f, -1.0f };
-    m_viewProj[1] = { -1.0f, 1.0f, 1.0f, -1.0f };
-}
+    , m_submitLayer(0) { }
 
 void OvrDirectModeComponent::SetEncoder(std::shared_ptr<CEncoder> pEncoder) {
     m_pEncoder = pEncoder;
-}
-
-void OvrDirectModeComponent::SetViewsConfig(
-    vr::HmdRect2_t projLeft,
-    vr::HmdMatrix34_t eyeToHeadLeft,
-    vr::HmdRect2_t projRight,
-    vr::HmdMatrix34_t eyeToHeadRight
-) {
-    m_viewProj[0] = projLeft;
-    m_eyeToHead[0] = eyeToHeadLeft;
-    m_viewProj[1] = projRight;
-    m_eyeToHead[1] = eyeToHeadRight;
 }
 
 /** Specific to Oculus compositor support, textures supplied must be created using this method. */
@@ -351,8 +334,6 @@ void OvrDirectModeComponent::CopyTexture(uint32_t layerCount) {
             pTexture,
             bounds,
             poses,
-            m_viewProj,
-            m_eyeToHead,
             layerCount,
             false,
             presentationTime,

--- a/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.h
+++ b/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.h
@@ -16,7 +16,12 @@ public:
 
     void SetEncoder(std::shared_ptr<CEncoder> pEncoder);
 
-    void SetViewsConfig(vr::HmdRect2_t projLeft, vr::HmdMatrix34_t eyeToHeadLeft, vr::HmdRect2_t projRight, vr::HmdMatrix34_t eyeToHeadRight);
+    void SetViewsConfig(
+        vr::HmdRect2_t projLeft,
+        vr::HmdMatrix34_t eyeToHeadLeft,
+        vr::HmdRect2_t projRight,
+        vr::HmdMatrix34_t eyeToHeadRight
+    );
 
     /** Specific to Oculus compositor support, textures supplied must be created using this method.
      */

--- a/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.h
+++ b/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.h
@@ -16,6 +16,8 @@ public:
 
     void SetEncoder(std::shared_ptr<CEncoder> pEncoder);
 
+    void SetViewsConfig(vr::HmdRect2_t projLeft, vr::HmdMatrix34_t eyeToHeadLeft, vr::HmdRect2_t projRight, vr::HmdMatrix34_t eyeToHeadRight);
+
     /** Specific to Oculus compositor support, textures supplied must be created using this method.
      */
     virtual void CreateSwapTextureSet(
@@ -70,6 +72,9 @@ private:
     vr::HmdQuaternion_t m_framePoseRotation;
     uint64_t m_targetTimestampNs;
     uint64_t m_prevTargetTimestampNs;
+
+    vr::HmdRect2_t m_viewProj[2];
+    vr::HmdMatrix34_t m_eyeToHead[2];
 
     std::mutex m_presentMutex;
 };

--- a/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.h
+++ b/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.h
@@ -16,13 +16,6 @@ public:
 
     void SetEncoder(std::shared_ptr<CEncoder> pEncoder);
 
-    void SetViewsConfig(
-        vr::HmdRect2_t projLeft,
-        vr::HmdMatrix34_t eyeToHeadLeft,
-        vr::HmdRect2_t projRight,
-        vr::HmdMatrix34_t eyeToHeadRight
-    );
-
     /** Specific to Oculus compositor support, textures supplied must be created using this method.
      */
     virtual void CreateSwapTextureSet(
@@ -77,9 +70,6 @@ private:
     vr::HmdQuaternion_t m_framePoseRotation;
     uint64_t m_targetTimestampNs;
     uint64_t m_prevTargetTimestampNs;
-
-    vr::HmdRect2_t m_viewProj[2];
-    vr::HmdMatrix34_t m_eyeToHead[2];
 
     std::mutex m_presentMutex;
 };


### PR DESCRIPTION
Fixes juddery menus on Riven, and possibly judder on other OpenXR apps (HUDs, 2D menus, text, etc rendered at higher resolutions are the most likely candidates).

[Before](https://youtu.be/cuP-xulPFYY) vs [After](https://youtu.be/ShsK4-j5hZQ)

**tl;dr on compositing**
- To composite with timewarp, we need three things: The exact view poses the layer frame was rendered at, the headset's per-eye view frustum tangents, and a renderer which can render a quad with positions/sizes in meters.
  - FrameRender is now passed the pose of each layer, the view tangents, and the eye transforms to make this happen.
- The layer's quad is centered at 0,0 and extended 1 unit out in each direction, and then each direction is multiplied by the view tangents.
  - Each layer's quad is projected forward by 700m (to "infinity") and scaled proportionally, to remove small positional differences from IPD and the user's head rotation.
  - If the layer is at the exact current view position (which is always the case for layer 0), it will be projected pixel-perfect onto the framebuffer.
  - Layers indices >=1 only ever seem to appear in OpenXR-based titles, I think OpenVR started compositing its app layers into layer 0 on our behalf within the last 6 months (the dashboard used to be juddery as well).
- For simplicity, and to make debugging a bit easier, I did all the vertex math on the CPU with the DirectX math functions (it's only 8 vertices and DirectX has SIMD support anyway).
  - I also split the draw command into two calls with different viewports/scissor rects, since the quads could cross between eyes after the transform
- Also I removed the depth buffer for now, since we were not actually using it. If we ever decide to try and get fancy with depth buffers we can add it back I guess.