### PR TITLE
feat: Remove SteamVR driver registration modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "cc",
  "pkg-config",
  "serde_json",
+ "sysinfo",
  "walkdir",
 ]
 

--- a/alvr/dashboard/src/dashboard/components/logs.rs
+++ b/alvr/dashboard/src/dashboard/components/logs.rs
@@ -7,7 +7,7 @@ use eframe::{
     epaint::Color32,
 };
 use settings_schema::Switch;
-use std::{collections::VecDeque, env};
+use std::collections::VecDeque;
 
 struct Entry {
     color: Color32,
@@ -89,10 +89,7 @@ impl LogsTab {
                 })
             }
             if ui.button("Open logs directory").clicked() {
-                let log_dir = alvr_filesystem::filesystem_layout_from_dashboard_exe(
-                    &env::current_exe().unwrap(),
-                )
-                .log_dir;
+                let log_dir = crate::get_filesystem_layout().log_dir;
                 ui.output_mut(|out| {
                     out.commands
                         .push(OutputCommand::OpenUrl(OpenUrl::same_tab(format!(

--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::Path;
-use std::{env, process::Command};
+use std::process::Command;
 
 use alvr_common::anyhow::bail;
 use alvr_common::{debug, error, info, warn};
@@ -48,8 +48,7 @@ pub fn maybe_wrap_vrcompositor_launcher() -> alvr_common::anyhow::Result<()> {
     }
 
     std::os::unix::fs::symlink(
-        alvr_filesystem::filesystem_layout_from_dashboard_exe(&env::current_exe().unwrap())
-            .vrcompositor_wrapper(),
+        crate::get_filesystem_layout().vrcompositor_wrapper(),
         &launcher_path,
     )?;
 

--- a/alvr/dashboard/src/steamvr_launcher/mod.rs
+++ b/alvr/dashboard/src/steamvr_launcher/mod.rs
@@ -3,7 +3,6 @@ mod linux_steamvr;
 #[cfg(windows)]
 mod windows_steamvr;
 
-use crate::data_sources;
 use alvr_common::{
     anyhow::{Context, Result},
     debug,
@@ -13,7 +12,6 @@ use alvr_common::{
     warn,
 };
 use alvr_filesystem as afs;
-use alvr_session::{DriverLaunchAction, DriversBackup};
 use serde_json::{self, json};
 use std::{
     env,
@@ -118,39 +116,10 @@ impl Launcher {
         #[cfg(target_os = "linux")]
         linux_steamvr::linux_hardware_checks();
 
-        let mut data_source = data_sources::get_local_session_source();
-
-        let launch_action = &data_source
-            .settings()
-            .extra
-            .steamvr_launcher
-            .driver_launch_action;
-
-        if !matches!(launch_action, DriverLaunchAction::NoAction) {
-            let other_drivers_paths = if matches!(
-                launch_action,
-                DriverLaunchAction::UnregisterOtherDriversAtStartup
-            ) && data_source.session().drivers_backup.is_none()
-            {
-                let drivers_paths = alvr_server_io::get_registered_drivers().unwrap_or_default();
-
-                alvr_server_io::driver_registration(&drivers_paths, false).ok();
-
-                drivers_paths
-            } else {
-                vec![]
-            };
-            let alvr_driver_dir =
-                afs::filesystem_layout_from_dashboard_exe(&env::current_exe().unwrap())
-                    .openvr_driver_root_dir;
-
-            alvr_server_io::driver_registration(&[alvr_driver_dir.clone()], true).ok();
-
-            data_source.session_mut().drivers_backup = Some(DriversBackup {
-                alvr_path: alvr_driver_dir,
-                other_paths: other_drivers_paths,
-            });
-        }
+        let alvr_driver_dir =
+            afs::filesystem_layout_from_dashboard_exe(&env::current_exe().unwrap())
+                .openvr_driver_root_dir;
+        alvr_server_io::driver_registration(&[alvr_driver_dir], true).ok();
 
         if let Err(err) = unblock_alvr_driver() {
             warn!("Failed to unblock ALVR driver: {:?}", err);

--- a/alvr/filesystem/src/lib.rs
+++ b/alvr/filesystem/src/lib.rs
@@ -302,30 +302,30 @@ static LAYOUT_FROM_ENV: Lazy<Option<Layout>> =
 
 // The path should include the executable file name
 // The path argument is used only if ALVR is built as portable
-pub fn filesystem_layout_from_dashboard_exe(path: &Path) -> Layout {
-    LAYOUT_FROM_ENV.clone().unwrap_or_else(|| {
+pub fn filesystem_layout_from_dashboard_exe(path: &Path) -> Option<Layout> {
+    LAYOUT_FROM_ENV.clone().or_else(|| {
         let root = if cfg!(target_os = "linux") {
             // FHS path is expected
-            path.parent().unwrap().parent().unwrap().to_owned()
+            path.parent()?.parent()?.to_owned()
         } else {
-            path.parent().unwrap().to_owned()
+            path.parent()?.to_owned()
         };
 
-        Layout::new(&root)
+        Some(Layout::new(&root))
     })
 }
 
 // The dir argument is used only if ALVR is built as portable
-pub fn filesystem_layout_from_openvr_driver_root_dir(dir: &Path) -> Layout {
-    LAYOUT_FROM_ENV.clone().unwrap_or_else(|| {
+pub fn filesystem_layout_from_openvr_driver_root_dir(dir: &Path) -> Option<Layout> {
+    LAYOUT_FROM_ENV.clone().or_else(|| {
         let root = if cfg!(target_os = "linux") {
             // FHS path is expected
-            dir.parent().unwrap().parent().unwrap().to_owned()
+            dir.parent()?.parent()?.to_owned()
         } else {
             dir.to_owned()
         };
 
-        Layout::new(&root)
+        Some(Layout::new(&root))
     })
 }
 

--- a/alvr/filesystem/src/lib.rs
+++ b/alvr/filesystem/src/lib.rs
@@ -105,7 +105,9 @@ pub struct Layout {
 }
 
 impl Layout {
-    pub fn new(root: &Path) -> Self {
+    pub fn new(root: &Path) -> Option<Self> {
+        let root = root.canonicalize().ok()?;
+
         #[cfg(target_os = "linux")]
         {
             // Get paths from environment or use FHS compliant paths
@@ -165,7 +167,7 @@ impl Layout {
                 root.join("share/vulkan/explicit_layer.d")
             };
 
-            Self {
+            Some(Self {
                 executables_dir,
                 libraries_dir,
                 static_resources_dir,
@@ -177,10 +179,10 @@ impl Layout {
                 firewalld_config_dir,
                 ufw_config_dir,
                 vulkan_layer_manifest_dir,
-            }
+            })
         }
         #[cfg(not(target_os = "linux"))]
-        Self {
+        Some(Self {
             executables_dir: root.to_owned(),
             libraries_dir: root.to_owned(),
             static_resources_dir: root.to_owned(),
@@ -192,7 +194,7 @@ impl Layout {
             firewalld_config_dir: root.to_owned(),
             ufw_config_dir: root.to_owned(),
             vulkan_layer_manifest_dir: root.to_owned(),
-        }
+        })
     }
 
     pub fn dashboard_exe(&self) -> PathBuf {
@@ -297,13 +299,21 @@ impl Layout {
     }
 }
 
-static LAYOUT_FROM_ENV: Lazy<Option<Layout>> =
-    Lazy::new(|| (!env!("root").is_empty()).then(|| Layout::new(Path::new(env!("root")))));
+// Use static var to prevent issues if the "root" env is changed at runtime
+static LAYOUT_FROM_ENV: Lazy<Option<Layout>> = Lazy::new(|| {
+    let root_dir_str = env!("root");
+    if !root_dir_str.is_empty() {
+        Layout::new(Path::new(root_dir_str))
+    } else {
+        None
+    }
+});
 
 // The path should include the executable file name
 // The path argument is used only if ALVR is built as portable
 pub fn filesystem_layout_from_dashboard_exe(path: &Path) -> Option<Layout> {
     LAYOUT_FROM_ENV.clone().or_else(|| {
+        let path = path.canonicalize().ok()?;
         let root = if cfg!(target_os = "linux") {
             // FHS path is expected
             path.parent()?.parent()?.to_owned()
@@ -311,13 +321,14 @@ pub fn filesystem_layout_from_dashboard_exe(path: &Path) -> Option<Layout> {
             path.parent()?.to_owned()
         };
 
-        Some(Layout::new(&root))
+        Layout::new(&root)
     })
 }
 
 // The dir argument is used only if ALVR is built as portable
 pub fn filesystem_layout_from_openvr_driver_root_dir(dir: &Path) -> Option<Layout> {
     LAYOUT_FROM_ENV.clone().or_else(|| {
+        let dir = dir.canonicalize().ok()?;
         let root = if cfg!(target_os = "linux") {
             // FHS path is expected
             dir.parent()?.parent()?.to_owned()
@@ -325,7 +336,7 @@ pub fn filesystem_layout_from_openvr_driver_root_dir(dir: &Path) -> Option<Layou
             dir.to_owned()
         };
 
-        Some(Layout::new(&root))
+        Layout::new(&root)
     })
 }
 
@@ -335,5 +346,5 @@ pub fn filesystem_layout_from_openvr_driver_root_dir(dir: &Path) -> Option<Layou
 pub fn filesystem_layout_invalid() -> Layout {
     LAYOUT_FROM_ENV
         .clone()
-        .unwrap_or_else(|| Layout::new(Path::new("")))
+        .unwrap_or_else(|| Layout::new(Path::new("./")).unwrap())
 }

--- a/alvr/launcher/src/actions.rs
+++ b/alvr/launcher/src/actions.rs
@@ -152,7 +152,9 @@ fn install_and_launch_apk(
         file.write_all(&apk_buffer)?;
     }
 
-    let layout = alvr_filesystem::Layout::new(&root);
+    let layout = alvr_filesystem::Layout::new(&root).ok_or_else(|| {
+        anyhow::anyhow!("Failed to obtain filesystem layout from installation directory")
+    })?;
     let adb_path = alvr_adb::commands::require_adb(&layout, |downloaded, total| {
         let progress = total.map(|t| downloaded as f32 / t as f32).unwrap_or(0.0);
         worker_message_sender

--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -556,12 +556,6 @@ impl Drop for ServerCoreContext {
                 connection::contruct_openvr_config(session_manager_lock.session());
         }
 
-        dbg_server_core!("Restore drivers registration backup");
-        if let Some(backup) = SESSION_MANAGER.write().session_mut().drivers_backup.take() {
-            alvr_server_io::driver_registration(&backup.other_paths, true).ok();
-            alvr_server_io::driver_registration(&[backup.alvr_path], false).ok();
-        }
-
         // todo: check if this is still needed
         while SESSION_MANAGER
             .read()

--- a/alvr/server_core/src/web_server.rs
+++ b/alvr/server_core/src/web_server.rs
@@ -247,10 +247,12 @@ async fn http_api(
                         *connection_context.video_recording_file.lock() = None
                     }
                     ServerRequest::FirewallRules(action) => {
-                        if alvr_server_io::firewall_rules(action).is_ok() {
-                            info!("Setting firewall rules succeeded!");
+                        if let Err(e) =
+                            alvr_server_io::firewall_rules(action, FILESYSTEM_LAYOUT.get().unwrap())
+                        {
+                            error!("Setting firewall rules failed! code: {e}");
                         } else {
-                            error!("Setting firewall rules failed!");
+                            info!("Setting firewall rules succeeded!");
                         }
                     }
                     ServerRequest::RegisterAlvrDriver => {

--- a/alvr/server_io/src/firewall.rs
+++ b/alvr/server_io/src/firewall.rs
@@ -22,7 +22,10 @@ fn netsh_delete_rule_command_string(rule_name: &str) -> String {
 // 1: firewall rule is already set
 // 126: pkexec request dismissed
 // other: command failed
-pub fn firewall_rules(action: FirewallRulesAction) -> Result<(), i32> {
+pub fn firewall_rules(
+    action: FirewallRulesAction,
+    filesystem_layout: &alvr_filesystem::Layout,
+) -> Result<(), i32> {
     let exit_status = if cfg!(target_os = "linux") {
         let action = if matches!(action, FirewallRulesAction::Add) {
             "add"
@@ -33,11 +36,9 @@ pub fn firewall_rules(action: FirewallRulesAction) -> Result<(), i32> {
         Command::new("bash")
             .arg(
                 PathBuf::from("../").join(
-                    alvr_filesystem::filesystem_layout_from_dashboard_exe(
-                        &env::current_exe().unwrap(),
-                    )
-                    .firewall_script_dir
-                    .join("alvr_fw_config.sh"),
+                    filesystem_layout
+                        .firewall_script_dir
+                        .join("alvr_fw_config.sh"),
                 ),
             )
             .arg(action)

--- a/alvr/server_openvr/Cargo.toml
+++ b/alvr/server_openvr/Cargo.toml
@@ -21,6 +21,7 @@ alvr_server_io.workspace = true
 alvr_session.workspace = true
 
 serde_json = "1"
+sysinfo = "0.33"
 
 [build-dependencies]
 alvr_filesystem = { path = "../filesystem" }

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -23,18 +23,13 @@ use alvr_packets::{ButtonValue, Haptics};
 use alvr_server_core::{HandType, ServerCoreContext, ServerCoreEvent};
 use alvr_session::{CodecType, ControllersConfig};
 use std::{
-    ffi::{c_char, c_void, CString},
+    ffi::{c_char, c_void, CString, OsStr},
     ptr,
     sync::{mpsc, Once},
     thread,
     time::{Duration, Instant},
 };
 
-static FILESYSTEM_LAYOUT: Lazy<afs::Layout> = Lazy::new(|| {
-    afs::filesystem_layout_from_openvr_driver_root_dir(
-        &alvr_server_io::get_driver_dir_from_registered().unwrap(),
-    )
-});
 static SERVER_CORE_CONTEXT: Lazy<RwLock<Option<ServerCoreContext>>> =
     Lazy::new(|| RwLock::new(None));
 
@@ -414,6 +409,20 @@ pub extern "C" fn shutdown_driver() {
     SERVER_CORE_CONTEXT.write().take();
 }
 
+// Check that there is no active dashboard instance not part of this driver installation
+pub fn should_initialize_driver(driver_layout: &afs::Layout) -> bool {
+    if let Some(proc) = sysinfo::System::new_all()
+        .processes_by_name(OsStr::new(&afs::dashboard_fname()))
+        .next()
+    {
+        if let Some(dashboard_path) = proc.exe() {
+            return driver_layout.dashboard_exe() == dashboard_path;
+        }
+    }
+
+    true
+}
+
 /// This is the SteamVR/OpenVR entry point
 /// # Safety
 #[no_mangle]
@@ -421,23 +430,36 @@ pub unsafe extern "C" fn HmdDriverFactory(
     interface_name: *const c_char,
     return_code: *mut i32,
 ) -> *mut c_void {
+    let Ok(driver_dir) = alvr_server_io::get_driver_dir_from_registered() else {
+        return ptr::null_mut();
+    };
+    let Some(filesystem_layout) =
+        alvr_filesystem::filesystem_layout_from_openvr_driver_root_dir(&driver_dir)
+    else {
+        return ptr::null_mut();
+    };
+
+    if !should_initialize_driver(&filesystem_layout) {
+        return ptr::null_mut();
+    }
+
     static ONCE: Once = Once::new();
-    ONCE.call_once(|| {
-        alvr_server_core::initialize_environment(FILESYSTEM_LAYOUT.clone());
+    ONCE.call_once(move || {
+        alvr_server_core::initialize_environment(filesystem_layout.clone());
 
         let log_to_disk = alvr_server_core::settings().extra.logging.log_to_disk;
 
         alvr_server_core::init_logging(
-            log_to_disk.then(|| FILESYSTEM_LAYOUT.session_log()),
-            Some(FILESYSTEM_LAYOUT.crash_log()),
+            log_to_disk.then(|| filesystem_layout.session_log()),
+            Some(filesystem_layout.crash_log()),
         );
 
         unsafe {
-            g_sessionPath = CString::new(FILESYSTEM_LAYOUT.session().to_string_lossy().to_string())
+            g_sessionPath = CString::new(filesystem_layout.session().to_string_lossy().to_string())
                 .unwrap()
                 .into_raw();
             g_driverRootDir = CString::new(
-                FILESYSTEM_LAYOUT
+                filesystem_layout
                     .openvr_driver_root_dir
                     .to_string_lossy()
                     .to_string(),

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -411,16 +411,14 @@ pub extern "C" fn shutdown_driver() {
 
 // Check that there is no active dashboard instance not part of this driver installation
 pub fn should_initialize_driver(driver_layout: &afs::Layout) -> bool {
-    if let Some(proc) = sysinfo::System::new_all()
+    // Note: if the iterator is empty, `all()` returns true
+    sysinfo::System::new_all()
         .processes_by_name(OsStr::new(&afs::dashboard_fname()))
-        .next()
-    {
-        if let Some(dashboard_path) = proc.exe() {
-            return driver_layout.dashboard_exe() == dashboard_path;
-        }
-    }
-
-    true
+        .all(|proc| {
+            proc.exe()
+                .map(|path| path == driver_layout.dashboard_exe())
+                .unwrap_or(true) // if path is unreadable then don't care
+        })
 }
 
 /// This is the SteamVR/OpenVR entry point

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -14,18 +14,11 @@ use settings_schema::{NumberType, SchemaNode};
 use std::{
     collections::{HashMap, HashSet},
     net::IpAddr,
-    path::PathBuf,
 };
 
 // SessionSettings is similar to Settings but it contains every branch, even unused ones. This is
 // the settings representation that the UI uses.
 pub type SessionSettings = settings::SettingsDefault;
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct DriversBackup {
-    pub alvr_path: PathBuf,
-    pub other_paths: Vec<PathBuf>,
-}
 
 // This structure is used to store the minimum configuration data that ALVR driver needs to
 // initialize OpenVR before having the chance to communicate with a client. When a client is
@@ -134,7 +127,6 @@ pub struct ClientConnectionConfig {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SessionConfig {
     pub server_version: Version,
-    pub drivers_backup: Option<DriversBackup>,
     pub openvr_config: OpenvrConfig,
     // The hashmap key is the hostname
     pub client_connections: HashMap<String, ClientConnectionConfig>,
@@ -145,7 +137,6 @@ impl Default for SessionConfig {
     fn default() -> Self {
         Self {
             server_version: ALVR_VERSION.clone(),
-            drivers_backup: None,
             openvr_config: OpenvrConfig {
                 // avoid realistic resolutions, as on first start, on Linux, it
                 // could trigger direct mode on an existing monitor

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1452,23 +1452,7 @@ pub struct LoggingConfig {
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
-pub enum DriverLaunchAction {
-    UnregisterOtherDriversAtStartup,
-    #[schema(strings(display_name = "Unregister ALVR at shutdown"))]
-    UnregisterAlvrAtShutdown,
-    NoAction,
-}
-
-#[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 pub struct SteamvrLauncher {
-    #[schema(strings(
-        help = r#"This controls the driver registration operations while launching SteamVR.
-Unregister other drivers at startup: This is the recommended option and will handle most interferences from other installed drivers.
-Unregister ALVR at shutdown: This should be used when you want to load other drivers like for full body tracking. Other VR streaming drivers like Virtual Desktop must be manually unregistered or uninstalled.
-No action: All driver registration actions should be performed manually, ALVR included. This allows to launch SteamVR without launching the dashboard first."#
-    ))]
-    pub driver_launch_action: DriverLaunchAction,
-
     #[schema(strings(display_name = "Open and close SteamVR with dashboard"))]
     pub open_close_steamvr_with_dashboard: bool,
 }
@@ -2111,9 +2095,6 @@ pub fn session_settings_default() -> SettingsDefault {
                 },
             },
             steamvr_launcher: SteamvrLauncherDefault {
-                driver_launch_action: DriverLaunchActionDefault {
-                    variant: DriverLaunchActionDefaultVariant::UnregisterOtherDriversAtStartup,
-                },
                 open_close_steamvr_with_dashboard: false,
             },
             capture: CaptureConfigDefault {

--- a/alvr/xtask/src/build.rs
+++ b/alvr/xtask/src/build.rs
@@ -81,7 +81,7 @@ pub fn build_streamer(
 ) {
     let sh = Shell::new().unwrap();
 
-    let build_layout = Layout::new(&afs::streamer_build_dir());
+    let build_layout = Layout::new(&afs::streamer_build_dir()).unwrap();
 
     let mut common_flags = vec![];
     match profile {

--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -75,7 +75,9 @@ enum BuildPlatform {
 pub fn run_streamer() {
     let sh = Shell::new().unwrap();
 
-    let dashboard_exe = Layout::new(&afs::streamer_build_dir()).dashboard_exe();
+    let dashboard_exe = Layout::new(&afs::streamer_build_dir())
+        .unwrap()
+        .dashboard_exe();
     cmd!(sh, "{dashboard_exe}").run().unwrap();
 }
 


### PR DESCRIPTION
At SteamVR launch, unconditionally register the ALVR driver. Also remove driver list backup.

In this PR I implement some sanity checks, that are now necessary since there is no unregistration of the driver:
* Before launching SteamVR from the dashboard, we unregister any ALVR driver which is not from the current instance
* Bail out at driver entry point (HmdDriverFactory) if we detect a running dashboard not from the same installation
* At dashboard launch, kill every other dashboard instance.
This should be sufficient to handle multiple ALVR installations (Steam release or not).

This PR should be merged only after #2754 and #2757