### PR TITLE
feat: :sparkles: Reduce session file length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "bindgen 0.70.1",
  "cc",
  "pkg-config",
+ "serde_json",
  "walkdir",
 ]
 

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -14,7 +14,7 @@ use alvr_common::{
     warn, DeviceMotion, Fov, OptLazy, Pose,
 };
 use alvr_packets::{ButtonEntry, ButtonValue, FaceData, ViewParams};
-use alvr_session::{CodecType, FoveatedEncodingConfig, MediacodecDataType};
+use alvr_session::{CodecType, FoveatedEncodingConfig, MediacodecPropType, MediacodecProperty};
 use std::{
     cell::RefCell,
     ffi::{c_char, c_void, CStr, CString},
@@ -880,25 +880,29 @@ pub extern "C" fn alvr_create_decoder(config: AlvrDecoderConfig) {
                 .iter()
                 .map(|option| unsafe {
                     let key = CStr::from_ptr(option.key).to_str().unwrap();
-                    let value = match option.ty {
-                        AlvrMediacodecPropType::Float => {
-                            MediacodecDataType::Float(option.value.float_)
-                        }
-                        AlvrMediacodecPropType::Int32 => {
-                            MediacodecDataType::Int32(option.value.int32)
-                        }
-                        AlvrMediacodecPropType::Int64 => {
-                            MediacodecDataType::Int64(option.value.int64)
-                        }
-                        AlvrMediacodecPropType::String => MediacodecDataType::String(
-                            CStr::from_ptr(option.value.string)
+                    let prop = match option.ty {
+                        AlvrMediacodecPropType::Float => MediacodecProperty {
+                            ty: MediacodecPropType::Float,
+                            value: option.value.float_.to_string(),
+                        },
+                        AlvrMediacodecPropType::Int32 => MediacodecProperty {
+                            ty: MediacodecPropType::Int32,
+                            value: option.value.int32.to_string(),
+                        },
+                        AlvrMediacodecPropType::Int64 => MediacodecProperty {
+                            ty: MediacodecPropType::Int64,
+                            value: option.value.int64.to_string(),
+                        },
+                        AlvrMediacodecPropType::String => MediacodecProperty {
+                            ty: MediacodecPropType::String,
+                            value: CStr::from_ptr(option.value.string)
                                 .to_str()
                                 .unwrap()
                                 .to_owned(),
-                        ),
+                        },
                     };
 
-                    (key.to_string(), value)
+                    (key.to_owned(), prop)
                 })
                 .collect()
         } else {

--- a/alvr/client_core/src/video_decoder/mod.rs
+++ b/alvr/client_core/src/video_decoder/mod.rs
@@ -2,7 +2,7 @@
 mod android;
 
 use alvr_common::anyhow::Result;
-use alvr_session::{CodecType, MediacodecDataType};
+use alvr_session::{CodecType, MediacodecProperty};
 use std::time::Duration;
 
 #[derive(Clone, Default, PartialEq)]
@@ -11,7 +11,7 @@ pub struct VideoDecoderConfig {
     pub force_software_decoder: bool,
     pub max_buffering_frames: f32,
     pub buffering_history_weight: f32,
-    pub options: Vec<(String, MediacodecDataType)>,
+    pub options: Vec<(String, MediacodecProperty)>,
     pub config_buffer: Vec<u8>,
 }
 

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -17,7 +17,7 @@ use alvr_common::{
 use alvr_packets::{FaceData, StreamConfig, ViewParams};
 use alvr_session::{
     BodyTrackingSourcesConfig, ClientsideFoveationConfig, ClientsideFoveationMode, CodecType,
-    FaceTrackingSourcesConfig, FoveatedEncodingConfig, MediacodecDataType,
+    FaceTrackingSourcesConfig, FoveatedEncodingConfig, MediacodecProperty,
 };
 use openxr as xr;
 use std::{
@@ -44,7 +44,7 @@ pub struct ParsedStreamConfig {
     pub force_software_decoder: bool,
     pub max_buffering_frames: f32,
     pub buffering_history_weight: f32,
-    pub decoder_options: Vec<(String, MediacodecDataType)>,
+    pub decoder_options: Vec<(String, MediacodecProperty)>,
 }
 
 impl ParsedStreamConfig {

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -804,12 +804,14 @@ fn connection_pipeline(
 
                     #[cfg(windows)]
                     if let Ok(id) = alvr_audio::get_windows_device_id(&device) {
+                        let prop = alvr_session::OpenvrProperty {
+                            key: alvr_session::OpenvrPropKey::AudioDefaultPlaybackDeviceIdString,
+                            value: id,
+                        };
                         ctx.events_sender
                             .send(ServerCoreEvent::SetOpenvrProperty {
                                 device_id: *alvr_common::HEAD_ID,
-                                prop: alvr_session::OpenvrProperty::AudioDefaultPlaybackDeviceId(
-                                    id,
-                                ),
+                                prop,
                             })
                             .ok();
                     } else {
@@ -833,12 +835,14 @@ fn connection_pipeline(
                     if let Ok(id) = AudioDevice::new_output(None)
                         .and_then(|d| alvr_audio::get_windows_device_id(&d))
                     {
+                        let prop = alvr_session::OpenvrProperty {
+                            key: alvr_session::OpenvrPropKey::AudioDefaultPlaybackDeviceIdString,
+                            value: id,
+                        };
                         ctx.events_sender
                             .send(ServerCoreEvent::SetOpenvrProperty {
                                 device_id: *alvr_common::HEAD_ID,
-                                prop: alvr_session::OpenvrProperty::AudioDefaultPlaybackDeviceId(
-                                    id,
-                                ),
+                                prop,
                             })
                             .ok();
                     }
@@ -861,7 +865,10 @@ fn connection_pipeline(
             ctx.events_sender
                 .send(ServerCoreEvent::SetOpenvrProperty {
                     device_id: *alvr_common::HEAD_ID,
-                    prop: alvr_session::OpenvrProperty::AudioDefaultRecordingDeviceId(id),
+                    prop: alvr_session::OpenvrProperty {
+                        key: alvr_session::OpenvrPropKey::AudioDefaultRecordingDeviceIdString,
+                        value: id,
+                    },
                 })
                 .ok();
         }

--- a/alvr/server_openvr/Cargo.toml
+++ b/alvr/server_openvr/Cargo.toml
@@ -20,6 +20,8 @@ alvr_server_core.workspace = true
 alvr_server_io.workspace = true
 alvr_session.workspace = true
 
+serde_json = "1"
+
 [build-dependencies]
 alvr_filesystem = { path = "../filesystem" }
 bindgen = "0.70"

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -72,9 +72,9 @@ extern "C" fn driver_ready_idle(set_default_chap: bool) {
             };
 
             match event {
-                ServerCoreEvent::SetOpenvrProperty { device_id, prop } => unsafe {
-                    SetOpenvrProperty(device_id, props::to_ffi_openvr_prop(prop))
-                },
+                ServerCoreEvent::SetOpenvrProperty { device_id, prop } => {
+                    props::set_openvr_prop(device_id, prop)
+                }
                 ServerCoreEvent::ClientConnected => {
                     unsafe {
                         InitializeStreaming();

--- a/alvr/server_openvr/src/props.rs
+++ b/alvr/server_openvr/src/props.rs
@@ -8,43 +8,72 @@ use crate::{
     FfiOpenvrPropertyType_Uint64, FfiOpenvrPropertyType_Vector3, FfiOpenvrPropertyValue,
 };
 use alvr_common::{
-    info, settings_schema::Switch, BODY_CHEST_ID, BODY_HIPS_ID, BODY_LEFT_ELBOW_ID,
+    debug, settings_schema::Switch, warn, BODY_CHEST_ID, BODY_HIPS_ID, BODY_LEFT_ELBOW_ID,
     BODY_LEFT_FOOT_ID, BODY_LEFT_KNEE_ID, BODY_RIGHT_ELBOW_ID, BODY_RIGHT_FOOT_ID,
-    BODY_RIGHT_KNEE_ID, HAND_LEFT_ID, HAND_RIGHT_ID, HAND_TRACKER_LEFT_ID, HAND_TRACKER_RIGHT_ID,
-    HEAD_ID,
+    BODY_RIGHT_KNEE_ID, DEVICE_ID_TO_PATH, HAND_LEFT_ID, HAND_RIGHT_ID, HAND_TRACKER_LEFT_ID,
+    HAND_TRACKER_RIGHT_ID, HEAD_ID,
 };
 use alvr_session::{
-    ControllersEmulationMode, HeadsetEmulationMode, OpenvrPropValue, OpenvrProperty,
+    ControllersEmulationMode, HeadsetEmulationMode, OpenvrPropKey, OpenvrPropType, OpenvrProperty,
 };
 use std::{
     ffi::{c_char, CString},
     ptr,
 };
 
-pub fn to_ffi_openvr_prop(prop: OpenvrProperty) -> FfiOpenvrProperty {
-    let (key, value) = prop.into_key_value();
+pub fn set_openvr_prop(device_id: u64, prop: OpenvrProperty) {
+    let key = prop.key as u32;
+    let ty = alvr_session::openvr_prop_key_to_type(prop.key);
+    let value = prop.value.clone();
 
-    let type_ = match value {
-        OpenvrPropValue::Bool(_) => FfiOpenvrPropertyType_Bool,
-        OpenvrPropValue::Float(_) => FfiOpenvrPropertyType_Float,
-        OpenvrPropValue::Int32(_) => FfiOpenvrPropertyType_Int32,
-        OpenvrPropValue::Uint64(_) => FfiOpenvrPropertyType_Uint64,
-        OpenvrPropValue::Vector3(_) => FfiOpenvrPropertyType_Vector3,
-        OpenvrPropValue::Double(_) => FfiOpenvrPropertyType_Double,
-        OpenvrPropValue::String(_) => FfiOpenvrPropertyType_String,
-    };
+    let device_name = DEVICE_ID_TO_PATH.get(&device_id).unwrap_or(&"Unknown");
 
-    let value = match value {
-        OpenvrPropValue::Bool(bool_) => FfiOpenvrPropertyValue {
-            bool_: bool_.into(),
-        },
-        OpenvrPropValue::Float(float_) => FfiOpenvrPropertyValue { float_ },
-        OpenvrPropValue::Int32(int32) => FfiOpenvrPropertyValue { int32 },
-        OpenvrPropValue::Uint64(uint64) => FfiOpenvrPropertyValue { uint64 },
-        OpenvrPropValue::Vector3(vector3) => FfiOpenvrPropertyValue { vector3 },
-        OpenvrPropValue::Double(double_) => FfiOpenvrPropertyValue { double_ },
-        OpenvrPropValue::String(value) => {
-            let c_string = CString::new(value).unwrap();
+    let (type_, maybe_value) = match ty {
+        OpenvrPropType::Bool => (
+            FfiOpenvrPropertyType_Bool,
+            value
+                .parse::<bool>()
+                .ok()
+                .map(|bool_| FfiOpenvrPropertyValue {
+                    bool_: bool_.into(),
+                }),
+        ),
+        OpenvrPropType::Float => (
+            FfiOpenvrPropertyType_Float,
+            value
+                .parse::<f32>()
+                .ok()
+                .map(|float_| FfiOpenvrPropertyValue { float_ }),
+        ),
+        OpenvrPropType::Int32 => (
+            FfiOpenvrPropertyType_Int32,
+            value
+                .parse::<i32>()
+                .ok()
+                .map(|int32| FfiOpenvrPropertyValue { int32 }),
+        ),
+        OpenvrPropType::Uint64 => (
+            FfiOpenvrPropertyType_Uint64,
+            value
+                .parse::<u64>()
+                .ok()
+                .map(|uint64| FfiOpenvrPropertyValue { uint64 }),
+        ),
+        OpenvrPropType::Vector3 => (
+            FfiOpenvrPropertyType_Vector3,
+            serde_json::from_str::<[f32; 3]>(&value)
+                .ok()
+                .map(|vector3| FfiOpenvrPropertyValue { vector3 }),
+        ),
+        OpenvrPropType::Double => (
+            FfiOpenvrPropertyType_Double,
+            value
+                .parse::<f64>()
+                .ok()
+                .map(|double_| FfiOpenvrPropertyValue { double_ }),
+        ),
+        OpenvrPropType::String => {
+            let c_string = CString::new(value.clone()).unwrap();
             let mut string = [0; 256];
 
             unsafe {
@@ -55,11 +84,31 @@ pub fn to_ffi_openvr_prop(prop: OpenvrProperty) -> FfiOpenvrProperty {
                 );
             }
 
-            FfiOpenvrPropertyValue { string }
+            (
+                FfiOpenvrPropertyType_String,
+                Some(FfiOpenvrPropertyValue { string }),
+            )
         }
     };
 
-    FfiOpenvrProperty { key, type_, value }
+    let Some(ffi_value) = maybe_value else {
+        warn!("Failed to parse {device_name} value for OpenVR property: {key:?}={value}");
+
+        return;
+    };
+
+    debug!("Setting {device_name} OpenVR prop: {key:?}={value}");
+
+    unsafe {
+        crate::SetOpenvrProperty(
+            *HEAD_ID,
+            FfiOpenvrProperty {
+                key,
+                type_,
+                value: ffi_value,
+            },
+        );
+    }
 }
 
 fn serial_number(device_id: u64) -> String {
@@ -134,119 +183,140 @@ pub extern "C" fn get_serial_number(device_id: u64, out_str: *mut c_char) -> u64
 
 #[no_mangle]
 pub extern "C" fn set_device_openvr_props(device_id: u64) {
-    use OpenvrProperty::*;
+    use OpenvrPropKey::*;
 
     let settings = alvr_server_core::settings();
 
-    if device_id == *HEAD_ID {
-        fn set_prop(prop: OpenvrProperty) {
-            info!("Setting head OpenVR prop: {prop:?}");
-            unsafe {
-                crate::SetOpenvrProperty(*HEAD_ID, to_ffi_openvr_prop(prop));
-            }
-        }
+    let set_prop = |key, value: &str| {
+        set_openvr_prop(
+            device_id,
+            OpenvrProperty {
+                key,
+                value: value.into(),
+            },
+        );
+    };
 
+    if device_id == *HEAD_ID {
         match &settings.headset.emulation_mode {
             HeadsetEmulationMode::RiftS => {
-                set_prop(TrackingSystemName("oculus".into()));
-                set_prop(ModelNumber("Oculus Rift S".into()));
-                set_prop(ManufacturerName("Oculus".into()));
-                set_prop(RenderModelName("generic_hmd".into()));
-                set_prop(RegisteredDeviceType("oculus/1WMGH000XX0000".into()));
-                set_prop(DriverVersion("1.42.0".into()));
-                set_prop(NamedIconPathDeviceOff(
-                    "{oculus}/icons/rifts_headset_off.png".into(),
-                ));
-                set_prop(NamedIconPathDeviceSearching(
-                    "{oculus}/icons/rifts_headset_searching.gif".into(),
-                ));
-                set_prop(NamedIconPathDeviceSearchingAlert(
-                    "{oculus}/icons/rifts_headset_alert_searching.gif".into(),
-                ));
-                set_prop(NamedIconPathDeviceReady(
-                    "{oculus}/icons/rifts_headset_ready.png".into(),
-                ));
-                set_prop(NamedIconPathDeviceReadyAlert(
-                    "{oculus}/icons/rifts_headset_ready_alert.png".into(),
-                ));
-                set_prop(NamedIconPathDeviceStandby(
-                    "{oculus}/icons/rifts_headset_standby.png".into(),
-                ));
+                set_prop(TrackingSystemNameString, "oculus");
+                set_prop(ModelNumberString, "Oculus Rift S");
+                set_prop(ManufacturerNameString, "Oculus");
+                set_prop(RenderModelNameString, "generic_hmd");
+                set_prop(RegisteredDeviceTypeString, "oculus/1WMGH000XX0000");
+                set_prop(DriverVersionString, "1.42.0");
+                set_prop(
+                    NamedIconPathDeviceOffString,
+                    "{oculus}/icons/rifts_headset_off.png",
+                );
+                set_prop(
+                    NamedIconPathDeviceSearchingString,
+                    "{oculus}/icons/rifts_headset_searching.gif",
+                );
+                set_prop(
+                    NamedIconPathDeviceSearchingAlertString,
+                    "{oculus}/icons/rifts_headset_alert_searching.gif",
+                );
+                set_prop(
+                    NamedIconPathDeviceReadyString,
+                    "{oculus}/icons/rifts_headset_ready.png",
+                );
+                set_prop(
+                    NamedIconPathDeviceReadyAlertString,
+                    "{oculus}/icons/rifts_headset_ready_alert.png",
+                );
+                set_prop(
+                    NamedIconPathDeviceStandbyString,
+                    "{oculus}/icons/rifts_headset_standby.png",
+                );
             }
             HeadsetEmulationMode::Quest2 => {
-                set_prop(TrackingSystemName("oculus".into()));
-                set_prop(ModelNumber("Miramar".into()));
-                set_prop(ManufacturerName("Oculus".into()));
-                set_prop(RenderModelName("generic_hmd".into()));
-                set_prop(RegisteredDeviceType("oculus/1WMHH000X00000".into()));
-                set_prop(DriverVersion("1.55.0".into()));
-                set_prop(NamedIconPathDeviceOff(
-                    "{oculus}/icons/quest_headset_off.png".into(),
-                ));
-                set_prop(NamedIconPathDeviceSearching(
-                    "{oculus}/icons/quest_headset_searching.gif".into(),
-                ));
-                set_prop(NamedIconPathDeviceSearchingAlert(
-                    "{oculus}/icons/quest_headset_alert_searching.gif".into(),
-                ));
-                set_prop(NamedIconPathDeviceReady(
-                    "{oculus}/icons/quest_headset_ready.png".into(),
-                ));
-                set_prop(NamedIconPathDeviceReadyAlert(
-                    "{oculus}/icons/quest_headset_ready_alert.png".into(),
-                ));
-                set_prop(NamedIconPathDeviceStandby(
-                    "{oculus}/icons/quest_headset_standby.png".into(),
-                ));
+                set_prop(TrackingSystemNameString, "oculus");
+                set_prop(ModelNumberString, "Miramar");
+                set_prop(ManufacturerNameString, "Oculus");
+                set_prop(RenderModelNameString, "generic_hmd");
+                set_prop(RegisteredDeviceTypeString, "oculus/1WMHH000X00000");
+                set_prop(DriverVersionString, "1.55.0");
+                set_prop(
+                    NamedIconPathDeviceOffString,
+                    "{oculus}/icons/quest_headset_off.png",
+                );
+                set_prop(
+                    NamedIconPathDeviceSearchingString,
+                    "{oculus}/icons/quest_headset_searching.gif",
+                );
+                set_prop(
+                    NamedIconPathDeviceSearchingAlertString,
+                    "{oculus}/icons/quest_headset_alert_searching.gif",
+                );
+                set_prop(
+                    NamedIconPathDeviceReadyString,
+                    "{oculus}/icons/quest_headset_ready.png",
+                );
+                set_prop(
+                    NamedIconPathDeviceReadyAlertString,
+                    "{oculus}/icons/quest_headset_ready_alert.png",
+                );
+                set_prop(
+                    NamedIconPathDeviceStandbyString,
+                    "{oculus}/icons/quest_headset_standby.png",
+                );
             }
             HeadsetEmulationMode::Vive => {
-                set_prop(TrackingSystemName("Vive Tracker".into()));
-                set_prop(ModelNumber("ALVR driver server".into()));
-                set_prop(ManufacturerName("HTC".into()));
-                set_prop(RenderModelName("generic_hmd".into()));
-                set_prop(RegisteredDeviceType("vive".into()));
-                set_prop(DriverVersion("".into()));
-                set_prop(NamedIconPathDeviceOff(
-                    "{htc}/icons/vive_headset_status_off.png".into(),
-                ));
-                set_prop(NamedIconPathDeviceSearching(
-                    "{htc}/icons/vive_headset_status_searching.gif".into(),
-                ));
-                set_prop(NamedIconPathDeviceSearchingAlert(
-                    "{htc}/icons/vive_headset_status_searching_alert.gif".into(),
-                ));
-                set_prop(NamedIconPathDeviceReady(
-                    "{htc}/icons/vive_headset_status_ready.png".into(),
-                ));
-                set_prop(NamedIconPathDeviceReadyAlert(
-                    "{htc}/icons/vive_headset_status_ready_alert.png".into(),
-                ));
-                set_prop(NamedIconPathDeviceStandby(
-                    "{htc}/icons/vive_headset_status_standby.png".into(),
-                ));
+                set_prop(TrackingSystemNameString, "Vive Tracker");
+                set_prop(ModelNumberString, "ALVR driver server");
+                set_prop(ManufacturerNameString, "HTC");
+                set_prop(RenderModelNameString, "generic_hmd");
+                set_prop(RegisteredDeviceTypeString, "vive");
+                set_prop(DriverVersionString, "");
+                set_prop(
+                    NamedIconPathDeviceOffString,
+                    "{htc}/icons/vive_headset_status_off.png",
+                );
+                set_prop(
+                    NamedIconPathDeviceSearchingString,
+                    "{htc}/icons/vive_headset_status_searching.gif",
+                );
+                set_prop(
+                    NamedIconPathDeviceSearchingAlertString,
+                    "{htc}/icons/vive_headset_status_searching_alert.gif",
+                );
+                set_prop(
+                    NamedIconPathDeviceReadyString,
+                    "{htc}/icons/vive_headset_status_ready.png",
+                );
+                set_prop(
+                    NamedIconPathDeviceReadyAlertString,
+                    "{htc}/icons/vive_headset_status_ready_alert.png",
+                );
+                set_prop(
+                    NamedIconPathDeviceStandbyString,
+                    "{htc}/icons/vive_headset_status_standby.png",
+                );
             }
             HeadsetEmulationMode::Custom { .. } => (),
         }
 
-        set_prop(UserIpdMeters(0.063));
-        set_prop(UserHeadToEyeDepthMeters(0.0));
-        set_prop(SecondsFromVsyncToPhotons(0.0));
+        set_prop(UserIpdMetersFloat, "0.063");
+        set_prop(UserHeadToEyeDepthMetersFloat, "0.0");
+        set_prop(SecondsFromVsyncToPhotonsFloat, "0.0");
 
         // return a constant that's not 0 (invalid) or 1 (reserved for Oculus)
-        set_prop(CurrentUniverseId(2));
+        set_prop(CurrentUniverseIdUint64, "2");
 
         if cfg!(windows) {
             // avoid "not fullscreen" warnings from vrmonitor
-            set_prop(IsOnDesktop(false));
+            set_prop(IsOnDesktopBool, "false");
 
             // We let SteamVR handle VSyncs. We just wait in PostPresent().
-            set_prop(DriverDirectModeSendsVsyncEvents(false));
+            set_prop(DriverDirectModeSendsVsyncEventsBool, "false");
         }
-        set_prop(DeviceProvidesBatteryStatus(true));
-        set_prop(ContainsProximitySensor(true));
+        set_prop(DeviceProvidesBatteryStatusBool, "true");
+        set_prop(ContainsProximitySensorBool, "true");
 
         for prop in &settings.headset.extra_openvr_props {
-            set_prop(prop.clone());
+            set_prop(prop.key, &prop.value);
         }
     } else if device_id == *HAND_LEFT_ID
         || device_id == *HAND_RIGHT_ID
@@ -256,268 +326,311 @@ pub extern "C" fn set_device_openvr_props(device_id: u64) {
         let left_hand = device_id == *HAND_LEFT_ID || device_id == *HAND_TRACKER_LEFT_ID;
         let right_hand = device_id == *HAND_RIGHT_ID || device_id == *HAND_TRACKER_RIGHT_ID;
         if let Switch::Enabled(config) = &settings.headset.controllers {
-            let set_prop = |prop| {
-                info!(
-                    "Setting {} controller OpenVR prop: {prop:?}",
-                    if left_hand { "left" } else { "right" }
-                );
-                unsafe {
-                    crate::SetOpenvrProperty(device_id, to_ffi_openvr_prop(prop));
-                }
-            };
-
             match config.emulation_mode {
                 ControllersEmulationMode::Quest2Touch => {
-                    set_prop(TrackingSystemName("oculus".into()));
-                    set_prop(ManufacturerName("Oculus".into()));
+                    set_prop(TrackingSystemNameString, "oculus");
+                    set_prop(ManufacturerNameString, "Oculus");
                     if left_hand {
-                        set_prop(ModelNumber("Miramar (Left Controller)".into()));
-                        set_prop(RenderModelName("oculus_quest2_controller_left".into()));
-                        set_prop(RegisteredDeviceType(
-                            "oculus/1WMHH000X00000_Controller_Left".into(),
-                        ));
+                        set_prop(ModelNumberString, "Miramar (Left Controller)");
+                        set_prop(RenderModelNameString, "oculus_quest2_controller_left");
+                        set_prop(
+                            RegisteredDeviceTypeString,
+                            "oculus/1WMHH000X00000_Controller_Left",
+                        );
                     } else if right_hand {
-                        set_prop(ModelNumber("Miramar (Right Controller)".into()));
-                        set_prop(RenderModelName("oculus_quest2_controller_right".into()));
-                        set_prop(RegisteredDeviceType(
-                            "oculus/1WMHH000X00000_Controller_Right".into(),
-                        ));
+                        set_prop(ModelNumberString, "Miramar (Right Controller)");
+                        set_prop(RenderModelNameString, "oculus_quest2_controller_right");
+                        set_prop(
+                            RegisteredDeviceTypeString,
+                            "oculus/1WMHH000X00000_Controller_Right",
+                        );
                     }
-                    set_prop(ControllerType("oculus_touch".into()));
-                    set_prop(InputProfilePath("{oculus}/input/touch_profile.json".into()));
+                    set_prop(ControllerTypeString, "oculus_touch");
+                    set_prop(InputProfilePathString, "{oculus}/input/touch_profile.json");
 
                     if left_hand {
-                        set_prop(NamedIconPathDeviceOff(
-                            "{oculus}/icons/rifts_left_controller_off.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearching(
-                            "{oculus}/icons/rifts_left_controller_searching.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearchingAlert(
-                            "{oculus}/icons/rifts_left_controller_searching_alert.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReady(
-                            "{oculus}/icons/rifts_left_controller_ready.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReadyAlert(
-                            "{oculus}/icons/rifts_left_controller_ready_alert.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceAlertLow(
-                            "{oculus}/icons/rifts_left_controller_ready_low.png".into(),
-                        ));
+                        set_prop(
+                            NamedIconPathDeviceOffString,
+                            "{oculus}/icons/rifts_left_controller_off.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingString,
+                            "{oculus}/icons/rifts_left_controller_searching.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingAlertString,
+                            "{oculus}/icons/rifts_left_controller_searching_alert.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyString,
+                            "{oculus}/icons/rifts_left_controller_ready.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyAlertString,
+                            "{oculus}/icons/rifts_left_controller_ready_alert.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceAlertLowString,
+                            "{oculus}/icons/rifts_left_controller_ready_low.png",
+                        );
                     } else if right_hand {
-                        set_prop(NamedIconPathDeviceOff(
-                            "{oculus}/icons/rifts_right_controller_off.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearching(
-                            "{oculus}/icons/rifts_right_controller_searching.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearchingAlert(
-                            "{oculus}/icons/rifts_right_controller_searching_alert.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReady(
-                            "{oculus}/icons/rifts_right_controller_ready.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReadyAlert(
-                            "{oculus}/icons/rifts_right_controller_ready_alert.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceAlertLow(
-                            "{oculus}/icons/rifts_right_controller_ready_low.png".into(),
-                        ));
+                        set_prop(
+                            NamedIconPathDeviceOffString,
+                            "{oculus}/icons/rifts_right_controller_off.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingString,
+                            "{oculus}/icons/rifts_right_controller_searching.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingAlertString,
+                            "{oculus}/icons/rifts_right_controller_searching_alert.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyString,
+                            "{oculus}/icons/rifts_right_controller_ready.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyAlertString,
+                            "{oculus}/icons/rifts_right_controller_ready_alert.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceAlertLowString,
+                            "{oculus}/icons/rifts_right_controller_ready_low.png",
+                        );
                     }
                 }
                 ControllersEmulationMode::Quest3Plus => {
-                    set_prop(TrackingSystemName("oculus".into()));
-                    set_prop(ManufacturerName("Oculus".into()));
-                    if left_hand {
-                        set_prop(ModelNumber("Meta Quest 3 (Left Controller)".into()));
-                        set_prop(RenderModelName("oculus_quest_plus_controller_left".into()));
-                        set_prop(RegisteredDeviceType(
-                            "oculus/1WMHH000X00000_Controller_Left".into(),
-                        ));
-                    } else if right_hand {
-                        set_prop(ModelNumber("Meta Quest 3 (Right Controller)".into()));
-                        set_prop(RenderModelName("oculus_quest_plus_controller_right".into()));
-                        set_prop(RegisteredDeviceType(
-                            "oculus/1WMHH000X00000_Controller_Right".into(),
-                        ));
-                    }
-                    set_prop(ControllerType("oculus_touch".into()));
-                    set_prop(InputProfilePath("{oculus}/input/touch_profile.json".into()));
+                    set_prop(TrackingSystemNameString, "oculus");
+                    set_prop(ManufacturerNameString, "Oculus");
 
                     if left_hand {
-                        set_prop(NamedIconPathDeviceOff(
-                            "{oculus}/icons/rifts_left_controller_off.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearching(
-                            "{oculus}/icons/rifts_left_controller_searching.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearchingAlert(
-                            "{oculus}/icons/rifts_left_controller_searching_alert.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReady(
-                            "{oculus}/icons/rifts_left_controller_ready.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReadyAlert(
-                            "{oculus}/icons/rifts_left_controller_ready_alert.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceAlertLow(
-                            "{oculus}/icons/rifts_left_controller_ready_low.png".into(),
-                        ));
+                        set_prop(ModelNumberString, "Meta Quest 3 (Left Controller)");
+                        set_prop(RenderModelNameString, "oculus_quest_plus_controller_left");
+                        set_prop(
+                            RegisteredDeviceTypeString,
+                            "oculus/1WMHH000X00000_Controller_Left",
+                        );
                     } else if right_hand {
-                        set_prop(NamedIconPathDeviceOff(
-                            "{oculus}/icons/rifts_right_controller_off.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearching(
-                            "{oculus}/icons/rifts_right_controller_searching.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearchingAlert(
-                            "{oculus}/icons/rifts_right_controller_searching_alert.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReady(
-                            "{oculus}/icons/rifts_right_controller_ready.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReadyAlert(
-                            "{oculus}/icons/rifts_right_controller_ready_alert.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceAlertLow(
-                            "{oculus}/icons/rifts_right_controller_ready_low.png".into(),
-                        ));
+                        set_prop(ModelNumberString, "Meta Quest 3 (Right Controller)");
+                        set_prop(RenderModelNameString, "oculus_quest_plus_controller_right");
+                        set_prop(
+                            RegisteredDeviceTypeString,
+                            "oculus/1WMHH000X00000_Controller_Right",
+                        );
+                    }
+                    set_prop(ControllerTypeString, "oculus_touch");
+                    set_prop(InputProfilePathString, "{oculus}/input/touch_profile.json");
+
+                    if left_hand {
+                        set_prop(
+                            NamedIconPathDeviceOffString,
+                            "{oculus}/icons/rifts_left_controller_off.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingString,
+                            "{oculus}/icons/rifts_left_controller_searching.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingAlertString,
+                            "{oculus}/icons/rifts_left_controller_searching_alert.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyString,
+                            "{oculus}/icons/rifts_left_controller_ready.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyAlertString,
+                            "{oculus}/icons/rifts_left_controller_ready_alert.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceAlertLowString,
+                            "{oculus}/icons/rifts_left_controller_ready_low.png",
+                        );
+                    } else if right_hand {
+                        set_prop(
+                            NamedIconPathDeviceOffString,
+                            "{oculus}/icons/rifts_right_controller_off.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingString,
+                            "{oculus}/icons/rifts_right_controller_searching.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingAlertString,
+                            "{oculus}/icons/rifts_right_controller_searching_alert.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyString,
+                            "{oculus}/icons/rifts_right_controller_ready.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyAlertString,
+                            "{oculus}/icons/rifts_right_controller_ready_alert.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceAlertLowString,
+                            "{oculus}/icons/rifts_right_controller_ready_low.png",
+                        );
                     }
                 }
                 ControllersEmulationMode::RiftSTouch => {
-                    set_prop(TrackingSystemName("oculus".into()));
-                    set_prop(ManufacturerName("Oculus".into()));
+                    set_prop(TrackingSystemNameString, "oculus");
+                    set_prop(ManufacturerNameString, "Oculus");
                     if left_hand {
-                        set_prop(ModelNumber("Oculus Rift S (Left Controller)".into()));
-                        set_prop(RenderModelName("oculus_rifts_controller_left".into()));
-                        set_prop(RegisteredDeviceType(
-                            "oculus/1WMGH000XX0000_Controller_Left".into(),
-                        ));
+                        set_prop(ModelNumberString, "Oculus Rift S (Left Controller)");
+                        set_prop(RenderModelNameString, "oculus_rifts_controller_left");
+                        set_prop(
+                            RegisteredDeviceTypeString,
+                            "oculus/1WMGH000XX0000_Controller_Left",
+                        );
                     } else if right_hand {
-                        set_prop(ModelNumber("Oculus Rift S (Right Controller)".into()));
-                        set_prop(RenderModelName("oculus_rifts_controller_right".into()));
-                        set_prop(RegisteredDeviceType(
-                            "oculus/1WMGH000XX0000_Controller_Right".into(),
-                        ));
+                        set_prop(ModelNumberString, "Oculus Rift S (Right Controller)");
+                        set_prop(RenderModelNameString, "oculus_rifts_controller_right");
+                        set_prop(
+                            RegisteredDeviceTypeString,
+                            "oculus/1WMGH000XX0000_Controller_Right",
+                        );
                     }
-                    set_prop(ControllerType("oculus_touch".into()));
-                    set_prop(InputProfilePath("{oculus}/input/touch_profile.json".into()));
+                    set_prop(ControllerTypeString, "oculus_touch");
+                    set_prop(InputProfilePathString, "{oculus}/input/touch_profile.json");
 
                     if left_hand {
-                        set_prop(NamedIconPathDeviceOff(
-                            "{oculus}/icons/rifts_left_controller_off.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearching(
-                            "{oculus}/icons/rifts_left_controller_searching.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearchingAlert(
-                            "{oculus}/icons/rifts_left_controller_searching_alert.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReady(
-                            "{oculus}/icons/rifts_left_controller_ready.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReadyAlert(
-                            "{oculus}/icons/rifts_left_controller_ready_alert.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceAlertLow(
-                            "{oculus}/icons/rifts_left_controller_ready_low.png".into(),
-                        ));
+                        set_prop(
+                            NamedIconPathDeviceOffString,
+                            "{oculus}/icons/rifts_left_controller_off.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingString,
+                            "{oculus}/icons/rifts_left_controller_searching.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingAlertString,
+                            "{oculus}/icons/rifts_left_controller_searching_alert.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyString,
+                            "{oculus}/icons/rifts_left_controller_ready.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyAlertString,
+                            "{oculus}/icons/rifts_left_controller_ready_alert.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceAlertLowString,
+                            "{oculus}/icons/rifts_left_controller_ready_low.png",
+                        );
                     } else if right_hand {
-                        set_prop(NamedIconPathDeviceOff(
-                            "{oculus}/icons/rifts_right_controller_off.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearching(
-                            "{oculus}/icons/rifts_right_controller_searching.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceSearchingAlert(
-                            "{oculus}/icons/rifts_right_controller_searching_alert.gif".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReady(
-                            "{oculus}/icons/rifts_right_controller_ready.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceReadyAlert(
-                            "{oculus}/icons/rifts_right_controller_ready_alert.png".into(),
-                        ));
-                        set_prop(NamedIconPathDeviceAlertLow(
-                            "{oculus}/icons/rifts_right_controller_ready_low.png".into(),
-                        ));
+                        set_prop(
+                            NamedIconPathDeviceOffString,
+                            "{oculus}/icons/rifts_right_controller_off.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingString,
+                            "{oculus}/icons/rifts_right_controller_searching.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceSearchingAlertString,
+                            "{oculus}/icons/rifts_right_controller_searching_alert.gif",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyString,
+                            "{oculus}/icons/rifts_right_controller_ready.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceReadyAlertString,
+                            "{oculus}/icons/rifts_right_controller_ready_alert.png",
+                        );
+                        set_prop(
+                            NamedIconPathDeviceAlertLowString,
+                            "{oculus}/icons/rifts_right_controller_ready_low.png",
+                        );
                     }
                 }
                 ControllersEmulationMode::ValveIndex => {
-                    set_prop(TrackingSystemName("indexcontroller".into()));
-                    set_prop(ManufacturerName("Valve".into()));
+                    set_prop(TrackingSystemNameString, "indexcontroller");
+                    set_prop(ManufacturerNameString, "Valve");
                     if left_hand {
-                        set_prop(ModelNumber("Knuckles (Left Controller)".into()));
-                        set_prop(RenderModelName(
-                            "{indexcontroller}valve_controller_knu_1_0_left".into(),
-                        ));
-                        set_prop(RegisteredDeviceType(
-                            "valve/index_controllerLHR-E217CD00_Left".into(),
-                        ));
+                        set_prop(ModelNumberString, "Knuckles (Left Controller)");
+                        set_prop(
+                            RenderModelNameString,
+                            "{indexcontroller}valve_controller_knu_1_0_left",
+                        );
+                        set_prop(
+                            RegisteredDeviceTypeString,
+                            "valve/index_controllerLHR-E217CD00_Left",
+                        );
                     } else if right_hand {
-                        set_prop(ModelNumber("Knuckles (Right Controller)".into()));
-                        set_prop(RenderModelName(
-                            "{indexcontroller}valve_controller_knu_1_0_right".into(),
-                        ));
-                        set_prop(RegisteredDeviceType(
-                            "valve/index_controllerLHR-E217CD00_Right".into(),
-                        ));
+                        set_prop(ModelNumberString, "Knuckles (Right Controller)");
+                        set_prop(
+                            RenderModelNameString,
+                            "{indexcontroller}valve_controller_knu_1_0_right",
+                        );
+                        set_prop(
+                            RegisteredDeviceTypeString,
+                            "valve/index_controllerLHR-E217CD00_Right",
+                        );
                     }
-                    set_prop(ControllerType("knuckles".into()));
-                    set_prop(InputProfilePath(
-                        "{indexcontroller}/input/index_controller_profile.json".into(),
-                    ));
+                    set_prop(ControllerTypeString, "knuckles");
+                    set_prop(
+                        InputProfilePathString,
+                        "{indexcontroller}/input/index_controller_profile.json",
+                    );
                 }
                 ControllersEmulationMode::ViveWand => {
-                    set_prop(TrackingSystemName("htc".into()));
-                    set_prop(ManufacturerName("HTC".into()));
-                    set_prop(RenderModelName("vr_controller_vive_1_5".into()));
+                    set_prop(TrackingSystemNameString, "htc");
+                    set_prop(ManufacturerNameString, "HTC");
+                    set_prop(RenderModelNameString, "vr_controller_vive_1_5");
                     if left_hand {
-                        set_prop(ModelNumber(
-                            "ALVR Remote Controller (Left Controller)".into(),
-                        ));
-                        set_prop(RegisteredDeviceType("vive_controller_Left".into()));
+                        set_prop(
+                            ModelNumberString,
+                            "ALVR Remote Controller (Left Controller)",
+                        );
+                        set_prop(RegisteredDeviceTypeString, "vive_controller_Left");
                     } else if right_hand {
-                        set_prop(ModelNumber(
-                            "ALVR Remote Controller (Right Controller)".into(),
-                        ));
-                        set_prop(RegisteredDeviceType("oculus/vive_controller_Right".into()));
+                        set_prop(
+                            ModelNumberString,
+                            "ALVR Remote Controller (Right Controller)",
+                        );
+                        set_prop(RegisteredDeviceTypeString, "oculus/vive_controller_Right");
                     }
-                    set_prop(ControllerType("vive_controller".into()));
-                    set_prop(InputProfilePath("{oculus}/input/touch_profile.json".into()));
+                    set_prop(ControllerTypeString, "vive_controller");
+                    set_prop(InputProfilePathString, "{oculus}/input/touch_profile.json");
                 }
                 ControllersEmulationMode::ViveTracker => {
-                    set_prop(TrackingSystemName("lighthouse".into()));
-                    set_prop(RenderModelName("{htc}vr_tracker_vive_1_0".into()));
+                    set_prop(TrackingSystemNameString, "lighthouse");
+                    set_prop(RenderModelNameString, "{htc}vr_tracker_vive_1_0");
                     if left_hand {
-                        set_prop(ModelNumber("Vive Tracker Pro MV (Left Controller)".into()));
-                        set_prop(RegisteredDeviceType("ALVR/tracker/left_foot".into()));
-                        set_prop(ControllerType("vive_tracker_left_foot".into()));
+                        set_prop(ModelNumberString, "Vive Tracker Pro MV (Left Controller)");
+                        set_prop(RegisteredDeviceTypeString, "ALVR/tracker/left_foot");
+                        set_prop(ControllerTypeString, "vive_tracker_left_foot");
                     } else if right_hand {
-                        set_prop(ModelNumber("Vive Tracker Pro MV (Right Controller)".into()));
-                        set_prop(RegisteredDeviceType("ALVR/tracker/right_foot".into()));
-                        set_prop(ControllerType("vive_tracker_right_foot".into()));
+                        set_prop(ModelNumberString, "Vive Tracker Pro MV (Right Controller)");
+                        set_prop(RegisteredDeviceTypeString, "ALVR/tracker/right_foot");
+                        set_prop(ControllerTypeString, "vive_tracker_right_foot");
                     }
-                    set_prop(InputProfilePath(
-                        "{htc}/input/vive_tracker_profile.json".into(),
-                    ));
+                    set_prop(
+                        InputProfilePathString,
+                        "{htc}/input/vive_tracker_profile.json",
+                    );
 
                     // All of these property values were dumped from real a vive tracker via
                     // https://github.com/SDraw/openvr_dumper and were copied from
                     // https://github.com/SDraw/driver_kinectV2
-                    set_prop(ResourceRoot("htc".into()));
-                    set_prop(WillDriftInYaw(false));
-                    set_prop(TrackingFirmwareVersion(
-                        "1541800000 RUNNER-WATCHMAN$runner-watchman@runner-watchman 2018-01-01 FPGA 512(2.56/0/0) BL 0 VRC 1541800000 Radio 1518800000".into(),
-                    ));
-                    set_prop(HardwareRevisionString(
-                        "product 128 rev 2.5.6 lot 2000/0/0 0".into(),
-                    ));
-                    set_prop(ConnectedWirelessDongle("D0000BE000".into()));
-                    set_prop(DeviceIsWireless(true));
-                    set_prop(DeviceIsCharging(false));
-                    set_prop(ControllerHandSelectionPriority(-1));
+                    set_prop(ResourceRootString, "htc");
+                    set_prop(WillDriftInYawBool, "false");
+                    set_prop(
+                        TrackingFirmwareVersionString,
+                        "1541800000 RUNNER-WATCHMAN$runner-watchman@runner-watchman 2018-01-01 FPGA 512(2.56/0/0) BL 0 VRC 1541800000 Radio 1518800000",
+                    );
+                    set_prop(
+                        HardwareRevisionString,
+                        "product 128 rev 2.5.6 lot 2000/0/0 0",
+                    );
+                    set_prop(ConnectedWirelessDongleString, "D0000BE000");
+                    set_prop(DeviceIsWirelessBool, "true");
+                    set_prop(DeviceIsChargingBool, "false");
+                    set_prop(ControllerHandSelectionPriorityInt32, "-1");
                     // vr::HmdMatrix34_t l_transform = {
                     //     {{-1.f, 0.f, 0.f, 0.f}, {0.f, 0.f, -1.f, 0.f}, {0.f, -1.f, 0.f, 0.f}}};
                     // vr_properties->SetProperty(this->prop_container,
@@ -525,82 +638,90 @@ pub extern "C" fn set_device_openvr_props(device_id: u64) {
                     //                            &l_transform,
                     //                            sizeof(vr::HmdMatrix34_t),
                     //                            vr::k_unHmdMatrix34PropertyTag);
-                    set_prop(FirmwareUpdateAvailable(false));
-                    set_prop(FirmwareManualUpdate(false));
-                    set_prop(FirmwareManualUpdateURL(
-                        "https://developer.valvesoftware.com/wiki/SteamVR/HowTo_Update_Firmware"
-                            .into(),
-                    ));
-                    set_prop(HardwareRevisionUint64(2214720000));
-                    set_prop(FirmwareVersion(1541800000));
-                    set_prop(FPGAVersion(512));
-                    set_prop(VRCVersion(1514800000));
-                    set_prop(RadioVersion(1518800000));
-                    set_prop(DongleVersion(8933539758));
-                    set_prop(DeviceCanPowerOff(true));
+                    set_prop(FirmwareUpdateAvailableBool, "false");
+                    set_prop(FirmwareManualUpdateBool, "false");
+                    set_prop(
+                        FirmwareManualUpdateURLString,
+                        "https://developer.valvesoftware.com/wiki/SteamVR/HowTo_Update_Firmware",
+                    );
+                    set_prop(HardwareRevisionUint64, "2214720000");
+                    set_prop(FirmwareVersionUint64, "1541800000");
+                    set_prop(FPGAVersionUint64, "512");
+                    set_prop(VRCVersionUint64, "1514800000");
+                    set_prop(RadioVersionUint64, "1518800000");
+                    set_prop(DongleVersionUint64, "8933539758");
+                    set_prop(DeviceCanPowerOffBool, "true");
                     // vr_properties->SetStringProperty(this->prop_container,
-                    //                                  vr::Prop_Firmware_ProgrammingTarget_String,
+                    //                                  vr::Prop_Firmware_ProgrammingTargetString,
                     //                                  GetSerialNumber().c_str());
-                    set_prop(FirmwareForceUpdateRequired(false));
-                    set_prop(FirmwareRemindUpdate(false));
-                    set_prop(HasDisplayComponent(false));
-                    set_prop(HasCameraComponent(false));
-                    set_prop(HasDriverDirectModeComponent(false));
-                    set_prop(HasVirtualDisplayComponent(false));
+                    set_prop(FirmwareForceUpdateRequiredBool, &serial_number(device_id));
+                    set_prop(FirmwareRemindUpdateBool, "false");
+                    set_prop(HasDisplayComponentBool, "false");
+                    set_prop(HasCameraComponentBool, "false");
+                    set_prop(HasDriverDirectModeComponentBool, "false");
+                    set_prop(HasVirtualDisplayComponentBool, "false");
 
                     // icons
-                    set_prop(NamedIconPathDeviceOff(
-                        "{htc}/icons/tracker_status_off.png".into(),
-                    ));
-                    set_prop(NamedIconPathDeviceSearching(
-                        "{htc}/icons/tracker_status_searching.gif".into(),
-                    ));
-                    set_prop(NamedIconPathDeviceSearchingAlert(
-                        "{htc}/icons/tracker_status_searching_alert.gif".into(),
-                    ));
-                    set_prop(NamedIconPathDeviceReady(
-                        "{htc}/icons/tracker_status_ready.png".into(),
-                    ));
-                    set_prop(NamedIconPathDeviceReadyAlert(
-                        "{htc}/icons/tracker_status_ready_alert.png".into(),
-                    ));
-                    set_prop(NamedIconPathDeviceNotReady(
-                        "{htc}/icons/tracker_status_error.png".into(),
-                    ));
-                    set_prop(NamedIconPathDeviceStandby(
-                        "{htc}/icons/tracker_status_standby.png".into(),
-                    ));
-                    set_prop(NamedIconPathDeviceAlertLow(
-                        "{htc}/icons/tracker_status_ready_low.png".into(),
-                    ));
+                    set_prop(
+                        NamedIconPathDeviceOffString,
+                        "{htc}/icons/tracker_status_off.png",
+                    );
+                    set_prop(
+                        NamedIconPathDeviceSearchingString,
+                        "{htc}/icons/tracker_status_searching.gif",
+                    );
+                    set_prop(
+                        NamedIconPathDeviceSearchingAlertString,
+                        "{htc}/icons/tracker_status_searching_alert.gif",
+                    );
+                    set_prop(
+                        NamedIconPathDeviceReadyString,
+                        "{htc}/icons/tracker_status_ready.png",
+                    );
+                    set_prop(
+                        NamedIconPathDeviceReadyAlertString,
+                        "{htc}/icons/tracker_status_ready_alert.png",
+                    );
+                    set_prop(
+                        NamedIconPathDeviceNotReadyString,
+                        "{htc}/icons/tracker_status_error.png",
+                    );
+                    set_prop(
+                        NamedIconPathDeviceStandbyString,
+                        "{htc}/icons/tracker_status_standby.png",
+                    );
+                    set_prop(
+                        NamedIconPathDeviceAlertLowString,
+                        "{htc}/icons/tracker_status_ready_low.png",
+                    );
                 }
                 ControllersEmulationMode::Custom { .. } => {}
             }
 
-            set_prop(SerialNumber(serial_number(device_id)));
-            set_prop(AttachedDeviceId(serial_number(device_id)));
+            set_prop(SerialNumberString, &serial_number(device_id));
+            set_prop(AttachedDeviceIdString, &serial_number(device_id));
 
-            set_prop(SupportedButtons(0xFFFFFFFFFFFFFFFF));
+            set_prop(SupportedButtonsUint64, "0xFFFFFFFFFFFFFFFF");
 
             // OpenXR does not support controller battery
-            set_prop(DeviceProvidesBatteryStatus(false));
+            set_prop(DeviceProvidesBatteryStatusBool, "false");
 
             // k_eControllerAxis_Joystick = 2
-            set_prop(Axis0Type(2));
+            set_prop(Axis0TypeInt32, "2");
 
             if matches!(config.emulation_mode, ControllersEmulationMode::ViveTracker) {
                 // TrackedControllerRole_Invalid
-                set_prop(ControllerRoleHint(0));
+                set_prop(ControllerRoleHintInt32, "0");
             } else if left_hand {
                 // TrackedControllerRole_LeftHand
-                set_prop(ControllerRoleHint(1));
+                set_prop(ControllerRoleHintInt32, "1");
             } else if right_hand {
                 // TrackedControllerRole_RightHand
-                set_prop(ControllerRoleHint(2));
+                set_prop(ControllerRoleHintInt32, "2");
             }
 
             for prop in &config.extra_openvr_props {
-                set_prop(prop.clone());
+                set_prop(prop.key, &prop.value);
             }
         }
     }

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -11,6 +11,22 @@ use settings_schema::{
 
 include!(concat!(env!("OUT_DIR"), "/openvr_property_keys.rs"));
 
+pub enum OpenvrPropType {
+    Bool,
+    Float,
+    Int32,
+    Uint64,
+    Vector3,
+    Double,
+    String,
+}
+
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, Debug)]
+pub struct OpenvrProperty {
+    pub key: OpenvrPropKey,
+    pub value: String,
+}
+
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 #[schema(gui = "button_group")]
 pub enum FrameSize {
@@ -305,11 +321,18 @@ CABAC produces better compression but it's significantly slower and may lead to 
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub enum MediacodecDataType {
-    Float(f32),
-    Int32(i32),
-    Int64(i64),
-    String(String),
+pub enum MediacodecPropType {
+    Float,
+    Int32,
+    Int64,
+    String,
+}
+
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct MediacodecProperty {
+    #[schema(strings(display_name = "Type"))]
+    pub ty: MediacodecPropType,
+    pub value: String,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
@@ -573,7 +596,7 @@ pub struct VideoConfig {
     ))]
     pub force_software_decoder: bool,
 
-    pub mediacodec_extra_options: Vec<(String, MediacodecDataType)>,
+    pub mediacodec_extra_options: Vec<(String, MediacodecProperty)>,
 
     #[schema(strings(
         help = "Resolution used for encoding and decoding. Relative to a single eye view."
@@ -1297,7 +1320,12 @@ pub fn session_settings_default() -> SettingsDefault {
     };
     let default_custom_openvr_props = VectorDefault {
         gui_collapsed: true,
-        element: OPENVR_PROPS_DEFAULT.clone(),
+        element: OpenvrPropertyDefault {
+            key: OpenvrPropKeyDefault {
+                variant: OpenvrPropKeyDefaultVariant::TrackingSystemNameString,
+            },
+            value: "".into(),
+        },
         content: vec![],
     };
     let socket_buffer = SocketBufferSizeDefault {
@@ -1432,13 +1460,12 @@ pub fn session_settings_default() -> SettingsDefault {
                 },
             },
             mediacodec_extra_options: {
-                fn int32_default(int32: i32) -> MediacodecDataTypeDefault {
-                    MediacodecDataTypeDefault {
-                        variant: MediacodecDataTypeDefaultVariant::Int32,
-                        Float: 0.0,
-                        Int32: int32,
-                        Int64: 0,
-                        String: "".into(),
+                fn int32_default(int32: i32) -> MediacodecPropertyDefault {
+                    MediacodecPropertyDefault {
+                        ty: MediacodecPropTypeDefault {
+                            variant: MediacodecPropTypeDefaultVariant::Int32,
+                        },
+                        value: int32.to_string(),
                     }
                 }
                 DictionaryDefault {


### PR DESCRIPTION
We rely on code generation, and we generate a long list of OpenVR props. This list gets copied to the session file even for props we don't use. But even worse, because of how we structured the session generation, the whole list is copied for each added prop (where only one value is used at a time). This PR makes the OpenVR props and Mediacodec props untyped so we work around the issue. Instead I added runtime checks with warns if case of errors.

For OpenVR props, I appended the value type in the prop name as hint for the user.

This PR is not urgent but review when you can