### PR TITLE
Made the dashboard and launcher report respective appids to the system

### DIFF
--- a/alvr/dashboard/src/main.rs
+++ b/alvr/dashboard/src/main.rs
@@ -92,6 +92,7 @@ fn main() {
         &format!("ALVR Dashboard (streamer v{})", *ALVR_VERSION),
         NativeOptions {
             viewport: ViewportBuilder::default()
+                .with_app_id("alvr.dashboard")
                 .with_inner_size((870.0, 600.0))
                 .with_icon(IconData {
                     rgba: image.rgba_data().to_owned(),

--- a/alvr/launcher/src/main.rs
+++ b/alvr/launcher/src/main.rs
@@ -65,6 +65,7 @@ fn main() {
         "ALVR Launcher",
         eframe::NativeOptions {
             viewport: ViewportBuilder::default()
+                .with_app_id("alvr.launcher")
                 .with_inner_size((700.0, 400.0))
                 .with_icon(IconData {
                     rgba: image.rgba_data().to_owned(),

--- a/alvr/xtask/resources/alvr.desktop
+++ b/alvr/xtask/resources/alvr.desktop
@@ -10,4 +10,4 @@ Categories=Game;
 StartupNotify=true
 PrefersNonDefaultGPU=true
 X-KDE-RunOnDiscreteGpu=true
-StartupWMClass=ALVR
+StartupWMClass=alvr.dashboard


### PR DESCRIPTION
It's good practice on Linux and especially Wayland based systems to report a well identifiable appid to the rest of the system. This PR gives the appids `alvr.dashboard` and `alvr.launcher` to the eframe projects respectively.