### PR TITLE
docs(linux): fix for no steamvr dashboard on hybrid graphics

### DIFF
--- a/wiki/Linux-Troubleshooting.md
+++ b/wiki/Linux-Troubleshooting.md
@@ -65,7 +65,7 @@ Put `DRI_PRIME=1 %command%` into SteamVR's commandline options and in those of a
 
 Put `__NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia %command%` into SteamVR's commandline options and in those of all VR games you intend to play with ALVR.
 
-### SteamVR Dashboard not rendering in VR
+### SteamVR Dashboard not rendering in VR on Nvidia discrete GPU
 If you encounter issues with the SteamVR dashboard not rendering in VR you may need to run the entire steam client itself via PRIME render offload. From a terminal run: `__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia steam-runtime`
 
 ## Wayland

--- a/wiki/Linux-Troubleshooting.md
+++ b/wiki/Linux-Troubleshooting.md
@@ -66,7 +66,7 @@ Put `DRI_PRIME=1 %command%` into SteamVR's commandline options and in those of a
 Put `__NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia %command%` into SteamVR's commandline options and in those of all VR games you intend to play with ALVR.
 
 ### SteamVR Dashboard not rendering in VR on Nvidia discrete GPU
-If you encounter issues with the SteamVR dashboard not rendering in VR you may need to run the entire steam client itself via PRIME render offload. From a terminal run: `__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia steam-runtime`
+If you encounter issues with the SteamVR dashboard not rendering in VR you may need to run the entire steam client itself via PRIME render offload. First close the steam client completey if you have it open already, you can do so by clicking the Steam dropdown in the top left and choosing exit. Then from a terminal run: `__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia steam-runtime`
 
 ## Wayland
 

--- a/wiki/Linux-Troubleshooting.md
+++ b/wiki/Linux-Troubleshooting.md
@@ -65,6 +65,9 @@ Put `DRI_PRIME=1 %command%` into SteamVR's commandline options and in those of a
 
 Put `__NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia %command%` into SteamVR's commandline options and in those of all VR games you intend to play with ALVR.
 
+### SteamVR Dashboard not rendering in VR
+If you encounter issues with the SteamVR dashboard not rendering in VR you may need to run the entire steam client itself via PRIME render offload. From a terminal run: `__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia steam-runtime`
+
 ## Wayland
 
 When using hyprland or Gnome Wayland you need to put `WAYLAND_DISPLAY='' %command%` into the SteamVR commandline options to force XWayland.


### PR DESCRIPTION
Adding PRIME render offload vars to SteamVR alone seems to cause an issue where the SteamVR dashboard will not render.  Running the entire steam client via PRIME render offload fixes it. https://github.com/ValveSoftware/SteamVR-for-Linux/issues/542#issuecomment-1266127370