### PR TITLE
feat(client): head prediction scaler

### DIFF
--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -209,6 +209,7 @@ fn connection_pipeline(
         } else {
             0.0
         },
+        settings.headset.head_prediction_scaler,
     ));
 
     let (mut control_sender, mut control_receiver) = proto_control_socket

--- a/alvr/client_core/src/statistics.rs
+++ b/alvr/client_core/src/statistics.rs
@@ -17,6 +17,7 @@ pub struct StatisticsManager {
     prev_vsync: Instant,
     total_pipeline_latency_average: SlidingWindowAverage<Duration>,
     steamvr_pipeline_latency: Duration,
+    head_prediction_scaler: f32,
 }
 
 impl StatisticsManager {
@@ -24,6 +25,7 @@ impl StatisticsManager {
         max_history_size: usize,
         nominal_server_frame_interval: Duration,
         steamvr_pipeline_frames: f32,
+        head_prediction_scaler: f32,
     ) -> Self {
         Self {
             max_history_size,
@@ -36,6 +38,7 @@ impl StatisticsManager {
             steamvr_pipeline_latency: Duration::from_secs_f32(
                 steamvr_pipeline_frames * nominal_server_frame_interval.as_secs_f32(),
             ),
+            head_prediction_scaler,
         }
     }
 
@@ -138,5 +141,9 @@ impl StatisticsManager {
         self.total_pipeline_latency_average
             .get_average()
             .saturating_sub(self.steamvr_pipeline_latency)
+    }
+
+    pub fn get_head_predilection_scaler(&self) -> f32 {
+        self.head_prediction_scaler
     }
 }

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1078,6 +1078,9 @@ Tilted: the world gets tilted when long pressing the oculus button. This is usef
     #[schema(flag = "real-time")]
     pub rotation_recentering_mode: RotationRecenteringMode,
 
+    #[schema(gui(slider(min = 0.0, max = 1.0, step = 0.01)))]
+    pub head_prediction_scaler: f32,
+
     #[schema(flag = "steamvr-restart")]
     pub controllers: Switch<ControllersConfig>,
 
@@ -1782,6 +1785,7 @@ pub fn session_settings_default() -> SettingsDefault {
             rotation_recentering_mode: RotationRecenteringModeDefault {
                 variant: RotationRecenteringModeDefaultVariant::Yaw,
             },
+            head_prediction_scaler: 1.0,
         },
         connection: ConnectionConfigDefault {
             stream_protocol: SocketProtocolDefault {


### PR DESCRIPTION
Please forgive the use of machine translation.

I'm not sure when it started, but it seems that a certain degree of predicted motion is now sent to SteamVR.

I understand the significance and effect of this prediction, but ... in environments with low frame rates (such as when in an instance of VRChat with a large number of players), the prediction is a little too large and noise occurs in the head motion.

Adjusting this to a fixed value may not suit some people, so I tried to make it adjustable in the settings!

It is implemented by adding an argument to predict_motion in `alvr\client_core\src\lib.rs` and adjusting delta_time_s.

My hope is that it is important to be able to adjust the strength of the prediction, so if there is a better implementation, please let me know!

<details>

<summary> Original Japanese </summary>

機械翻訳を使用することをご容赦ください。

いつからかはわからないですが、ある程度予測されたモーションを SteamVR に送るようになっていますね。
その予測の行う意義や効果はよくわかるのですが ... フレームレートがあまり出ない環境下(VRChat にて非常にプレイヤーの多い インスタンスにいる場合など)では 少し予測が大きく頭のモーションにノイズが発生してしまいます。

これを固定値で調整することは人によって合わないことが発生しうるので、設定にて調整できるようにしてみました！


実装としては、`alvr\client_core\src\lib.rs` の predict_motion に引数を追加し、 delta_time_s を調整することで実装されています。

私の希望としては、予測の強さを調整できることが大事なので、もっと良い実装があるのであれば教えてほしいです！

</details>