### PR TITLE
feat(server_openvr): :sparkles: Add "Enforce server frame pacing"

### DIFF
--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -384,13 +384,24 @@ extern "C" fn report_present(timestamp_ns: u64, offset_ns: u64) {
 
 extern "C" fn wait_for_vsync() {
     // NB: don't sleep while locking SERVER_DATA_MANAGER or SERVER_CORE_CONTEXT
-    let sleep_duration = SERVER_CORE_CONTEXT
-        .read()
-        .as_ref()
-        .and_then(|ctx| ctx.duration_until_next_vsync())
-        .unwrap_or(Duration::from_millis(8));
+    let sleep_duration = if alvr_server_core::settings()
+        .video
+        .enforce_server_frame_pacing
+    {
+        SERVER_CORE_CONTEXT
+            .read()
+            .as_ref()
+            .and_then(|ctx| ctx.duration_until_next_vsync())
+    } else {
+        None
+    };
 
-    thread::sleep(sleep_duration);
+    if let Some(duration) = sleep_duration {
+        thread::sleep(duration);
+    } else {
+        // Fallback to avoid deadlocking people's systems accidentally
+        thread::sleep(Duration::from_millis(8));
+    }
 }
 
 pub extern "C" fn shutdown_driver() {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -602,6 +602,12 @@ Blend: corresponds to un-premultiplied alpha"))]
     #[schema(gui(slider(min = 0.50, max = 0.99, step = 0.01)))]
     pub buffering_history_weight: f32,
 
+    #[schema(strings(
+        help = r"This works only on Windows. It shouldn't be disabled except in certain circumstances when you know the VR game will not meet the target framerate."
+    ))]
+    #[schema(flag = "real-time")]
+    pub enforce_server_frame_pacing: bool,
+
     #[schema(flag = "steamvr-restart")]
     pub encoder_config: EncoderConfig,
 
@@ -1418,6 +1424,7 @@ pub fn session_settings_default() -> SettingsDefault {
             preferred_fps: 72.,
             max_buffering_frames: 2.0,
             buffering_history_weight: 0.90,
+            enforce_server_frame_pacing: true,
             bitrate: BitrateConfigDefault {
                 gui_collapsed: false,
                 mode: BitrateModeDefault {


### PR DESCRIPTION
This is exactly the same as the old "Optimize game render latency" but with a different name to make it more clear that you don't want to touch it unless you know what you are doing