### PR TITLE
feat: :sparkles: Add eye and lip tracking on Vive

### DIFF
--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -94,10 +94,10 @@ orientation = "landscape"
 [[package.metadata.android.application.activity.intent_filter]]
 actions = ["android.intent.action.MAIN"]
 categories = [
-    "android.intent.category.LAUNCHER",
-    "com.oculus.intent.category.VR",
-    "com.yvr.intent.category.VR",
-    "org.khronos.openxr.intent.category.IMMERSIVE_HMD",
+	"android.intent.category.LAUNCHER",
+	"com.oculus.intent.category.VR",
+	"com.yvr.intent.category.VR",
+	"org.khronos.openxr.intent.category.IMMERSIVE_HMD",
 ]
 
 # Quest entries
@@ -147,13 +147,13 @@ value = "V2.0"
 # Vive entries
 [[package.metadata.android.uses_feature]]
 name = "wave.feature.eyetracking"
-required = true
+required = false
 [[package.metadata.android.uses_feature]]
 name = "wave.feature.handtracking"
 required = true
 [[package.metadata.android.uses_feature]]
 name = "wave.feature.lipexpression"
-required = true
+required = false
 [[package.metadata.android.application.meta_data]]
 name = "minWaveSDKVersion"
 value = "1"

--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -144,9 +144,15 @@ value = "HIGH"
 name = "com.oculus.handtracking.version"
 value = "V2.0"
 
-# Vive Focus 3 entries
+# Vive entries
+[[package.metadata.android.uses_feature]]
+name = "wave.feature.eyetracking"
+required = true
 [[package.metadata.android.uses_feature]]
 name = "wave.feature.handtracking"
+required = true
+[[package.metadata.android.uses_feature]]
+name = "wave.feature.lipexpression"
 required = true
 [[package.metadata.android.application.meta_data]]
 name = "minWaveSDKVersion"

--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -94,10 +94,10 @@ orientation = "landscape"
 [[package.metadata.android.application.activity.intent_filter]]
 actions = ["android.intent.action.MAIN"]
 categories = [
-	"android.intent.category.LAUNCHER",
-	"com.oculus.intent.category.VR",
-	"com.yvr.intent.category.VR",
-	"org.khronos.openxr.intent.category.IMMERSIVE_HMD",
+    "android.intent.category.LAUNCHER",
+    "com.oculus.intent.category.VR",
+    "com.yvr.intent.category.VR",
+    "org.khronos.openxr.intent.category.IMMERSIVE_HMD",
 ]
 
 # Quest entries

--- a/alvr/client_openxr/src/extra_extensions/face_tracking2_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/face_tracking2_fb.rs
@@ -2,12 +2,14 @@ use openxr::{self as xr, raw, sys};
 use std::ptr;
 
 pub struct FaceTracker2FB {
+    // Keeping a reference to the session to ensure that the tracker handle remains valid
+    _session: xr::Session<xr::AnyGraphics>,
     handle: sys::FaceTracker2FB,
     ext_fns: raw::FaceTracking2FB,
 }
 
 impl FaceTracker2FB {
-    pub fn new<G>(session: &xr::Session<G>, visual: bool, audio: bool) -> xr::Result<Self> {
+    pub fn new<G>(session: xr::Session<G>, visual: bool, audio: bool) -> xr::Result<Self> {
         let ext_fns = session
             .instance()
             .exts()
@@ -38,7 +40,11 @@ impl FaceTracker2FB {
             ))?
         };
 
-        Ok(Self { handle, ext_fns })
+        Ok(Self {
+            _session: session.into_any_graphics(),
+            handle,
+            ext_fns,
+        })
     }
 
     pub fn get_face_expression_weights(&self, time: xr::Time) -> xr::Result<Option<Vec<f32>>> {

--- a/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
+++ b/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
@@ -66,14 +66,14 @@ impl FacialTrackerHTC {
         })
     }
 
