### PR TITLE
fix(server_openvr): :bug: Fix stuck framerate on SteamVR

### DIFF
--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -388,7 +388,7 @@ extern "C" fn wait_for_vsync() {
         .read()
         .as_ref()
         .and_then(|ctx| ctx.duration_until_next_vsync())
-        .unwrap_or(Duration::from_millis(50));
+        .unwrap_or(Duration::from_millis(8));
 
     thread::sleep(sleep_duration);
 }


### PR DESCRIPTION
This is a rather controversial PR. We verified on discord that this is the fix for lower framerate than expected on SteamVR but we don't yet have an explanation of why. The rationale for this change is that SteamVR might get stuck on a low framerate if we initialize on 50ms frametime.