### PR TITLE
feat(client): ✨ Add reprojection support for C API

### DIFF
--- a/alvr/client_core/resources/lobby_quad.wgsl
+++ b/alvr/client_core/resources/lobby_quad.wgsl
@@ -1,11 +1,3 @@
-struct VertexOutput {
-    @builtin(position) position: vec4f,
-    @location(0) uv: vec2f,
-}
-
-@group(0) @binding(0) var hud_texture: texture_2d<f32>;
-@group(0) @binding(1) var hud_sampler: sampler;
-
 struct PushConstant {
     transform: mat4x4f,
     object_type: u32,
@@ -13,14 +5,19 @@ struct PushConstant {
 }
 var<push_constant> pc: PushConstant;
 
+@group(0) @binding(0) var hud_texture: texture_2d<f32>;
+@group(0) @binding(1) var hud_sampler: sampler;
+
+struct VertexOutput {
+    @builtin(position) position: vec4f,
+    @location(0) uv: vec2f,
+}
+
 @vertex
 fn vertex_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     var result: VertexOutput;
 
-    let norm_vert_a = f32(vertex_index & 1);
-    let norm_vert_b = f32(vertex_index >> 1);
-
-    result.uv = vec2f(norm_vert_a, norm_vert_b);
+    result.uv = vec2f(f32(vertex_index & 1), f32(vertex_index >> 1));
     result.position = pc.transform * vec4f(result.uv.x - 0.5, 0.5 - result.uv.y, 0.0, 1.0);
 
     return result;

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -159,8 +159,8 @@ pub fn to_capi_pose(pose: Pose) -> AlvrPose {
 
 #[repr(C)]
 pub struct AlvrViewParams {
-    pub pose: AlvrPose,
-    pub fov: AlvrFov,
+    pose: AlvrPose,
+    fov: AlvrFov,
 }
 
 #[repr(C)]
@@ -681,6 +681,7 @@ pub struct AlvrLobbyViewParams {
     fov: AlvrFov,
 }
 
+#[repr(C)]
 pub struct AlvrStreamViewParams {
     swapchain_index: u32,
     reprojection_rotation: AlvrQuat,
@@ -689,17 +690,17 @@ pub struct AlvrStreamViewParams {
 
 #[repr(C)]
 pub struct AlvrStreamConfig {
-    pub view_resolution_width: u32,
-    pub view_resolution_height: u32,
-    pub swapchain_textures: *mut *const u32,
-    pub swapchain_length: u32,
-    pub enable_foveation: bool,
-    pub foveation_center_size_x: f32,
-    pub foveation_center_size_y: f32,
-    pub foveation_center_shift_x: f32,
-    pub foveation_center_shift_y: f32,
-    pub foveation_edge_ratio_x: f32,
-    pub foveation_edge_ratio_y: f32,
+    view_resolution_width: u32,
+    view_resolution_height: u32,
+    swapchain_textures: *mut *const u32,
+    swapchain_length: u32,
+    enable_foveation: bool,
+    foveation_center_size_x: f32,
+    foveation_center_size_y: f32,
+    foveation_center_shift_x: f32,
+    foveation_center_shift_y: f32,
+    foveation_edge_ratio_x: f32,
+    foveation_edge_ratio_y: f32,
 }
 
 #[no_mangle]

--- a/alvr/client_openxr/src/lobby.rs
+++ b/alvr/client_openxr/src/lobby.rs
@@ -2,7 +2,7 @@ use crate::{
     graphics::{self, ProjectionLayerAlphaConfig, ProjectionLayerBuilder},
     interaction::{self, InteractionContext},
 };
-use alvr_client_core::graphics::{GraphicsContext, LobbyRenderer, RenderViewInput, SDR_FORMAT_GL};
+use alvr_client_core::graphics::{GraphicsContext, LobbyRenderer, LobbyViewParams, SDR_FORMAT_GL};
 use alvr_common::{glam::UVec2, parking_lot::RwLock, Pose};
 use openxr as xr;
 use std::{rc::Rc, sync::Arc};
@@ -144,12 +144,12 @@ impl Lobby {
 
         self.renderer.render(
             [
-                RenderViewInput {
+                LobbyViewParams {
                     pose: crate::from_xr_pose(views[0].pose),
                     fov: crate::from_xr_fov(views[0].fov),
                     swapchain_index: left_swapchain_idx,
                 },
-                RenderViewInput {
+                LobbyViewParams {
                     pose: crate::from_xr_pose(views[1].pose),
                     fov: crate::from_xr_fov(views[1].fov),
                     swapchain_index: right_swapchain_idx,

--- a/alvr/common/src/primitives.rs
+++ b/alvr/common/src/primitives.rs
@@ -3,12 +3,23 @@ use serde::{Deserialize, Serialize};
 use std::ops::Mul;
 
 // Field of view in radians
-#[derive(Serialize, Deserialize, PartialEq, Default, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
 pub struct Fov {
     pub left: f32,
     pub right: f32,
     pub up: f32,
     pub down: f32,
+}
+
+impl Default for Fov {
+    fn default() -> Self {
+        Fov {
+            left: -1.0,
+            right: 1.0,
+            up: 1.0,
+            down: -1.0,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Default, Debug)]


### PR DESCRIPTION
~~When reprojection is invoked for Pico headsets, the resolution is noticeably degraded. this is what I expected. But we may have to find another solution.~~

Reduced scope to only provide reprojection support for the C API. Reprojection is always enabled but I believe it's not cause of lower performance, it's a simple vertex transform. Only if the input rotation is not identity, then the image would look blurrier because of aliasing, but otherwise the sampling would be pixel perfect.