### PR TITLE
feat(client_openxr): Add support for Play for Dream MR + misc fixes for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a fork of [ALVR](https://github.com/polygraphene/ALVR).
 |       Apple Vision Pro       |    :heavy_check_mark: ([store link](https://apps.apple.com/app/alvr/id6479728026))     |
 |      Quest 1/2/3/3S/Pro      | :heavy_check_mark: ([store link](https://www.meta.com/experiences/7674846229245715) *) |
 |     Pico Neo 3/4/4 Ultra     |                                   :heavy_check_mark:                                   |
-|    Play For Dream YVR 1/2    |                                   :heavy_check_mark:                                   |
+|    Play For Dream YVR 1/2/MR |                                   :heavy_check_mark:                                   |
 | Vive Focus 3/Vision/XR Elite |                                   :heavy_check_mark:                                   |
 |           Lynx R1            |                                   :heavy_check_mark:                                   |
 |     PhoneVR (smartphone)     |     :heavy_check_mark: ** ([repo](https://github.com/PhoneVR-Developers/PhoneVR))      |

--- a/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
@@ -10,8 +10,7 @@ pub struct PassthroughFB {
 }
 
 impl PassthroughFB {
-    pub fn new(session: &xr::Session<xr::OpenGlEs>) -> xr::Result<Self> {
-        let platform = alvr_system_info::platform();
+    pub fn new(session: &xr::Session<xr::OpenGlEs>, platform: Platform) -> xr::Result<Self> {
         let ext_fns = session
             .instance()
             .exts()
@@ -56,8 +55,8 @@ impl PassthroughFB {
             layer_handle,
         };
 
-        // HACK: YVR runtime seems to ignore IS_RUNNING_AT_CREATION
-        if platform == Platform::Yvr {
+        // HACK: YVR runtime seems to ignore IS_RUNNING_AT_CREATION on versions <= 3.0.1
+        if platform.is_yvr() {
             unsafe { super::xr_res((ext_fns.passthrough_start)(handle))? };
         }
 

--- a/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
@@ -54,6 +54,7 @@ impl PassthroughFB {
             layer_handle,
         };
 
+        // HACK: YVR runtime seems to ignore IS_RUNNING_AT_CREATION
         unsafe { super::xr_res((ext_fns.passthrough_start)(handle))? };
 
         Ok(Self {

--- a/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
@@ -35,7 +35,7 @@ impl PassthroughFB {
             ty: sys::PassthroughLayerCreateInfoFB::TYPE,
             next: ptr::null(),
             passthrough: handle,
-            flags: sys::PassthroughFlagsFB::IS_RUNNING_AT_CREATION,
+            flags: sys::PassthroughFlagsFB::EMPTY,
             purpose: sys::PassthroughLayerPurposeFB::RECONSTRUCTION,
         };
         unsafe {
@@ -54,7 +54,8 @@ impl PassthroughFB {
             layer_handle,
         };
 
-        // HACK: YVR runtime seems to ignore IS_RUNNING_AT_CREATION
+        // HACK: YVR runtime seems to ignore IS_RUNNING_AT_CREATION, so we do this
+        // instead for all headsets
         unsafe { super::xr_res((ext_fns.passthrough_start)(handle))? };
 
         Ok(Self {

--- a/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
@@ -54,6 +54,8 @@ impl PassthroughFB {
             layer_handle,
         };
 
+        unsafe { super::xr_res((ext_fns.passthrough_start)(handle))? };
+
         Ok(Self {
             handle,
             layer_handle,

--- a/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
@@ -1,3 +1,4 @@
+use alvr_system_info::Platform;
 use openxr::{self as xr, raw, sys};
 use std::ptr;
 
@@ -10,6 +11,7 @@ pub struct PassthroughFB {
 
 impl PassthroughFB {
     pub fn new(session: &xr::Session<xr::OpenGlEs>) -> xr::Result<Self> {
+        let platform = alvr_system_info::platform();
         let ext_fns = session
             .instance()
             .exts()
@@ -55,7 +57,9 @@ impl PassthroughFB {
         };
 
         // HACK: YVR runtime seems to ignore IS_RUNNING_AT_CREATION
-        unsafe { super::xr_res((ext_fns.passthrough_start)(handle))? };
+        if platform == Platform::Yvr {
+            unsafe { super::xr_res((ext_fns.passthrough_start)(handle))? };
+        }
 
         Ok(Self {
             handle,

--- a/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
@@ -35,7 +35,7 @@ impl PassthroughFB {
             ty: sys::PassthroughLayerCreateInfoFB::TYPE,
             next: ptr::null(),
             passthrough: handle,
-            flags: sys::PassthroughFlagsFB::EMPTY,
+            flags: sys::PassthroughFlagsFB::IS_RUNNING_AT_CREATION,
             purpose: sys::PassthroughLayerPurposeFB::RECONSTRUCTION,
         };
         unsafe {
@@ -54,8 +54,7 @@ impl PassthroughFB {
             layer_handle,
         };
 
-        // HACK: YVR runtime seems to ignore IS_RUNNING_AT_CREATION, so we do this
-        // instead for all headsets
+        // HACK: YVR runtime seems to ignore IS_RUNNING_AT_CREATION
         unsafe { super::xr_res((ext_fns.passthrough_start)(handle))? };
 
         Ok(Self {

--- a/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
+++ b/alvr/client_openxr/src/extra_extensions/passthrough_fb.rs
@@ -49,7 +49,7 @@ impl PassthroughFB {
         let layer = sys::CompositionLayerPassthroughFB {
             ty: sys::CompositionLayerPassthroughFB::TYPE,
             next: ptr::null(),
-            flags: xr::CompositionLayerFlags::EMPTY,
+            flags: xr::CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA,
             space: sys::Space::NULL,
             layer_handle,
         };

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -150,7 +150,7 @@ impl InteractionContext {
             }
             p if p.is_pico() => PICO4S_CONTROLLER_PROFILE_PATH,
             p if p.is_vive() => FOCUS3_CONTROLLER_PROFILE_PATH,
-            Platform::Yvr => YVR_CONTROLLER_PROFILE_PATH,
+            Platform::Yvr | Platform::PfdMr => YVR_CONTROLLER_PROFILE_PATH,
             _ => QUEST_CONTROLLER_PROFILE_PATH,
         };
         let controllers_profile_id = alvr_common::hash_string(controllers_profile_path);

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -150,7 +150,7 @@ impl InteractionContext {
             }
             p if p.is_pico() => PICO4S_CONTROLLER_PROFILE_PATH,
             p if p.is_vive() => FOCUS3_CONTROLLER_PROFILE_PATH,
-            Platform::Yvr | Platform::PfdMr => YVR_CONTROLLER_PROFILE_PATH,
+            p if p.is_yvr() => YVR_CONTROLLER_PROFILE_PATH,
             _ => QUEST_CONTROLLER_PROFILE_PATH,
         };
         let controllers_profile_id = alvr_common::hash_string(controllers_profile_path);

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -145,7 +145,7 @@ pub fn entry_point() {
         | Platform::Pico4
         | Platform::Pico4Pro
         | Platform::Pico4Enterprise => "_pico_old",
-        Platform::Yvr => "_yvr",
+        Platform::Yvr | Platform::PfdMr => "_yvr",
         Platform::Lynx => "_lynx",
         _ => "",
     };
@@ -326,7 +326,7 @@ pub fn entry_point() {
 
                             core_context.resume();
 
-                            passthrough_layer = PassthroughLayer::new(&xr_session).ok();
+                            passthrough_layer = PassthroughLayer::new(&xr_session, platform).ok();
 
                             session_running = true;
                         }
@@ -405,7 +405,7 @@ pub fn entry_point() {
                     }
                     ClientCoreEvent::StreamingStopped => {
                         if passthrough_layer.is_none() {
-                            passthrough_layer = PassthroughLayer::new(&xr_session).ok();
+                            passthrough_layer = PassthroughLayer::new(&xr_session, platform).ok();
                         }
 
                         interaction_context
@@ -442,7 +442,7 @@ pub fn entry_point() {
                     }
                     ClientCoreEvent::RealTimeConfig(config) => {
                         if config.passthrough.is_some() && passthrough_layer.is_none() {
-                            passthrough_layer = PassthroughLayer::new(&xr_session).ok();
+                            passthrough_layer = PassthroughLayer::new(&xr_session, platform).ok();
                         } else if config.passthrough.is_none() && passthrough_layer.is_some() {
                             passthrough_layer = None;
                         }

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -253,7 +253,7 @@ pub fn entry_point() {
         };
 
         if exts.fb_color_space {
-            xr_session.set_color_space(xr::ColorSpaceFB::P3).unwrap();
+            xr_session.set_color_space(xr::ColorSpaceFB::REC709).unwrap();
         }
 
         let capabilities = ClientCapabilities {

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -145,7 +145,7 @@ pub fn entry_point() {
         | Platform::Pico4
         | Platform::Pico4Pro
         | Platform::Pico4Enterprise => "_pico_old",
-        Platform::Yvr | Platform::PfdMr => "_yvr",
+        p if p.is_yvr() => "_yvr",
         Platform::Lynx => "_lynx",
         _ => "",
     };

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -253,7 +253,9 @@ pub fn entry_point() {
         };
 
         if exts.fb_color_space {
-            xr_session.set_color_space(xr::ColorSpaceFB::REC709).unwrap();
+            xr_session
+                .set_color_space(xr::ColorSpaceFB::REC709)
+                .unwrap();
         }
 
         let capabilities = ClientCapabilities {

--- a/alvr/client_openxr/src/passthrough.rs
+++ b/alvr/client_openxr/src/passthrough.rs
@@ -1,5 +1,6 @@
 use crate::extra_extensions::{PassthroughFB, PassthroughHTC};
 use alvr_common::anyhow::{bail, Result};
+use alvr_system_info::Platform;
 use openxr::{
     self as xr,
     sys::{CompositionLayerPassthroughFB, CompositionLayerPassthroughHTC},
@@ -13,13 +14,13 @@ pub struct PassthroughLayer<'a> {
 }
 
 impl PassthroughLayer<'_> {
-    pub fn new(session: &xr::Session<xr::OpenGlEs>) -> Result<Self> {
+    pub fn new(session: &xr::Session<xr::OpenGlEs>, platform: Platform) -> Result<Self> {
         let mut handle_fb = None;
         let mut handle_htc = None;
 
         let exts = session.instance().exts();
         if exts.fb_passthrough.is_some() {
-            handle_fb = Some(PassthroughFB::new(session)?);
+            handle_fb = Some(PassthroughFB::new(session, platform)?);
         } else if exts.htc_passthrough.is_some() {
             handle_htc = Some(PassthroughHTC::new(session)?);
         } else {

--- a/alvr/common/src/inputs.rs
+++ b/alvr/common/src/inputs.rs
@@ -454,7 +454,9 @@ pub static CONTROLLER_PROFILE_INFO: Lazy<HashMap<u64, InteractionProfileInfo>> =
                 path: YVR_CONTROLLER_PROFILE_PATH,
                 button_set: [
                     *LEFT_X_CLICK_ID,
+                    *LEFT_X_TOUCH_ID,
                     *LEFT_Y_CLICK_ID,
+                    *LEFT_Y_TOUCH_ID,
                     *LEFT_MENU_CLICK_ID,
                     *LEFT_SQUEEZE_CLICK_ID,
                     *LEFT_TRIGGER_TOUCH_ID,
@@ -463,9 +465,11 @@ pub static CONTROLLER_PROFILE_INFO: Lazy<HashMap<u64, InteractionProfileInfo>> =
                     *LEFT_THUMBSTICK_Y_ID,
                     *LEFT_THUMBSTICK_CLICK_ID,
                     *LEFT_THUMBSTICK_TOUCH_ID,
-                    *LEFT_THUMBREST_TOUCH_ID,
+                    *LEFT_THUMBREST_TOUCH_ID, // might not actually be present?
                     *RIGHT_A_CLICK_ID,
+                    *RIGHT_A_TOUCH_ID,
                     *RIGHT_B_CLICK_ID,
+                    *RIGHT_B_TOUCH_ID,
                     *RIGHT_SYSTEM_CLICK_ID,
                     *RIGHT_SQUEEZE_CLICK_ID,
                     *RIGHT_TRIGGER_TOUCH_ID,
@@ -474,7 +478,7 @@ pub static CONTROLLER_PROFILE_INFO: Lazy<HashMap<u64, InteractionProfileInfo>> =
                     *RIGHT_THUMBSTICK_Y_ID,
                     *RIGHT_THUMBSTICK_CLICK_ID,
                     *RIGHT_THUMBSTICK_TOUCH_ID,
-                    *RIGHT_THUMBREST_TOUCH_ID,
+                    *RIGHT_THUMBREST_TOUCH_ID, // might not actually be present?
                 ]
                 .into_iter()
                 .collect(),

--- a/alvr/system_info/src/lib.rs
+++ b/alvr/system_info/src/lib.rs
@@ -33,6 +33,7 @@ pub enum Platform {
     XRElite,
     ViveUnknown,
     Yvr,
+    PfdMr,
     Lynx,
     AndroidUnknown,
     AppleHeadset,
@@ -74,6 +75,10 @@ impl Platform {
             Platform::Focus3 | Platform::FocusVision | Platform::XRElite | Platform::ViveUnknown
         )
     }
+
+    pub const fn is_yvr(&self) -> bool {
+        matches!(self, Platform::Yvr | Platform::PfdMr)
+    }
 }
 
 impl Display for Platform {
@@ -97,6 +102,7 @@ impl Display for Platform {
             Platform::XRElite => "VIVE XR Elite",
             Platform::ViveUnknown => "HTC VIVE (unknown)",
             Platform::Yvr => "YVR",
+            Platform::PfdMr => "Play For Dream MR",
             Platform::Lynx => "Lynx Headset",
             Platform::AndroidUnknown => "Android (unknown)",
             Platform::AppleHeadset => "Apple Headset",
@@ -145,7 +151,7 @@ pub fn platform() -> Platform {
             ("HTC", "VIVE XR Series", _, _) => Platform::XRElite,
             ("HTC", _, _, _) => Platform::ViveUnknown,
             ("YVR", _, _, _) => Platform::Yvr,
-            ("Play For Dream", _, _, _) => Platform::Yvr,
+            ("Play For Dream", _, _, _) => Platform::PfdMr,
             ("Lynx Mixed Reality", _, _, _) => Platform::Lynx,
             _ => Platform::AndroidUnknown,
         }

--- a/alvr/system_info/src/lib.rs
+++ b/alvr/system_info/src/lib.rs
@@ -145,6 +145,7 @@ pub fn platform() -> Platform {
             ("HTC", "VIVE XR Series", _, _) => Platform::XRElite,
             ("HTC", _, _, _) => Platform::ViveUnknown,
             ("YVR", _, _, _) => Platform::Yvr,
+            ("Play For Dream", _, _, _) => Platform::Yvr,
             ("Lynx Mixed Reality", _, _, _) => Platform::Lynx,
             _ => Platform::AndroidUnknown,
         }

--- a/alvr/system_info/src/lib.rs
+++ b/alvr/system_info/src/lib.rs
@@ -33,7 +33,7 @@ pub enum Platform {
     XRElite,
     ViveUnknown,
     Yvr,
-    PfdMr,
+    PlayForDreamMR,
     Lynx,
     AndroidUnknown,
     AppleHeadset,
@@ -77,7 +77,7 @@ impl Platform {
     }
 
     pub const fn is_yvr(&self) -> bool {
-        matches!(self, Platform::Yvr | Platform::PfdMr)
+        matches!(self, Platform::Yvr | Platform::PlayForDreamMR)
     }
 }
 
@@ -102,7 +102,7 @@ impl Display for Platform {
             Platform::XRElite => "VIVE XR Elite",
             Platform::ViveUnknown => "HTC VIVE (unknown)",
             Platform::Yvr => "YVR",
-            Platform::PfdMr => "Play For Dream MR",
+            Platform::PlayForDreamMR => "Play For Dream MR",
             Platform::Lynx => "Lynx Headset",
             Platform::AndroidUnknown => "Android (unknown)",
             Platform::AppleHeadset => "Apple Headset",
@@ -151,7 +151,7 @@ pub fn platform() -> Platform {
             ("HTC", "VIVE XR Series", _, _) => Platform::XRElite,
             ("HTC", _, _, _) => Platform::ViveUnknown,
             ("YVR", _, _, _) => Platform::Yvr,
-            ("Play For Dream", _, _, _) => Platform::PfdMr,
+            ("Play For Dream", _, _, _) => Platform::PlayForDreamMR,
             ("Lynx Mixed Reality", _, _, _) => Platform::Lynx,
             _ => Platform::AndroidUnknown,
         }


### PR DESCRIPTION
- Add PFD MR to platform matcher as a YVR headset
- YVR runtime complains about the passthrough flags needing to be non-zero, [and they're right](https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrCompositionLayerFlagBits.html)
- Fix the color space to be Rec.709, technically it should be Display P3 (P3 with an sRGB white point) or sRGB, but those aren't options and Rec.709 is easy to work with for H26x anyway.