### PR TITLE
Saner default saturation and sharpening for color correction

### DIFF
--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1775,9 +1775,9 @@ pub fn session_settings_default() -> SettingsDefault {
                 content: ColorCorrectionConfigDefault {
                     brightness: 0.,
                     contrast: 0.,
-                    saturation: 0.5,
+                    saturation: 0.,
                     gamma: 1.,
-                    sharpening: 0.5,
+                    sharpening: 0.25,
                 },
             },
         },


### PR DESCRIPTION
- Removed the pointless default saturation boost of 0.5 when enabling color correction.

- Also reduced the default sharpening value from 0.5 to 0.25, which provides a more visually natural result by minimizing haloing/ringing artifacts. The current sharpening method remains rudimentary, and higher values quickly turn into an eye sore.