-    pub fn get_facial_expressions(&self) -> xr::Result<Option<Vec<f32>>> {
+    pub fn get_facial_expressions(&self, sample_time: xr::Time) -> xr::Result<Option<Vec<f32>>> {
         let mut weights = Vec::with_capacity(self.expression_count);
 
         let mut facial_expressions = sys::FacialExpressionsHTC {
             ty: sys::FacialExpressionsHTC::TYPE,
             next: ptr::null_mut(),
             is_active: sys::FALSE,
-            sample_time: xr::Time::from_nanos(0),
+            sample_time,
             expression_count: self.expression_count as u32,
             expression_weightings: weights.as_mut_ptr(),
         };

--- a/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
+++ b/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
@@ -66,14 +66,14 @@ impl FacialTrackerHTC {
         })
     }
 
-    pub fn get_facial_expressions(&self, sample_time: xr::Time) -> xr::Result<Option<Vec<f32>>> {
+    pub fn get_facial_expressions(&self, time: xr::Time) -> xr::Result<Option<Vec<f32>>> {
         let mut weights = Vec::with_capacity(self.expression_count);
 
         let mut facial_expressions = sys::FacialExpressionsHTC {
             ty: sys::FacialExpressionsHTC::TYPE,
             next: ptr::null_mut(),
             is_active: sys::FALSE,
-            sample_time,
+            sample_time: time,
             expression_count: self.expression_count as u32,
             expression_weightings: weights.as_mut_ptr(),
         };

--- a/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
+++ b/alvr/client_openxr/src/extra_extensions/facial_tracking_htc.rs
@@ -2,6 +2,8 @@ use openxr::{self as xr, raw, sys};
 use std::ptr;
 
 pub struct FacialTrackerHTC {
+    // Keeping a reference to the session to ensure that the tracker handle remains valid
+    _session: xr::Session<xr::AnyGraphics>,
     handle: sys::FacialTrackerHTC,
     ext_fns: raw::FacialTrackingHTC,
     expression_count: usize,
@@ -9,7 +11,8 @@ pub struct FacialTrackerHTC {
 
 impl FacialTrackerHTC {
     pub fn new<G>(
-        session: &xr::Session<G>,
+        session: xr::Session<G>,
+        system: xr::SystemId,
         facial_tracking_type: xr::FacialTrackingTypeHTC,
     ) -> xr::Result<Self> {
         let ext_fns = session
@@ -17,6 +20,29 @@ impl FacialTrackerHTC {
             .exts()
             .htc_facial_tracking
             .ok_or(sys::Result::ERROR_EXTENSION_NOT_PRESENT)?;
+
+        let props = super::get_props(
+            &session,
+            system,
+            sys::SystemFacialTrackingPropertiesHTC {
+                ty: sys::SystemFacialTrackingPropertiesHTC::TYPE,
+                next: ptr::null_mut(),
+                support_eye_facial_tracking: sys::FALSE,
+                support_lip_facial_tracking: sys::FALSE,
+            },
+        )?;
+
+        let expression_count = if facial_tracking_type == sys::FacialTrackingTypeHTC::EYE_DEFAULT
+            && props.support_eye_facial_tracking.into()
+        {
+            sys::FACIAL_EXPRESSION_EYE_COUNT_HTC
+        } else if facial_tracking_type == sys::FacialTrackingTypeHTC::LIP_DEFAULT
+            && props.support_lip_facial_tracking.into()
+        {
+            sys::FACIAL_EXPRESSION_LIP_COUNT_HTC
+        } else {
+            return Err(sys::Result::ERROR_FEATURE_UNSUPPORTED);
+        };
 
         let mut handle = sys::FacialTrackerHTC::NULL;
         let info = sys::FacialTrackerCreateInfoHTC {
@@ -32,13 +58,8 @@ impl FacialTrackerHTC {
             ))?
         };
 
-        let expression_count = if facial_tracking_type == sys::FacialTrackingTypeHTC::EYE_DEFAULT {
-            sys::FACIAL_EXPRESSION_EYE_COUNT_HTC
-        } else {
-            sys::FACIAL_EXPRESSION_LIP_COUNT_HTC
-        };
-
         Ok(Self {
+            _session: session.into_any_graphics(),
             handle,
             ext_fns,
             expression_count,
@@ -64,6 +85,8 @@ impl FacialTrackerHTC {
             ))?;
 
             if facial_expressions.is_active.into() {
+                weights.set_len(self.expression_count);
+
                 Ok(Some(weights))
             } else {
                 Ok(None)

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -351,6 +351,23 @@ impl InteractionContext {
             xr_session.create_hand_tracker(xr::Hand::RIGHT)
         });
 
+        // Note: HTC facial tracking can only be created at startup before xrBeginSession. We don't
+        // know the reason.
+        let eye_tracker_htc = create_ext_object("FacialTrackerHTC (eyes)", Some(true), || {
+            FacialTrackerHTC::new(
+                xr_session.clone(),
+                xr_system,
+                xr::FacialTrackingTypeHTC::EYE_DEFAULT,
+            )
+        });
+        let lip_tracker_htc = create_ext_object("FacialTrackerHTC (lips)", Some(true), || {
+            FacialTrackerHTC::new(
+                xr_session.clone(),
+                xr_system,
+                xr::FacialTrackingTypeHTC::LIP_DEFAULT,
+            )
+        });
+
         Self {
             xr_session,
             xr_system,
@@ -384,8 +401,8 @@ impl InteractionContext {
                 combined_eyes_source,
                 eye_tracker_fb: None,
                 face_tracker_fb: None,
-                eye_tracker_htc: None,
-                lip_tracker_htc: None,
+                eye_tracker_htc,
+                lip_tracker_htc,
                 face_tracker_pico: None,
             },
             body_sources: BodySources {
@@ -406,8 +423,6 @@ impl InteractionContext {
         self.multimodal_hands_enabled = false;
         self.face_sources.eye_tracker_fb = None;
         self.face_sources.face_tracker_fb = None;
-        self.face_sources.eye_tracker_htc = None;
-        self.face_sources.lip_tracker_htc = None;
         self.face_sources.face_tracker_pico = None;
         self.body_sources.body_tracker_fb = None;
         self.body_sources.body_tracker_bd = None;
@@ -470,30 +485,6 @@ impl InteractionContext {
             "FaceTrackerPico",
             config.face_tracking.as_ref().map(|s| s.face_tracking_pico),
             || FaceTrackerPico::new(self.xr_session.clone(), true, true),
-        );
-
-        self.face_sources.eye_tracker_htc = create_ext_object(
-            "FacialTrackerHTC (eyes)",
-            config.face_tracking.as_ref().map(|s| s.eye_expressions_htc),
-            || {
-                FacialTrackerHTC::new(
-                    self.xr_session.clone(),
-                    self.xr_system,
-                    xr::FacialTrackingTypeHTC::EYE_DEFAULT,
-                )
-            },
-        );
-
-        self.face_sources.lip_tracker_htc = create_ext_object(
-            "FacialTrackerHTC (lips)",
-            config.face_tracking.as_ref().map(|s| s.lip_expressions_htc),
-            || {
-                FacialTrackerHTC::new(
-                    self.xr_session.clone(),
-                    self.xr_system,
-                    xr::FacialTrackingTypeHTC::LIP_DEFAULT,
-                )
-            },
         );
 
         self.body_sources.body_tracker_fb = create_ext_object(

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -463,7 +463,7 @@ impl InteractionContext {
         self.face_sources.face_tracker_fb = create_ext_object(
             "FaceTracker2FB",
             config.face_tracking.as_ref().map(|s| s.face_tracking_fb),
-            || FaceTracker2FB::new(&self.xr_session, true, true),
+            || FaceTracker2FB::new(self.xr_session.clone(), true, true),
         );
 
         self.face_sources.face_tracker_pico = create_ext_object(
@@ -475,13 +475,25 @@ impl InteractionContext {
         self.face_sources.eye_tracker_htc = create_ext_object(
             "FacialTrackerHTC (eyes)",
             config.face_tracking.as_ref().map(|s| s.eye_expressions_htc),
-            || FacialTrackerHTC::new(&self.xr_session, xr::FacialTrackingTypeHTC::EYE_DEFAULT),
+            || {
+                FacialTrackerHTC::new(
+                    self.xr_session.clone(),
+                    self.xr_system,
+                    xr::FacialTrackingTypeHTC::EYE_DEFAULT,
+                )
+            },
         );
 
         self.face_sources.lip_tracker_htc = create_ext_object(
             "FacialTrackerHTC (lips)",
             config.face_tracking.as_ref().map(|s| s.lip_expressions_htc),
-            || FacialTrackerHTC::new(&self.xr_session, xr::FacialTrackingTypeHTC::LIP_DEFAULT),
+            || {
+                FacialTrackerHTC::new(
+                    self.xr_session.clone(),
+                    self.xr_system,
+                    xr::FacialTrackingTypeHTC::LIP_DEFAULT,
+                )
+            },
         );
 
         self.body_sources.body_tracker_fb = create_ext_object(
@@ -890,7 +902,6 @@ pub fn get_htc_eye_expression(context: &FaceSources) -> Option<Vec<f32>> {
         .eye_tracker_htc
         .as_ref()
         .and_then(|t| t.get_facial_expressions().ok().flatten())
-        .map(|weights| weights.into_iter().collect())
 }
 
 pub fn get_htc_lip_expression(context: &FaceSources) -> Option<Vec<f32>> {
@@ -898,7 +909,6 @@ pub fn get_htc_lip_expression(context: &FaceSources) -> Option<Vec<f32>> {
         .lip_tracker_htc
         .as_ref()
         .and_then(|t| t.get_facial_expressions().ok().flatten())
-        .map(|weights| weights.into_iter().collect())
 }
 
 pub fn get_fb_body_skeleton(

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -897,18 +897,22 @@ pub fn get_pico_face_expression(context: &FaceSources, time: Duration) -> Option
         .map(|weights| weights.into_iter().collect())
 }
 
-pub fn get_htc_eye_expression(context: &FaceSources) -> Option<Vec<f32>> {
+pub fn get_htc_eye_expression(context: &FaceSources, time: Duration) -> Option<Vec<f32>> {
+    let xr_time = crate::to_xr_time(time);
+
     context
         .eye_tracker_htc
         .as_ref()
-        .and_then(|t| t.get_facial_expressions().ok().flatten())
+        .and_then(|t| t.get_facial_expressions(xr_time).ok().flatten())
 }
 
-pub fn get_htc_lip_expression(context: &FaceSources) -> Option<Vec<f32>> {
+pub fn get_htc_lip_expression(context: &FaceSources, time: Duration) -> Option<Vec<f32>> {
+    let xr_time = crate::to_xr_time(time);
+
     context
         .lip_tracker_htc
         .as_ref()
-        .and_then(|t| t.get_facial_expressions().ok().flatten())
+        .and_then(|t| t.get_facial_expressions(xr_time).ok().flatten())
 }
 
 pub fn get_fb_body_skeleton(

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -17,7 +17,7 @@ use alvr_common::{
     Fov, Pose, HAND_LEFT_ID,
 };
 use alvr_graphics::GraphicsContext;
-use alvr_session::{BodyTrackingBDConfig, BodyTrackingSourcesConfig};
+use alvr_session::{BodyTrackingBDConfig, BodyTrackingSourcesConfig, FaceTrackingSourcesConfig};
 use alvr_system_info::Platform;
 use extra_extensions::{
     BD_BODY_TRACKING_EXTENSION_NAME, META_BODY_TRACKING_FULL_BODY_EXTENSION_NAME,
@@ -295,8 +295,15 @@ pub fn entry_point() {
                 prompt_calibration_on_start: false,
             }),
         };
+        let lobby_face_tracking_config = FaceTrackingSourcesConfig {
+            eye_tracking_fb: false,
+            face_tracking_fb: false,
+            face_tracking_pico: false,
+            eye_expressions_htc: true,
+            lip_expressions_htc: true,
+        };
         let lobby_interaction_sources = InteractionSourcesConfig {
-            face_tracking: None,
+            face_tracking: Some(lobby_face_tracking_config),
             body_tracking: Some(lobby_body_tracking_config),
             prefers_multimodal_input: true,
         };
@@ -482,6 +489,13 @@ pub fn entry_point() {
             let (layer, display_time) = if let Some(stream) = &mut stream_context {
                 stream.render(frame_interval, vsync_time)
             } else {
+                let face_tracker_test = &interaction_context
+                    .read()
+                    .face_sources
+                    .lip_tracker_htc
+                    .as_ref()
+                    .map(|t| t.get_facial_expressions(crate::to_xr_time(vsync_time)));
+                alvr_common::info!("{:#?}", face_tracker_test);
                 (lobby.render(vsync_time), vsync_time)
             };
 

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -17,7 +17,7 @@ use alvr_common::{
     Fov, Pose, HAND_LEFT_ID,
 };
 use alvr_graphics::GraphicsContext;
-use alvr_session::{BodyTrackingBDConfig, BodyTrackingSourcesConfig, FaceTrackingSourcesConfig};
+use alvr_session::{BodyTrackingBDConfig, BodyTrackingSourcesConfig};
 use alvr_system_info::Platform;
 use extra_extensions::{
     BD_BODY_TRACKING_EXTENSION_NAME, META_BODY_TRACKING_FULL_BODY_EXTENSION_NAME,
@@ -295,15 +295,8 @@ pub fn entry_point() {
                 prompt_calibration_on_start: false,
             }),
         };
-        let lobby_face_tracking_config = FaceTrackingSourcesConfig {
-            eye_tracking_fb: false,
-            face_tracking_fb: false,
-            face_tracking_pico: false,
-            eye_expressions_htc: true,
-            lip_expressions_htc: true,
-        };
         let lobby_interaction_sources = InteractionSourcesConfig {
-            face_tracking: Some(lobby_face_tracking_config),
+            face_tracking: None,
             body_tracking: Some(lobby_body_tracking_config),
             prefers_multimodal_input: true,
         };
@@ -489,13 +482,6 @@ pub fn entry_point() {
             let (layer, display_time) = if let Some(stream) = &mut stream_context {
                 stream.render(frame_interval, vsync_time)
             } else {
-                let face_tracker_test = &interaction_context
-                    .read()
-                    .face_sources
-                    .lip_tracker_htc
-                    .as_ref()
-                    .map(|t| t.get_facial_expressions(crate::to_xr_time(vsync_time)));
-                alvr_common::info!("{:#?}", face_tracker_test);
                 (lobby.render(vsync_time), vsync_time)
             };
 

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -538,8 +538,8 @@ fn stream_input_loop(
             fb_face_expression: interaction::get_fb_face_expression(&int_ctx.face_sources, now).or(
                 interaction::get_pico_face_expression(&int_ctx.face_sources, now),
             ),
-            htc_eye_expression: interaction::get_htc_eye_expression(&int_ctx.face_sources),
-            htc_lip_expression: interaction::get_htc_lip_expression(&int_ctx.face_sources),
+            htc_eye_expression: interaction::get_htc_eye_expression(&int_ctx.face_sources, now),
+            htc_lip_expression: interaction::get_htc_lip_expression(&int_ctx.face_sources, now),
         };
 
         if let Some((tracker, joint_count)) = &int_ctx.body_sources.body_tracker_fb {


### PR DESCRIPTION
Tested and working on the Focus Vision. because of a limitation of the runtime, the tracker objects can only be initialized at startup.