### PR TITLE
docs(linux): Warning against beta vulkan-radeon version in Linux Troubleshooting wiki page

### DIFF
--- a/wiki/Linux-Troubleshooting.md
+++ b/wiki/Linux-Troubleshooting.md
@@ -37,9 +37,13 @@ If you have Amdvlk installed on your system, it overrides other vulkan drivers a
 ### Fix
 
 Check if amdvlk or amdgpu-pro are installed by seeing if `ls /usr/share/vulkan/icd.d/ | grep -e amd_icd -e amd_pro` shows anything.
-If so, uninstall amdvlk and/or the amdgpu-pro drivers from your system. (This method may not catch all installations due to distro variations)
+If so, uninstall amdvlk and/or the amdgpu-pro drivers from your system. (This method may not catch all installations due to distro variations).
 
 On arch, first install `vulkan-radeon` and uninstall other drivers.
+
+Avoid using the beta vulkan-radeon version.
+
+On arch, that means using the vulkan-radeon package from the official repositories and not the vulkan-radeon-git from the mesa-git repo.
 
 ## Failed to create VAAPI encoder
 

--- a/wiki/Linux-Troubleshooting.md
+++ b/wiki/Linux-Troubleshooting.md
@@ -28,7 +28,7 @@ Could be related to Arch AUR package (either installed not for nvidia on nvidia 
 
 Try using a launcher or portable .tar.gz release from the Releases page.
 
-## Artifacting, no SteamVR Overlay or graphical glitches in streaming view
+## Segfault, Artifacting, no SteamVR Overlay or graphical glitches in streaming view
 
 Could be related to AMD amdvlk or amdgpu-pro driver being present on your system.
 


### PR DESCRIPTION
Hi,

I am running archlinux. My version of vulkan-radeon was from the mesa-git repo, which is for beta builds of the mesa stack.

I ran into some problems. Lauching the dashboard or any VR game with it resulted in a segfault. Not remembering I had the beta version, I tried using other vulkan implementation, namely amdvlk, which caused the issues described in the "Artifacting, no SteamVR Overlay or graphical glitches streaming view" section.

As I don't know how many people are using said beta version, I feel it might be relevant to add the warning in the wiki.

I have updated the section title and text accordingly.