### PR TITLE
(feat) Improve frame pacing, and only go framepaceless if the GPU is loaded

### DIFF
--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -507,6 +507,38 @@ impl ServerCoreContext {
             .map(|stats| stats.duration_until_next_vsync())
     }
 
+    pub fn last_game_time_latency(&self) -> Option<Duration> {
+        self.connection_context
+            .statistics_manager
+            .read()
+            .as_ref()
+            .map(|stats| stats.last_game_time_latency())
+    }
+
+    pub fn last_compose_latency(&self) -> Option<Duration> {
+        self.connection_context
+            .statistics_manager
+            .read()
+            .as_ref()
+            .map(|stats| stats.last_compose_latency())
+    }
+
+    pub fn last_frame_present_interval(&self) -> Option<Duration> {
+        self.connection_context
+            .statistics_manager
+            .read()
+            .as_ref()
+            .map(|stats| stats.last_frame_present_interval())
+    }
+
+    pub fn display_interval(&self) -> Option<Duration> {
+        self.connection_context
+            .statistics_manager
+            .read()
+            .as_ref()
+            .map(|stats| stats.display_interval())
+    }
+
     pub fn restart(self) {
         dbg_server_core!("restart");
 


### PR DESCRIPTION
So, there's two modes of frame pacing: Framepaceless and framepaced.

Framepaceless was changed so that it will only omit sleeps if:
 - The game latency is over the display interval
 - The compositor is taking more than 2ms (ie, the GPU is actually loaded)
 - Server FPS (present-to-present latency) is under display interval.

Seems to be more stable in high-FPS games (and the overlay).

Framepaced was changed so that it will subtract the compositing latency from the vsync sleep. Sometimes if the GPU is starting to get fully loaded, the compositing latency will go up to ~5ms or so. This means that for example (assuming a 100Hz HMD):
 - If a game is taking 7ms to render and the compositing takes 3-4ms, the vsync round-up will start constantly thrashing.
 - If a game is taking 10ms to render and the compositing takes 5ms, the vsync will round up like it should.
 - If a game is taking 15ms to render and the compositing takes 5ms, the vsync will round up twice, when arguably it shouldn't have.

For whatever reason, subtracting the compositing latency from the vsync sleep seems to agree more with SteamVR's frame pacing, and in nearing-display-frametime situations, seems to result in a less-thrashy graph. I think what happens is that if a game is taking 7ms to render and compositing takes 3-4ms, the client-side frame queue has an easier time absorbing the impact of 1-2ms variance on the next frame as opposed to the 10ms/0ms thrashing if it starts rounding. For even lower FPS games, SteamVR's frame pacing seems to take the wheel and the graphs get really flat.

I also think that the framepaced change basically makes the framepaceless change almost useless.