### PR TITLE
fix: handle JNI java exceptions properly in client_core

### DIFF
--- a/alvr/system_info/src/android.rs
+++ b/alvr/system_info/src/android.rs
@@ -1,8 +1,44 @@
 use alvr_common::warn;
-use jni::{objects::JObject, sys::jobject, JNIEnv, JavaVM};
+use jni::{
+    errors::Error,
+    objects::{JObject, JString, JValue, JValueOwned},
+    sys::jobject,
+    JNIEnv, JavaVM,
+};
 use std::net::{IpAddr, Ipv4Addr};
 
 pub const MICROPHONE_PERMISSION: &str = "android.permission.RECORD_AUDIO";
+
+// Will call a JNI method and handle any Java exceptions that might occur
+fn env_call_method_handled<'local>(
+    env: &mut JNIEnv<'local>,
+    object: &JObject,
+    method: &str,
+    sig: &str,
+    args: &[JValue],
+) -> Result<JValueOwned<'local>, Error> {
+    env.call_method(object, method, sig, args)
+        .map_err(|e| match e {
+            jni::errors::Error::JavaException => {
+                env.exception_describe().unwrap();
+                let jthorw = env.exception_occurred().unwrap();
+                env.exception_clear().unwrap();
+                let exception_to_jstring: JString = env
+                    .call_method(jthorw, "toString", "()Ljava/lang/String;", &[])
+                    .unwrap()
+                    .l()
+                    .unwrap()
+                    .into();
+                let excp_string = env.get_string(&exception_to_jstring).unwrap();
+                let err = String::from("Java Exception Occured: ") + excp_string.to_str().unwrap();
+                // At this point even if we let this error propagate, the next unwrap will panic with only unclear "JavaException" literal,
+                // so we can panic here itself with more detailed JavaException reason message and let crate::backtrace::backtrace() be printed
+                // This can also be synced with server side in future if we have that feature
+                panic!("{err}");
+            }
+            _ => e,
+        })
+}
 
 pub fn vm() -> JavaVM {
     unsafe { JavaVM::from_raw(ndk_context::android_context().vm().cast()).unwrap() }
@@ -28,16 +64,16 @@ pub fn try_get_permission(permission: &str) {
 
     let mic_perm_jstring = env.new_string(permission).unwrap();
 
-    let permission_status = env
-        .call_method(
-            unsafe { JObject::from_raw(context()) },
-            "checkSelfPermission",
-            "(Ljava/lang/String;)I",
-            &[(&mic_perm_jstring).into()],
-        )
-        .unwrap()
-        .i()
-        .unwrap();
+    let permission_status = env_call_method_handled(
+        &mut env,
+        unsafe { &JObject::from_raw(context()) },
+        "checkSelfPermission",
+        "(Ljava/lang/String;)I",
+        &[(&mic_perm_jstring).into()],
+    )
+    .unwrap()
+    .i()
+    .unwrap();
 
     if permission_status != 0 {
         let string_class = env.find_class("java/lang/String").unwrap();
@@ -45,8 +81,9 @@ pub fn try_get_permission(permission: &str) {
             .new_object_array(1, string_class, mic_perm_jstring)
             .unwrap();
 
-        env.call_method(
-            unsafe { JObject::from_raw(context()) },
+        env_call_method_handled(
+            &mut env,
+            unsafe { &JObject::from_raw(context()) },
             "requestPermissions",
             "([Ljava/lang/String;I)V",
             &[(&perm_array).into(), 0.into()],
@@ -86,8 +123,9 @@ pub fn manufacturer_name() -> String {
 fn get_system_service<'a>(env: &mut JNIEnv<'a>, service_name: &str) -> JObject<'a> {
     let service_str = env.new_string(service_name).unwrap();
 
-    env.call_method(
-        unsafe { JObject::from_raw(context()) },
+    env_call_method_handled(
+        env,
+        unsafe { &JObject::from_raw(context()) },
         "getSystemService",
         "(Ljava/lang/String;)Ljava/lang/Object;",
         &[(&service_str).into()],
@@ -103,18 +141,17 @@ pub fn local_ip() -> IpAddr {
     let mut env = vm.attach_current_thread().unwrap();
 
     let wifi_manager = get_system_service(&mut env, "wifi");
-    let wifi_info = env
-        .call_method(
-            wifi_manager,
-            "getConnectionInfo",
-            "()Landroid/net/wifi/WifiInfo;",
-            &[],
-        )
-        .unwrap()
-        .l()
-        .unwrap();
-    let ip_i32 = env
-        .call_method(wifi_info, "getIpAddress", "()I", &[])
+    let wifi_info = env_call_method_handled(
+        &mut env,
+        &wifi_manager,
+        "getConnectionInfo",
+        "()Landroid/net/wifi/WifiInfo;",
+        &[],
+    )
+    .unwrap()
+    .l()
+    .unwrap();
+    let ip_i32 = env_call_method_handled(&mut env, &wifi_info, "getIpAddress", "()I", &[])
         .unwrap()
         .i()
         .unwrap();
@@ -133,18 +170,17 @@ pub fn set_wifi_lock(enabled: bool) {
     let wifi_manager = get_system_service(&mut env, "wifi");
 
     fn set_lock<'a>(env: &mut JNIEnv<'a>, lock: &JObject, enabled: bool) {
-        env.call_method(lock, "setReferenceCounted", "(Z)V", &[false.into()])
-            .unwrap();
-        env.call_method(
-            &lock,
+        env_call_method_handled(env, lock, "setReferenceCounted", "(Z)V", &[false.into()]).unwrap();
+        env_call_method_handled(
+            env,
+            lock,
             if enabled { "acquire" } else { "release" },
             "()V",
             &[],
         )
         .unwrap();
 
-        let lock_is_aquired = env
-            .call_method(lock, "isHeld", "()Z", &[])
+        let lock_is_aquired = env_call_method_handled(env, &lock, "isHeld", "()Z", &[])
             .unwrap()
             .z()
             .unwrap();
@@ -155,38 +191,38 @@ pub fn set_wifi_lock(enabled: bool) {
     }
 
     let wifi_lock_jstring = env.new_string("alvr_wifi_lock").unwrap();
-    let wifi_lock = env
-        .call_method(
-            &wifi_manager,
-            "createWifiLock",
-            "(ILjava/lang/String;)Landroid/net/wifi/WifiManager$WifiLock;",
-            &[
-                if get_api_level() >= 29 {
-                    // Recommended for virtual reality since it disables WIFI scans
-                    4 // WIFI_MODE_FULL_LOW_LATENCY
-                } else {
-                    3 // WIFI_MODE_FULL_HIGH_PERF
-                }
-                .into(),
-                (&wifi_lock_jstring).into(),
-            ],
-        )
-        .unwrap()
-        .l()
-        .unwrap();
+    let wifi_lock = env_call_method_handled(
+        &mut env,
+        &wifi_manager,
+        "createWifiLock",
+        "(ILjava/lang/String;)Landroid/net/wifi/WifiManager$WifiLock;",
+        &[
+            if get_api_level() >= 29 {
+                // Recommended for virtual reality since it disables WIFI scans
+                4 // WIFI_MODE_FULL_LOW_LATENCY
+            } else {
+                3 // WIFI_MODE_FULL_HIGH_PERF
+            }
+            .into(),
+            (&wifi_lock_jstring).into(),
+        ],
+    )
+    .unwrap()
+    .l()
+    .unwrap();
     set_lock(&mut env, &wifi_lock, enabled);
 
     let multicast_lock_jstring = env.new_string("alvr_multicast_lock").unwrap();
-    let multicast_lock = env
-        .call_method(
-            wifi_manager,
-            "createMulticastLock",
-            "(Ljava/lang/String;)Landroid/net/wifi/WifiManager$MulticastLock;",
-            &[(&multicast_lock_jstring).into()],
-        )
-        .unwrap()
-        .l()
-        .unwrap();
+    let multicast_lock = env_call_method_handled(
+        &mut env,
+        &wifi_manager,
+        "createMulticastLock",
+        "(Ljava/lang/String;)Landroid/net/wifi/WifiManager$MulticastLock;",
+        &[(&multicast_lock_jstring).into()],
+    )
+    .unwrap()
+    .l()
+    .unwrap();
     set_lock(&mut env, &multicast_lock, enabled);
 }
 
@@ -204,9 +240,8 @@ pub fn get_battery_status() -> (f32, bool) {
             &[(&intent_action_jstring).into()],
         )
         .unwrap();
-    let battery_intent = env
-        .call_method(
-            unsafe { JObject::from_raw(context()) },
+    let battery_intent = env_call_method_handled(&mut env,
+            unsafe { &JObject::from_raw(context()) },
             "registerReceiver",
             "(Landroid/content/BroadcastReceiver;Landroid/content/IntentFilter;)Landroid/content/Intent;",
             &[(&JObject::null()).into(), (&intent_filter).into()],
@@ -216,39 +251,39 @@ pub fn get_battery_status() -> (f32, bool) {
         .unwrap();
 
     let level_jstring = env.new_string("level").unwrap();
-    let level = env
-        .call_method(
-            &battery_intent,
-            "getIntExtra",
-            "(Ljava/lang/String;I)I",
-            &[(&level_jstring).into(), (-1).into()],
-        )
-        .unwrap()
-        .i()
-        .unwrap();
+    let level = env_call_method_handled(
+        &mut env,
+        &battery_intent,
+        "getIntExtra",
+        "(Ljava/lang/String;I)I",
+        &[(&level_jstring).into(), (-1).into()],
+    )
+    .unwrap()
+    .i()
+    .unwrap();
     let scale_jstring = env.new_string("scale").unwrap();
-    let scale = env
-        .call_method(
-            &battery_intent,
-            "getIntExtra",
-            "(Ljava/lang/String;I)I",
-            &[(&scale_jstring).into(), (-1).into()],
-        )
-        .unwrap()
-        .i()
-        .unwrap();
+    let scale = env_call_method_handled(
+        &mut env,
+        &battery_intent,
+        "getIntExtra",
+        "(Ljava/lang/String;I)I",
+        &[(&scale_jstring).into(), (-1).into()],
+    )
+    .unwrap()
+    .i()
+    .unwrap();
 
     let plugged_jstring = env.new_string("plugged").unwrap();
-    let plugged = env
-        .call_method(
-            &battery_intent,
-            "getIntExtra",
-            "(Ljava/lang/String;I)I",
-            &[(&plugged_jstring).into(), (-1).into()],
-        )
-        .unwrap()
-        .i()
-        .unwrap();
+    let plugged = env_call_method_handled(
+        &mut env,
+        &battery_intent,
+        "getIntExtra",
+        "(Ljava/lang/String;I)I",
+        &[(&plugged_jstring).into(), (-1).into()],
+    )
+    .unwrap()
+    .i()
+    .unwrap();
 
     (level as f32 / scale as f32, plugged > 0)
 }


### PR DESCRIPTION
### TLDR
```java
ALVR panicked: What happened:
panicked at alvr\system_info\src\android.rs:37:17:
Java Exception Occured: java.lang.SecurityException: WifiService: Neither user 10165 nor current process has android.permission.CHANGE_WIFI_MULTICAST_STATE
```

### After using the PR
```java
02:51:34.878 11648-11648 System.err              viritualisres.phonevr                W  java.lang.SecurityException: WifiService: Neither user 10165 nor current process has android.permission.CHANGE_WIFI_MULTICAST_STATE.
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.os.Parcel.createExceptionOrNull(Parcel.java:2373)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.os.Parcel.createException(Parcel.java:2357)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.os.Parcel.readException(Parcel.java:2340)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.os.Parcel.readException(Parcel.java:2282)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.net.wifi.IWifiManager$Stub$Proxy.acquireMulticastLock(IWifiManager.java:2634)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.net.wifi.WifiManager$MulticastLock.acquire(WifiManager.java:4762)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at viritualisres.phonevr.ALVRActivity.initializeNative(Native Method)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at viritualisres.phonevr.ALVRActivity.onCreate(ALVRActivity.java:108)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.Activity.performCreate(Activity.java:8000)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.Activity.performCreate(Activity.java:7984)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1309)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3422)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3601)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
02:51:34.892 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2066)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at android.os.Handler.dispatchMessage(Handler.java:106)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at android.os.Looper.loop(Looper.java:223)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.ActivityThread.main(ActivityThread.java:7656)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at java.lang.reflect.Method.invoke(Native Method)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  Caused by: android.os.RemoteException: Remote stack trace:
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.ContextImpl.enforce(ContextImpl.java:2018)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at android.app.ContextImpl.enforceCallingOrSelfPermission(ContextImpl.java:2046)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at android.content.ContextWrapper.enforceCallingOrSelfPermission(ContextWrapper.java:851)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at com.android.server.wifi.WifiServiceImpl.enforceMulticastChangePermission(WifiServiceImpl.java:720)
02:51:34.893 11648-11648 System.err              viritualisres.phonevr                W  	at com.android.server.wifi.WifiServiceImpl.acquireMulticastLock(WifiServiceImpl.java:3370)
02:51:36.142 11648-11648 [ALVR NATIVE-RUST]      viritualisres.phonevr                E  ALVR panicked: What happened:
                                                                                         panicked at alvr\system_info\src\android.rs:37:17:
                                                                                         Java Exception Occured: java.lang.SecurityException: WifiService: Neither user 10165 nor current process has android.permission.CHANGE_WIFI_MULTICAST_STATE.
                                                                                         
                                                                                         Backtrace:
                                                                                            0: alvr_common::logging::set_panic_hook::{{closure}}
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\common\src\logging.rs:191:13
                                                                                            1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/alloc/src/boxed.rs:1984:9
                                                                                               std::panicking::rust_panic_with_hook
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/std/src/panicking.rs:825:13
                                                                                            2: std::panicking::begin_panic_handler::{{closure}}
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/std/src/panicking.rs:690:13
                                                                                            3: std::sys::backtrace::__rust_end_short_backtrace
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/std/src/sys/backtrace.rs:170:18
                                                                                            4: rust_begin_unwind
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/std/src/panicking.rs:681:5
                                                                                            5: core::panicking::panic_fmt
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/core/src/panicking.rs:75:14
                                                                                            6: alvr_system_info::android::env_call_method_handled::{{closure}}
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\system_info\src\android.rs:37:17
                                                                                            7: core::result::Result<T,E>::map_err
                                                                                                      at C:\Users\user\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library/core/src\result.rs:856:27
                                                                                            8: alvr_system_info::android::env_call_method_handled
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\system_info\src\android.rs:20:5
                                                                                            9: alvr_system_info::android::set_wifi_lock::set_lock
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\system_info\src\android.rs:174:9
                                                                                           10: alvr_system_info::android::set_wifi_lock
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\system_info\src\android.rs:226:5
                                                                                           11: alvr_client_core::ClientCoreContext::new
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\client_core\src\lib.rs:98:13
                                                                                           12: alvr_initialize
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\client_core\src\c_api.rs:298:40
                                                                                           13: Java_viritualisres_phonevr_ALVRActivity_initializeNative
                                                                                                      at D:/Users/Documents/GitHub/PhoneVR/code/mobile/android/PhoneVR/app/.cxx/Debug/3k205by4/x86/D:/Users/Documents/GitHub/PhoneVR/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp:211:5
                                                                                           14: art_quick_generic_jni_trampoline
                                                                                           15: art_quick_invoke_stub
                                                                                           16: _ZN3art9ArtMethod6InvokeEPNS_6ThreadEPjjPNS_6JValueEPKc
                                                                                           17: _ZN3art11interpreter34ArtInterpreterToCompiledCodeBridgeEPNS_6ThreadEPNS_9ArtMethodEPNS_11ShadowFrameEtPNS_6JValueE
                                                                                           18: _ZN3art11interpreter6DoCallILb0ELb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
                                                                                           19: MterpInvokeDirect
                                                                                           20: mterp_op_invoke_direct
                                                                                           21: MterpInvokeVirtual
                                                                                           22: mterp_op_invoke_virtual
                                                                                           23: MterpInvokeVirtual
                                                                                           24: mterp_op_invoke_virtual
                                                                                           25: MterpInvokeVirtual
                                                                                           26: mterp_op_invoke_virtual
                                                                                           27: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
                                                                                           28: _ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE
                                                                                           29: _ZN3art11interpreter6DoCallILb0ELb1EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
                                                                                           30: _ZN3art11interpreter20ExecuteSwitchImplCppILb1ELb0EEEvPNS0_17SwitchImplContextE
                                                                                           31: ExecuteSwitchImplAsm
                                                                                           32: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
02:51:36.142 11648-11648 [ALVR NATIVE-RUST]      viritualisres.phonevr                E    33: _ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE
                                                                                           34: _ZN3art11interpreter6DoCallILb0ELb1EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
                                                                                           35: _ZN3art11interpreter20ExecuteSwitchImplCppILb1ELb0EEEvPNS0_17SwitchImplContextE
                                                                                           36: ExecuteSwitchImplAsm
                                                                                           37: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
                                                                                           38: _ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE
                                                                                           39: _ZN3art11interpreter6DoCallILb0ELb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
                                                                                           40: MterpInvokeVirtual
                                                                                           41: mterp_op_invoke_virtual
                                                                                           42: MterpInvokeVirtual
                                                                                           43: mterp_op_invoke_virtual
                                                                                           44: MterpInvokeVirtual
                                                                                           45: mterp_op_invoke_virtual
                                                                                           46: MterpInvokeVirtual
                                                                                           47: mterp_op_invoke_virtual
                                                                                           48: MterpInvokeVirtual
                                                                                           49: mterp_op_invoke_virtual
                                                                                           50: MterpInvokeVirtual
                                                                                           51: mterp_op_invoke_virtual
                                                                                           52: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
                                                                                           53: _ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE
                                                                                           54: _ZN3art11interpreter6DoCallILb0ELb1EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
                                                                                           55: _ZN3art11interpreter20ExecuteSwitchImplCppILb1ELb0EEEvPNS0_17SwitchImplContextE
                                                                                           56: ExecuteSwitchImplAsm
                                                                                           57: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
                                                                                           58: _ZN3art11interpreter30EnterInterpreterFromEntryPointEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameE
                                                                                           59: artQuickToInterpreterBridge
                                                                                           60: art_quick_to_interpreter_bridge
                                                                                           61: art_quick_invoke_static_stub
                                                                                           62: _ZN3art9ArtMethod6InvokeEPNS_6ThreadEPjjPNS_6JValueEPKc
                                                                                           63: _ZN3art12InvokeMethodERKNS_33ScopedObjectAccessAlreadyRunnableEP8_jobjectS4_S4_j
                                                                                           64: _ZN3artL13Method_invokeEP7_JNIEnvP8_jobjectS3_P13_jobjectArray
                                                                                           
```

### before
```java
03:09:12.419 13602-13602 [ALVR NATIVE-RUST]      viritualisres.phonevr                E  ALVR panicked: What happened:
                                                                                         panicked at alvr\system_info\src\android.rs:144:10:
                                                                                         called `Result::unwrap()` on an `Err` value: JavaException
                                                                                         
                                                                                         Backtrace:
                                                                                            0: alvr_common::logging::set_panic_hook::{{closure}}
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\common\src\logging.rs:191:13
                                                                                            1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/alloc/src/boxed.rs:1984:9
                                                                                               std::panicking::rust_panic_with_hook
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/std/src/panicking.rs:825:13
                                                                                            2: std::panicking::begin_panic_handler::{{closure}}
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/std/src/panicking.rs:690:13
                                                                                            3: std::sys::backtrace::__rust_end_short_backtrace
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/std/src/sys/backtrace.rs:170:18
                                                                                            4: rust_begin_unwind
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/std/src/panicking.rs:681:5
                                                                                            5: core::panicking::panic_fmt
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/core/src/panicking.rs:75:14
                                                                                            6: core::result::unwrap_failed
                                                                                                      at /rustc/c44b3d50fea96a3e0417e8264c16ea21a0a3fca2/library/core/src/result.rs:1699:5
                                                                                            7: core::result::Result<T,E>::unwrap
                                                                                                      at C:\Users\user\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library/core/src\result.rs:1104:23
                                                                                               alvr_system_info::android::set_wifi_lock::set_lock
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\system_info\src\android.rs:138:9
                                                                                            8: alvr_system_info::android::set_wifi_lock
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\system_info\src\android.rs:190:5
                                                                                            9: alvr_client_core::ClientCoreContext::new
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\client_core\src\lib.rs:98:13
                                                                                           10: alvr_initialize
                                                                                                      at D:\Users\Documents\GitHub\PhoneVR\code\mobile\android\PhoneVR\ALVR\alvr\client_core\src\c_api.rs:298:40
                                                                                           11: Java_viritualisres_phonevr_ALVRActivity_initializeNative
                                                                                                      at D:/Users/Documents/GitHub/PhoneVR/code/mobile/android/PhoneVR/app/.cxx/Debug/3k205by4/x86/D:/Users/Documents/GitHub/PhoneVR/code/mobile/android/PhoneVR/app/src/main/cpp/alvr_main.cpp:211:5
                                                                                           12: art_quick_generic_jni_trampoline
                                                                                           13: art_quick_invoke_stub
                                                                                           14: _ZN3art9ArtMethod6InvokeEPNS_6ThreadEPjjPNS_6JValueEPKc
                                                                                           15: _ZN3art11interpreter34ArtInterpreterToCompiledCodeBridgeEPNS_6ThreadEPNS_9ArtMethodEPNS_11ShadowFrameEtPNS_6JValueE
                                                                                           16: _ZN3art11interpreter6DoCallILb0ELb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
                                                                                           17: MterpInvokeDirect
                                                                                           18: mterp_op_invoke_direct
                                                                                           19: MterpInvokeVirtual
                                                                                           20: mterp_op_invoke_virtual
                                                                                           21: MterpInvokeVirtual
                                                                                           22: mterp_op_invoke_virtual
                                                                                           23: MterpInvokeVirtual
                                                                                           24: mterp_op_invoke_virtual
                                                                                           25: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
                                                                                           26: _ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE
                                                                                           27: _ZN3art11interpreter6DoCallILb0ELb1EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
                                                                                           28: _ZN3art11interpreter20ExecuteSwitchImplCppILb1ELb0EEEvPNS0_17SwitchImplContextE
                                                                                           29: ExecuteSwitchImplAsm
                                                                                           30: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
                                                                                           31: _ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE
                                                                                           32: _ZN3art11interpreter6DoCallILb0ELb1EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
03:09:12.420 13602-13602 [ALVR NATIVE-RUST]      viritualisres.phonevr                E    33: _ZN3art11interpreter20ExecuteSwitchImplCppILb1ELb0EEEvPNS0_17SwitchImplContextE
                                                                                           34: ExecuteSwitchImplAsm
                                                                                           35: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
                                                                                           36: _ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE
                                                                                           37: _ZN3art11interpreter6DoCallILb0ELb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
                                                                                           38: MterpInvokeVirtual
                                                                                           39: mterp_op_invoke_virtual
                                                                                           40: MterpInvokeVirtual
                                                                                           41: mterp_op_invoke_virtual
                                                                                           42: MterpInvokeVirtual
                                                                                           43: mterp_op_invoke_virtual
                                                                                           44: MterpInvokeVirtual
                                                                                           45: mterp_op_invoke_virtual
                                                                                           46: MterpInvokeVirtual
                                                                                           47: mterp_op_invoke_virtual
                                                                                           48: MterpInvokeVirtual
                                                                                           49: mterp_op_invoke_virtual
                                                                                           50: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
                                                                                           51: _ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE
                                                                                           52: _ZN3art11interpreter6DoCallILb0ELb1EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtPNS_6JValueE
                                                                                           53: _ZN3art11interpreter20ExecuteSwitchImplCppILb1ELb0EEEvPNS0_17SwitchImplContextE
                                                                                           54: ExecuteSwitchImplAsm
                                                                                           55: _ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.llvm.16375758241455872412
                                                                                           56: _ZN3art11interpreter30EnterInterpreterFromEntryPointEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameE
                                                                                           57: artQuickToInterpreterBridge
                                                                                           58: art_quick_to_interpreter_bridge
                                                                                           59: art_quick_invoke_static_stub
                                                                                           60: _ZN3art9ArtMethod6InvokeEPNS_6ThreadEPjjPNS_6JValueEPKc
                                                                                           61: _ZN3art12InvokeMethodERKNS_33ScopedObjectAccessAlreadyRunnableEP8_jobjectS4_S4_j
                                                                                           62: _ZN3artL13Method_invokeEP7_JNIEnvP8_jobjectS3_P13_jobjectArray
                                                                                           
```