### PR TITLE
fix(server_openvr): :bug: Make SteamVR chaperone consistent with ALVR

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/ChaperoneUpdater.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/ChaperoneUpdater.cpp
@@ -55,6 +55,12 @@ void ShutdownOpenvrClient() {
 
 bool IsOpenvrClientReady() { return isOpenvrInit; }
 
+void ResetChaperoneToStage() {
+#ifndef __APPLE__
+    vr::VRChaperone()->ResetZeroPose(vr::TrackingUniverseRawAndUncalibrated);
+#endif
+}
+
 void _SetChaperoneArea(float areaWidth, float areaHeight) {
     Debug("SetChaperoneArea");
 
@@ -96,6 +102,7 @@ void _SetChaperoneArea(float areaWidth, float areaHeight) {
         );
     }
 
+    ResetChaperoneToStage();
 #endif
 }
 

--- a/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
@@ -212,24 +212,25 @@ public:
                 }
 
                 HapticsSend(id, haptics.fDurationSeconds, haptics.fFrequency, haptics.fAmplitude);
-            }
+            } else if (event.eventType == vr::VREvent_ChaperoneUniverseHasChanged
+                       || event.eventType == vr::VREvent_ChaperoneRoomSetupFinished
+                       || event.eventType == vr::VREvent_ChaperoneFlushCache
+                       || event.eventType == vr::VREvent_ChaperoneSettingsHaveChanged
+                       || event.eventType == vr::VREvent_SeatedZeroPoseReset
+                       || event.eventType == vr::VREvent_StandingZeroPoseReset
+                       || event.eventType == vr::VREvent_SceneApplicationChanged
+                       || event.eventType == VendorEvent_ALVRDriverResync) {
+                ResetChaperoneToStage();
+
 #ifdef __linux__
-            else if (event.eventType == vr::VREvent_ChaperoneUniverseHasChanged
-                     || event.eventType == vr::VREvent_ChaperoneRoomSetupFinished
-                     || event.eventType == vr::VREvent_ChaperoneFlushCache
-                     || event.eventType == vr::VREvent_ChaperoneSettingsHaveChanged
-                     || event.eventType == vr::VREvent_SeatedZeroPoseReset
-                     || event.eventType == vr::VREvent_StandingZeroPoseReset
-                     || event.eventType == vr::VREvent_SceneApplicationChanged
-                     || event.eventType == VendorEvent_ALVRDriverResync) {
                 if (hmd && hmd->m_poseHistory) {
                     auto rawZeroPose = GetRawZeroPose();
                     if (rawZeroPose != nullptr) {
                         hmd->m_poseHistory->SetTransform(*rawZeroPose);
                     }
                 }
-            }
 #endif
+            }
         }
         if (vr::VRServerDriverHost()->IsExiting() && !shutdown_called) {
             Debug("DriverProvider: Received shutdown event");

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -159,6 +159,7 @@ extern "C" void SetButton(unsigned long long buttonID, FfiButtonValue value);
 
 extern "C" void InitOpenvrClient();
 extern "C" void ShutdownOpenvrClient();
+extern "C" void ResetChaperoneToStage();
 extern "C" void SetChaperoneArea(float areaWidth, float areaHeight);
 
 extern "C" void CaptureFrame();


### PR DESCRIPTION
Often times, recentering using SteamVR, breaks ALVR calibration. With this PR we force SteamVR to revert to stage tracking any time it gets reset as standing or seated.

Not tested yet. The code that listens for recentering could cause an infinite loop.