### PR TITLE
feat(server_openvr): :sparkles: Defer TrackedDevices initialization

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/Controller.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.cpp
@@ -23,9 +23,9 @@ bool Controller::activate() {
 
     auto vr_driver_input = vr::VRDriverInput();
 
-    SetOpenvrProps(this->device_id);
+    SetOpenvrProps((void*)this, this->device_id);
 
-    RegisterButtons(this->device_id);
+    RegisterButtons((void*)this, this->device_id);
 
     vr_driver_input->CreateHapticComponent(this->prop_container, "/output/haptic", &m_compHaptic);
 

--- a/alvr/server_openvr/cpp/alvr_server/HMD.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/HMD.cpp
@@ -84,7 +84,7 @@ bool Hmd::activate() {
 
     auto vr_properties = vr::VRProperties();
 
-    SetOpenvrProps(this->device_id);
+    SetOpenvrProps((void*)this, this->device_id);
 
     vr_properties->SetFloatProperty(
         this->prop_container,

--- a/alvr/server_openvr/cpp/alvr_server/TrackedDevice.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/TrackedDevice.cpp
@@ -89,7 +89,7 @@ bool TrackedDevice::register_device() {
             this->device_class,
             (vr::ITrackedDeviceServerDriver*)this
         )) {
-        Error("Failed to register device");
+        Error("Failed to register device (%s)", this->get_serial_number().c_str());
 
         return false;
     }

--- a/alvr/server_openvr/cpp/alvr_server/TrackedDevice.h
+++ b/alvr/server_openvr/cpp/alvr_server/TrackedDevice.h
@@ -3,6 +3,13 @@
 #include "bindings.h"
 #include "openvr_driver_wrap.h"
 #include <map>
+#include <optional>
+
+enum class ActivationState {
+    Pending,
+    Success,
+    Failure,
+};
 
 class TrackedDevice : vr::ITrackedDeviceServerDriver {
 public:
@@ -10,12 +17,13 @@ public:
     vr::PropertyContainerHandle_t prop_container = vr::k_ulInvalidPropertyContainer;
     vr::DriverPose_t last_pose;
 
-    void register_device();
+    bool register_device();
     void set_prop(FfiOpenvrProperty prop);
 
 protected:
     uint64_t device_id;
     vr::ETrackedDeviceClass device_class;
+    ActivationState activation_state = ActivationState::Pending;
 
     TrackedDevice(uint64_t device_id, vr::ETrackedDeviceClass device_class);
     std::string get_serial_number();

--- a/alvr/server_openvr/cpp/alvr_server/TrackedDevice.h
+++ b/alvr/server_openvr/cpp/alvr_server/TrackedDevice.h
@@ -2,7 +2,9 @@
 
 #include "bindings.h"
 #include "openvr_driver_wrap.h"
+#include <condition_variable>
 #include <map>
+#include <mutex>
 #include <optional>
 
 enum class ActivationState {
@@ -23,7 +25,6 @@ public:
 protected:
     uint64_t device_id;
     vr::ETrackedDeviceClass device_class;
-    ActivationState activation_state = ActivationState::Pending;
 
     TrackedDevice(uint64_t device_id, vr::ETrackedDeviceClass device_class);
     std::string get_serial_number();
@@ -32,6 +33,10 @@ protected:
     virtual void* get_component(const char*) = 0;
 
 private:
+    ActivationState activation_state = ActivationState::Pending;
+    std::mutex activation_mutex = {};
+    std::condition_variable activation_condvar = {};
+
     // ITrackedDeviceServerDriver
     vr::EVRInitError Activate(vr::TrackedDeviceIndex_t object_id) final;
     void Deactivate() final {

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -129,13 +129,13 @@ extern "C" void (*ReportPresent)(unsigned long long timestamp_ns, unsigned long 
 extern "C" void (*ReportComposed)(unsigned long long timestamp_ns, unsigned long long offset_ns);
 extern "C" FfiDynamicEncoderParams (*GetDynamicEncoderParams)();
 extern "C" unsigned long long (*GetSerialNumber)(unsigned long long deviceID, char* outString);
-extern "C" void (*SetOpenvrProps)(unsigned long long deviceID);
-extern "C" void (*RegisterButtons)(unsigned long long deviceID);
+extern "C" void (*SetOpenvrProps)(void* instancePtr, unsigned long long deviceID);
+extern "C" void (*RegisterButtons)(void* instancePtr, unsigned long long deviceID);
 extern "C" void (*WaitForVSync)();
 
 extern "C" void CppInit();
 extern "C" void* CppOpenvrEntryPoint(const char* pInterfaceName, int* pReturnCode);
-extern "C" void InitializeStreaming();
+extern "C" bool InitializeStreaming();
 extern "C" void DeinitializeStreaming();
 extern "C" void SendVSync();
 extern "C" void RequestIDR();
@@ -152,8 +152,9 @@ extern "C" void VideoErrorReportReceive();
 extern "C" void RequestDriverResync();
 extern "C" void ShutdownSteamvr();
 
-extern "C" void SetOpenvrProperty(unsigned long long deviceID, FfiOpenvrProperty prop);
-extern "C" void RegisterButton(unsigned long long deviceID, unsigned long long buttonID);
+extern "C" void SetOpenvrProperty(void* instancePtr, FfiOpenvrProperty prop);
+extern "C" void SetOpenvrPropByDeviceID(unsigned long long deviceID, FfiOpenvrProperty prop);
+extern "C" void RegisterButton(void* instancePtr, unsigned long long buttonID);
 extern "C" void SetViewsConfig(FfiViewsConfig config);
 extern "C" void SetBattery(unsigned long long deviceID, float gauge_value, bool is_plugged);
 extern "C" void SetButton(unsigned long long buttonID, FfiButtonValue value);

--- a/alvr/server_openvr/src/props.rs
+++ b/alvr/server_openvr/src/props.rs
@@ -17,11 +17,11 @@ use alvr_session::{
     ControllersEmulationMode, HeadsetEmulationMode, OpenvrPropKey, OpenvrPropType, OpenvrProperty,
 };
 use std::{
-    ffi::{c_char, CString},
+    ffi::{c_char, c_void, CString},
     ptr,
 };
 
-pub fn set_openvr_prop(device_id: u64, prop: OpenvrProperty) {
+pub fn set_openvr_prop(instance_ptr: Option<*mut c_void>, device_id: u64, prop: OpenvrProperty) {
     let key = prop.key as u32;
     let ty = alvr_session::openvr_prop_key_to_type(prop.key);
     let value = prop.value.clone();
@@ -102,15 +102,16 @@ pub fn set_openvr_prop(device_id: u64, prop: OpenvrProperty) {
 
     debug!("Setting {device_name} OpenVR prop: {:?}={value}", prop.key);
 
-    unsafe {
-        crate::SetOpenvrProperty(
-            device_id,
-            FfiOpenvrProperty {
-                key,
-                type_,
-                value: ffi_value,
-            },
-        );
+    let ffi_prop = FfiOpenvrProperty {
+        key,
+        type_,
+        value: ffi_value,
+    };
+
+    if let Some(instance_ptr) = instance_ptr {
+        unsafe { crate::SetOpenvrProperty(instance_ptr, ffi_prop) }
+    } else {
+        unsafe { crate::SetOpenvrPropByDeviceID(device_id, ffi_prop) }
     }
 }
 
@@ -188,13 +189,14 @@ pub extern "C" fn get_serial_number(device_id: u64, out_str: *mut c_char) -> u64
 }
 
 #[no_mangle]
-pub extern "C" fn set_device_openvr_props(device_id: u64) {
+pub extern "C" fn set_device_openvr_props(instance_ptr: *mut c_void, device_id: u64) {
     use OpenvrPropKey::*;
 
     let settings = alvr_server_core::settings();
 
     let set_prop = |key, value: &str| {
         set_openvr_prop(
+            Some(instance_ptr),
             device_id,
             OpenvrProperty {
                 key,


### PR DESCRIPTION
In this PR I make the following changes:
* Move TrackedDevices initialization and registration from `DriverProvider::Init()` to `InitializeStreaming()`
* Don't wait for the HMD activation to start the alvr_server_openvr event loop
* Because of this, to avoid race conditions, `TrackedDevice::registrer_device()` now waits for the `ITrackedDeviceServerDriver::Activate()` call.
* Don't store tracked devices in `g_driver_provider` until they are successfully activated. This requires changing the signature of `SetOpenvrProps()` and `RegisterButtons()` to reference the devices by pointer instead of ID. Allow controllers and trackers to fail registration (we are already handling the absence of any of these devices)

Notably, In this PR i'm not implementing the skip of the first SteamVR restart when the client first connects, this will be done in the next PRs.