### PR TITLE
bugfix(server_openvr, linux): Fix intel graphics failing to run ALVR

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/Controller.h
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.h
@@ -8,7 +8,7 @@
 class Controller : public TrackedDevice {
 public:
     Controller(uint64_t deviceID, vr::EVRSkeletalTrackingLevel skeletonLevel);
-    virtual ~Controller() {};
+    virtual ~Controller() { };
     void RegisterButton(uint64_t id);
     void SetButton(uint64_t id, FfiButtonValue value);
     bool OnPoseUpdate(uint64_t targetTimestampNs, float predictionS, FfiHandData handData);

--- a/alvr/server_openvr/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/CEncoder.cpp
@@ -207,7 +207,6 @@ void CEncoder::Run() {
         FrameRender render(vk_ctx, init, m_fds);
         auto output = render.CreateOutput();
 
-        alvr::VkFrameCtx vk_frame_ctx(vk_ctx, output.imageInfo);
         alvr::VkFrame frame(
             vk_ctx, output.image, output.imageInfo, output.size, output.memory, output.drm
         );
@@ -215,7 +214,7 @@ void CEncoder::Run() {
             &render,
             vk_ctx,
             frame,
-            vk_frame_ctx,
+            output.imageInfo,
             render.GetEncodingWidth(),
             render.GetEncodingHeight()
         );

--- a/alvr/server_openvr/cpp/platform/linux/EncodePipeline.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/EncodePipeline.cpp
@@ -25,13 +25,14 @@ std::unique_ptr<alvr::EncodePipeline> alvr::EncodePipeline::Create(
     Renderer* render,
     VkContext& vk_ctx,
     VkFrame& input_frame,
-    VkFrameCtx& vk_frame_ctx,
+    VkImageCreateInfo& image_create_info,
     uint32_t width,
     uint32_t height
 ) {
     if (Settings::Instance().m_force_sw_encoding == false) {
         if (vk_ctx.nvidia) {
             try {
+                alvr::VkFrameCtx vk_frame_ctx(vk_ctx, image_create_info);
                 auto nvenc = std::make_unique<alvr::EncodePipelineNvEnc>(
                     render, vk_ctx, input_frame, vk_frame_ctx, width, height
                 );

--- a/alvr/server_openvr/cpp/platform/linux/EncodePipeline.h
+++ b/alvr/server_openvr/cpp/platform/linux/EncodePipeline.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <vulkan/vulkan_core.h>
 
 extern "C" struct AVCodecContext;
 extern "C" struct AVPacket;
@@ -41,7 +42,7 @@ public:
         Renderer* render,
         VkContext& vk_ctx,
         VkFrame& input_frame,
-        VkFrameCtx& vk_frame_ctx,
+        VkImageCreateInfo& image_create_info,
         uint32_t width,
         uint32_t height
     );


### PR DESCRIPTION
Fixes https://github.com/alvr-org/ALVR/issues/2014

Known issues around intel graphics in alvr: 
* Software encoding doesn't work (crashes steamvr)
* Quality looks different compared to vaapi on amd, might be issues with parameters passed to ffmpeg (compression doesn't seem to affect it much

Tested on Intel Arc laptop graphics (intel ultra 9)