### PR TITLE
Disable Pico face tracking lipsync mode

### DIFF
--- a/alvr/client_openxr/src/extra_extensions/face_tracking_pico.rs
+++ b/alvr/client_openxr/src/extra_extensions/face_tracking_pico.rs
@@ -52,12 +52,7 @@ impl FaceTrackerPico {
 
         let mut tracking_flags = 0;
 
-        if visual {
-            tracking_flags |= TRACKING_MODE_FACE_BIT;
-        }
-        if audio {
-            tracking_flags |= TRACKING_MODE_FACE_LIPSYNC | TRACKING_MODE_FACE_LIPSYNC_BLEND_SHAPES;
-        }
+        tracking_flags |= TRACKING_MODE_FACE_BIT;
 
         Ok(Self {
             session: session.into_any_graphics(),


### PR DESCRIPTION
Pico has a "Lipsync" face tracking mode which uses headset audio to drive face tracking blendshapes when it detects audio. Typically applications (such as VRChat) already have this sort of functionality, and face tracked avatars typically have options to enable/disable it in-game. Having face tracking blendshapes overridden by the headset without any user control is not expected behavior and causes confusion when troubleshooting avatar face tracking.

See the Pico documentation for details.
https://developer.picoxr.com/document/unity-avatar/face-tracking/