### PR TITLE
feat(common): :sparkles: Add `Pose * DeviceMotion` operator

### DIFF
--- a/alvr/common/src/primitives.rs
+++ b/alvr/common/src/primitives.rs
@@ -55,3 +55,15 @@ pub struct DeviceMotion {
     pub linear_velocity: Vec3,
     pub angular_velocity: Vec3,
 }
+
+impl Mul<DeviceMotion> for Pose {
+    type Output = DeviceMotion;
+
+    fn mul(self, rhs: DeviceMotion) -> DeviceMotion {
+        DeviceMotion {
+            pose: self * rhs.pose,
+            linear_velocity: self.orientation * rhs.linear_velocity,
+            angular_velocity: self.orientation * rhs.angular_velocity,
+        }
+    }
+}

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -115,11 +115,7 @@ impl TrackingManager {
     }
 
     pub fn recenter_motion(&self, motion: DeviceMotion) -> DeviceMotion {
-        DeviceMotion {
-            pose: self.recenter_pose(motion.pose),
-            linear_velocity: self.inverse_recentering_origin.orientation * motion.linear_velocity,
-            angular_velocity: self.inverse_recentering_origin.orientation * motion.angular_velocity,
-        }
+        self.inverse_recentering_origin * motion
     }
 
     // Performs all kinds of tracking transformations, driven by settings.


### PR DESCRIPTION
The main purpose of this is to reuse this calculation in multiple places in a private fork