### PR TITLE
fix(server_openvr): Fix CPU/GPU deadlocking at 100% usage before the headset connects

### DIFF
--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -378,24 +378,13 @@ extern "C" fn report_present(timestamp_ns: u64, offset_ns: u64) {
 
 extern "C" fn wait_for_vsync() {
     // NB: don't sleep while locking SERVER_DATA_MANAGER or SERVER_CORE_CONTEXT
-    let sleep_duration = if alvr_server_core::settings()
-        .video
-        .optimize_game_render_latency
-    {
-        SERVER_CORE_CONTEXT
-            .read()
-            .as_ref()
-            .and_then(|ctx| ctx.duration_until_next_vsync())
-    } else {
-        None
-    };
+    let sleep_duration = SERVER_CORE_CONTEXT
+        .read()
+        .as_ref()
+        .and_then(|ctx| ctx.duration_until_next_vsync())
+        .unwrap_or(Duration::from_millis(50));
 
-    if let Some(duration) = sleep_duration {
-        thread::sleep(duration);
-    } else {
-        // Fallback to avoid deadlocking people's systems accidentally
-        thread::sleep(Duration::from_millis(1));
-    }
+    thread::sleep(sleep_duration);
 }
 
 pub extern "C" fn shutdown_driver() {

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -382,15 +382,10 @@ extern "C" fn wait_for_vsync() {
         .video
         .optimize_game_render_latency
     {
-        // We default to 10ms in the event that a headset hasn't connected,
-        // because otherwise systems can lock up with 100% GPU.
-        Some(
-            SERVER_CORE_CONTEXT
-                .read()
-                .as_ref()
-                .and_then(|ctx| ctx.duration_until_next_vsync())
-                .unwrap_or(Duration::from_millis(10)),
-        )
+        SERVER_CORE_CONTEXT
+            .read()
+            .as_ref()
+            .and_then(|ctx| ctx.duration_until_next_vsync())
     } else {
         None
     };
@@ -398,7 +393,7 @@ extern "C" fn wait_for_vsync() {
     if let Some(duration) = sleep_duration {
         thread::sleep(duration);
     } else {
-        // Don't deadlock people's systems even if they ask nicely
+        // Fallback to avoid deadlocking people's systems accidentally
         thread::sleep(Duration::from_millis(1));
     }
 }

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -584,10 +584,6 @@ pub struct VideoConfig {
     #[schema(gui(slider(min = 0.50, max = 0.99, step = 0.01)))]
     pub buffering_history_weight: f32,
 
-    #[schema(strings(help = "This works only on Windows"))]
-    #[schema(flag = "real-time")]
-    pub optimize_game_render_latency: bool,
-
     #[schema(flag = "steamvr-restart")]
     pub encoder_config: EncoderConfig,
 
@@ -1347,7 +1343,6 @@ pub fn session_settings_default() -> SettingsDefault {
             preferred_fps: 72.,
             max_buffering_frames: 2.0,
             buffering_history_weight: 0.90,
-            optimize_game_render_latency: true,
             bitrate: BitrateConfigDefault {
                 gui_collapsed: false,
                 mode: BitrateModeDefault {


### PR DESCRIPTION
Add a mandatory 1ms wait for users w/ optimize_game_render_latency off, and otherwise ensure a 10ms dummy wait until a headset connects and we have a statistics context to keep track of the actual vsync interval.