### PR TITLE
fix: send full view config to openvr

### DIFF
--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -217,8 +217,8 @@ impl ClientCoreContext {
         if let Some(sender) = &mut *self.connection_context.control_sender.lock() {
             sender
                 .send(&ClientControlPacket::ViewsConfig(ViewsConfig {
+                    pose: [views[0].pose, views[1].pose],
                     fov: [views[0].fov, views[1].fov],
-                    ipd_m: (views[0].pose.position - views[1].pose.position).length(),
                 }))
                 .ok();
         }

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -217,7 +217,7 @@ pub enum ServerControlPacket {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ViewsConfig {
     // Note: the head-to-eye transform is always a translation along the x axis
-    pub ipd_m: f32,
+    pub pose: [Pose; 2],
     pub fov: [Fov; 2],
 }
 

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -216,7 +216,6 @@ pub enum ServerControlPacket {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ViewsConfig {
-    // Note: the head-to-eye transform is always a translation along the x axis
     pub pose: [Pose; 2],
     pub fov: [Fov; 2],
 }

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -1214,16 +1214,7 @@ fn connection_pipeline(
                     ClientControlPacket::ViewsConfig(config) => {
                         ctx.events_sender
                             .send(ServerCoreEvent::ViewsConfig(ViewsConfig {
-                                local_view_transforms: [
-                                    Pose {
-                                        position: Vec3::new(-config.ipd_m / 2., 0., 0.),
-                                        orientation: Quat::IDENTITY,
-                                    },
-                                    Pose {
-                                        position: Vec3::new(config.ipd_m / 2., 0., 0.),
-                                        orientation: Quat::IDENTITY,
-                                    },
-                                ],
+                                local_view_transforms: config.pose,
                                 fov: config.fov,
                             }))
                             .ok();

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -10,11 +10,11 @@ use crate::{
 use alvr_adb::{WiredConnection, WiredConnectionStatus};
 use alvr_common::{
     con_bail, dbg_connection, debug, error,
-    glam::{Quat, UVec2, Vec2, Vec3},
+    glam::{UVec2, Vec2},
     info,
     parking_lot::{Condvar, Mutex, RwLock},
     settings_schema::Switch,
-    warn, AnyhowToCon, ConResult, ConnectionError, ConnectionState, LifecycleState, Pose,
+    warn, AnyhowToCon, ConResult, ConnectionError, ConnectionState, LifecycleState,
     BUTTON_INFO, CONTROLLER_PROFILE_INFO, QUEST_CONTROLLER_PROFILE_PATH,
 };
 use alvr_events::{AdbEvent, ButtonEvent, EventType};

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -14,8 +14,8 @@ use alvr_common::{
     info,
     parking_lot::{Condvar, Mutex, RwLock},
     settings_schema::Switch,
-    warn, AnyhowToCon, ConResult, ConnectionError, ConnectionState, LifecycleState,
-    BUTTON_INFO, CONTROLLER_PROFILE_INFO, QUEST_CONTROLLER_PROFILE_PATH,
+    warn, AnyhowToCon, ConResult, ConnectionError, ConnectionState, LifecycleState, BUTTON_INFO,
+    CONTROLLER_PROFILE_INFO, QUEST_CONTROLLER_PROFILE_PATH,
 };
 use alvr_events::{AdbEvent, ButtonEvent, EventType};
 use alvr_packets::{

--- a/alvr/server_openvr/cpp/alvr_server/Controller.h
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.h
@@ -8,7 +8,7 @@
 class Controller : public TrackedDevice {
 public:
     Controller(uint64_t deviceID, vr::EVRSkeletalTrackingLevel skeletonLevel);
-    virtual ~Controller() { };
+    virtual ~Controller() {};
     void RegisterButton(uint64_t id);
     void SetButton(uint64_t id, FfiButtonValue value);
     bool OnPoseUpdate(uint64_t targetTimestampNs, float predictionS, FfiHandData handData);

--- a/alvr/server_openvr/cpp/alvr_server/Controller.h
+++ b/alvr/server_openvr/cpp/alvr_server/Controller.h
@@ -8,7 +8,7 @@
 class Controller : public TrackedDevice {
 public:
     Controller(uint64_t deviceID, vr::EVRSkeletalTrackingLevel skeletonLevel);
-    virtual ~Controller() {};
+    virtual ~Controller() { };
     void RegisterButton(uint64_t id);
     void SetButton(uint64_t id, FfiButtonValue value);
     bool OnPoseUpdate(uint64_t targetTimestampNs, float predictionS, FfiHandData handData);

--- a/alvr/server_openvr/cpp/alvr_server/HMD.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/HMD.cpp
@@ -30,8 +30,9 @@ vr::HmdRect2_t fov_to_projection(FfiFov fov) {
 
 vr::HmdMatrix34_t pose_to_transform(FfiPose pose) {
     vr::HmdMatrix34_t transform;
-    HmdMatrix_QuatToMat(pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z,
-                        &transform);
+    HmdMatrix_QuatToMat(
+        pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z, &transform
+    );
     transform.m[0][3] = pose.position[0];
     transform.m[1][3] = pose.position[1];
     transform.m[2][3] = pose.position[2];
@@ -49,7 +50,7 @@ Hmd::Hmd()
     Debug("Hmd::constructor");
 
     auto dummy_fov = FfiFov { -1.0, 1.0, 1.0, -1.0 };
-    auto identity_pose = FfiPose{{0, 0, 0, 1}, {0, 0, 0}};
+    auto identity_pose = FfiPose { { 0, 0, 0, 1 }, { 0, 0, 0 } };
 
     this->views_config = FfiViewsConfig {};
     this->views_config.fov[0] = dummy_fov;

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -14,6 +14,11 @@ struct FfiQuat {
     float w;
 };
 
+struct FfiPose {
+    FfiQuat orientation;
+    float position[3];
+};
+
 struct FfiHandSkeleton {
     float jointPositions[31][3];
     FfiQuat jointRotations[31];
@@ -62,7 +67,7 @@ struct FfiOpenvrProperty {
 
 struct FfiViewsConfig {
     FfiFov fov[2];
-    float ipd_m;
+    FfiPose pose[2];
 };
 
 enum FfiButtonType {

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -84,9 +84,28 @@ fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                                 down: config.fov[1].down,
                             },
                         ],
-                        // todo: send full matrix to steamvr
-                        ipd_m: config.local_view_transforms[1].position.x
-                            - config.local_view_transforms[0].position.x,
+                        pose: [
+                            FfiPose {
+                                orientation: {
+                                    let q = config.local_view_transforms[0].orientation;
+                                    FfiQuat{w: q.w, x: q.x, y: q.y, z: q.z}
+                                },
+                                position: {
+                                    let v = config.local_view_transforms[0].position;
+                                    [v.x, v.y, v.z]
+                                },
+                            },
+                            FfiPose {
+                                orientation: {
+                                    let q = config.local_view_transforms[1].orientation;
+                                    FfiQuat{w: q.w, x: q.x, y: q.y, z: q.z}
+                                },
+                                position: {
+                                    let v = config.local_view_transforms[1].position;
+                                    [v.x, v.y, v.z]
+                                },
+                            },
+                        ],
                     });
                 },
                 ServerCoreEvent::Tracking { sample_timestamp } => {

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -86,34 +86,12 @@ fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                         ],
                         pose: [
                             FfiPose {
-                                orientation: {
-                                    let q = config.local_view_transforms[0].orientation;
-                                    FfiQuat {
-                                        w: q.w,
-                                        x: q.x,
-                                        y: q.y,
-                                        z: q.z,
-                                    }
-                                },
-                                position: {
-                                    let v = config.local_view_transforms[0].position;
-                                    [v.x, v.y, v.z]
-                                },
+                                orientation: tracking::to_ffi_quat(config.local_view_transforms[0].orientation),
+                                position: config.local_view_transforms[0].position.to_array(),
                             },
                             FfiPose {
-                                orientation: {
-                                    let q = config.local_view_transforms[1].orientation;
-                                    FfiQuat {
-                                        w: q.w,
-                                        x: q.x,
-                                        y: q.y,
-                                        z: q.z,
-                                    }
-                                },
-                                position: {
-                                    let v = config.local_view_transforms[1].position;
-                                    [v.x, v.y, v.z]
-                                },
+                                orientation: tracking::to_ffi_quat(config.local_view_transforms[1].orientation),
+                                position: config.local_view_transforms[1].position.to_array(),
                             },
                         ],
                     });

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -86,11 +86,15 @@ fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                         ],
                         pose: [
                             FfiPose {
-                                orientation: tracking::to_ffi_quat(config.local_view_transforms[0].orientation),
+                                orientation: tracking::to_ffi_quat(
+                                    config.local_view_transforms[0].orientation,
+                                ),
                                 position: config.local_view_transforms[0].position.to_array(),
                             },
                             FfiPose {
-                                orientation: tracking::to_ffi_quat(config.local_view_transforms[1].orientation),
+                                orientation: tracking::to_ffi_quat(
+                                    config.local_view_transforms[1].orientation,
+                                ),
                                 position: config.local_view_transforms[1].position.to_array(),
                             },
                         ],

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -88,7 +88,12 @@ fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                             FfiPose {
                                 orientation: {
                                     let q = config.local_view_transforms[0].orientation;
-                                    FfiQuat{w: q.w, x: q.x, y: q.y, z: q.z}
+                                    FfiQuat {
+                                        w: q.w,
+                                        x: q.x,
+                                        y: q.y,
+                                        z: q.z,
+                                    }
                                 },
                                 position: {
                                     let v = config.local_view_transforms[0].position;
@@ -98,7 +103,12 @@ fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                             FfiPose {
                                 orientation: {
                                     let q = config.local_view_transforms[1].orientation;
-                                    FfiQuat{w: q.w, x: q.x, y: q.y, z: q.z}
+                                    FfiQuat {
+                                        w: q.w,
+                                        x: q.x,
+                                        y: q.y,
+                                        z: q.z,
+                                    }
                                 },
                                 position: {
                                     let v = config.local_view_transforms[1].position;

--- a/alvr/server_openvr/src/tracking.rs
+++ b/alvr/server_openvr/src/tracking.rs
@@ -26,7 +26,7 @@ pub static BODY_TRACKER_IDS: Lazy<[u64; 8]> = Lazy::new(|| {
     ]
 });
 
-fn to_ffi_quat(quat: Quat) -> FfiQuat {
+pub fn to_ffi_quat(quat: Quat) -> FfiQuat {
     FfiQuat {
         x: quat.x,
         y: quat.y,


### PR DESCRIPTION
Background: Same as [#2198](https://github.com/alvr-org/ALVR/pull/2198), rebased on the latest master. This change is specifically required for the PFDM MR device.

The PFDM MR device employs physically rotated displays to enable an expanded field of view (FOV). Previously, frame rotation was handled by the device runtime compositor to maintain 3rd party apps's backward compatibility (though this approach limited full utilization of the expanded FOV).

![341272482-3b7d5d07-f06f-479f-a287-81e1b9de3e9e](https://github.com/user-attachments/assets/f77dd69b-58fa-4580-bf1a-250973a1366a)

The latest OTA update introduces support for the standard KHR OpenXR Loader. OpenXR apps using the KHR loader must now render pre-rotated frames based on the left/right view configurations. If the full view configurations were not provided to OpenVR, the incorrect rendering could cause binocular misalignment.

The changes maintain theoretical compatibility across headset devices, and has been verified using Quest 3 units.