### PR TITLE
fix(server_core): :bug: Fix server locking the session unnecessarily

### DIFF
--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -251,15 +251,14 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
         dbg_connection!("handshake_loop: Try connect to wired device");
 
         let mut wired_client_ips = HashMap::new();
-        if let Some((client_hostname, _)) =
-            SESSION_MANAGER
-                .read()
-                .client_list()
-                .iter()
-                .find(|(hostname, info)| {
-                    info.connection_state == ConnectionState::Disconnected
-                        && hostname.as_str() == WIRED_CLIENT_HOSTNAME
-                })
+        if SESSION_MANAGER
+            .read()
+            .client_list()
+            .iter()
+            .any(|(hostname, info)| {
+                info.connection_state == ConnectionState::Disconnected
+                    && hostname.as_str() == WIRED_CLIENT_HOSTNAME
+            })
         {
             // Make sure the wired connection is created once and kept alive
             let wired_connection = if let Some(connection) = &wired_connection {
@@ -320,7 +319,7 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
             }
 
             let client_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
-            wired_client_ips.insert(client_ip, client_hostname.to_owned());
+            wired_client_ips.insert(client_ip, WIRED_CLIENT_HOSTNAME.to_owned());
         }
 
         if !wired_client_ips.is_empty()


### PR DESCRIPTION
This was a hard one. Apparently when using a if-let statement, the compiler will extend the lifetime of every temporary at the right of `=` for the whole if block, not only the matched value. One of the temporaries is the `RwReadLock` from `SESSION_MANAGER.read()`, so even adding a bunch of `.clone()`s wouldn't work. In this case I didn't actually need to use a if-let so i converted it to a plain if statement which doesn't suffer from the same limitations. This weird behavior should be fixed by the 2024 rust edition.