### PR TITLE
feat: Change Pico platform detection

### DIFF
--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -141,6 +141,7 @@ impl InteractionContext {
             Platform::Pico4 | Platform::Pico4Pro | Platform::Pico4Enterprise => {
                 PICO4_CONTROLLER_PROFILE_PATH
             }
+            p if p.is_pico() => PICO4S_CONTROLLER_PROFILE_PATH,
             p if p.is_vive() => FOCUS3_CONTROLLER_PROFILE_PATH,
             Platform::Yvr => YVR_CONTROLLER_PROFILE_PATH,
             _ => QUEST_CONTROLLER_PROFILE_PATH,

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -138,7 +138,9 @@ impl InteractionContext {
             p if p.is_quest() => QUEST_CONTROLLER_PROFILE_PATH, // todo: create new controller profile for quest pro and 3
             Platform::PicoNeo3 => PICO_NEO3_CONTROLLER_PROFILE_PATH,
             Platform::Pico4Ultra => PICO4S_CONTROLLER_PROFILE_PATH,
-            p if p.is_pico() => PICO4_CONTROLLER_PROFILE_PATH,
+            Platform::Pico4 | Platform::Pico4Pro | Platform::Pico4Enterprise => {
+                PICO4_CONTROLLER_PROFILE_PATH
+            }
             p if p.is_vive() => FOCUS3_CONTROLLER_PROFILE_PATH,
             Platform::Yvr => YVR_CONTROLLER_PROFILE_PATH,
             _ => QUEST_CONTROLLER_PROFILE_PATH,
@@ -286,8 +288,12 @@ impl InteractionContext {
             && !platform.is_vive()
             && extra_extensions::supports_eye_gaze_interaction(&xr_session, xr_system)
         {
+            // todo: research Pico Neo 3 Pro Eye platform detection
             #[cfg(target_os = "android")]
-            if platform.is_pico() {
+            if matches!(
+                platform,
+                Platform::PicoNeo3 | Platform::Pico4Pro | Platform::Pico4Enterprise
+            ) {
                 alvr_system_info::try_get_permission("com.picovr.permission.EYE_TRACKING")
             }
 

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -137,7 +137,11 @@ pub fn entry_point() {
 
     let loader_suffix = match platform {
         Platform::Quest1 => "_quest1",
-        Platform::PicoNeo3 | Platform::PicoG3 | Platform::Pico4 => "_pico_old",
+        Platform::PicoNeo3
+        | Platform::PicoG3
+        | Platform::Pico4
+        | Platform::Pico4Pro
+        | Platform::Pico4Enterprise => "_pico_old",
         Platform::Yvr => "_yvr",
         Platform::Lynx => "_lynx",
         _ => "",

--- a/alvr/system_info/src/lib.rs
+++ b/alvr/system_info/src/lib.rs
@@ -23,6 +23,8 @@ pub enum Platform {
     QuestUnknown,
     PicoNeo3,
     Pico4,
+    Pico4Pro,
+    Pico4Enterprise,
     Pico4Ultra,
     PicoG3,
     PicoUnknown,
@@ -59,6 +61,8 @@ impl Platform {
             Platform::PicoG3
                 | Platform::PicoNeo3
                 | Platform::Pico4
+                | Platform::Pico4Pro
+                | Platform::Pico4Enterprise
                 | Platform::Pico4Ultra
                 | Platform::PicoUnknown
         )
@@ -83,6 +87,8 @@ impl Display for Platform {
             Platform::QuestUnknown => "Quest (unknown)",
             Platform::PicoNeo3 => "Pico Neo 3",
             Platform::Pico4 => "Pico 4",
+            Platform::Pico4Pro => "Pico 4 Pro",
+            Platform::Pico4Enterprise => "Pico 4 Enterprise",
             Platform::Pico4Ultra => "Pico 4 Ultra",
             Platform::PicoG3 => "Pico G3",
             Platform::PicoUnknown => "Pico (unknown)",
@@ -120,9 +126,11 @@ pub fn platform() -> Platform {
             ("Oculus", _, "seacliff") => Platform::QuestPro,
             ("Oculus", _, _) => Platform::QuestUnknown,
             ("Pico", "Pico Neo 3" | "Pico Neo3 Link", _) => Platform::PicoNeo3,
-            ("Pico", _, "PICOA8110" | "phoenix") => Platform::Pico4,
-            ("Pico", _, "sparrow") => Platform::Pico4Ultra,
-            ("Pico", _, "merline") => Platform::PicoG3,
+            ("Pico", "A8A10", _) => Platform::Pico4Pro,
+            ("Pico", "A8E50", _) => Platform::Pico4Enterprise,
+            ("Pico", "A8110", _) => Platform::Pico4,
+            ("Pico", "A9210", _) => Platform::Pico4Ultra,
+            ("Pico", "A7Q10", _) => Platform::PicoG3,
             ("Pico", _, _) => Platform::PicoUnknown,
             ("HTC", "VIVE Focus 3", _) => Platform::Focus3,
             ("HTC", "VIVE Focus Vision", _) => Platform::FocusVision,


### PR DESCRIPTION
Introduces `Platform::Pico4Enterprise` and `Platform::Pico4Pro`, changes device model detection criteria.