### PR TITLE
fix: Update flatpak sdk

### DIFF
--- a/alvr/xtask/flatpak/com.valvesoftware.Steam.Utility.alvr.json
+++ b/alvr/xtask/flatpak/com.valvesoftware.Steam.Utility.alvr.json
@@ -1,7 +1,7 @@
 {
   "id": "com.valvesoftware.Steam.Utility.alvr",
   "branch": "stable",
-  "sdk": "org.freedesktop.Sdk//23.08",
+  "sdk": "org.freedesktop.Sdk//24.08",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.llvm16",
     "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
It seems rust-stable is limited to rust 1.81 with the 23.08 sdk and that also seems quite old considering a 2 year support window. So we have to update the flatpak sdk.
But I haven't tested this because flatpak is so annoying to get working, we could just send it off to a nightly and see if it works.