### PR TITLE
Use VR controllers as trackers while preserving accurate hand tracking

### DIFF
--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -107,6 +107,8 @@ pub struct HandInteraction {
     pub grip_action: xr::Action<xr::Posef>,
     pub grip_space: xr::Space,
 
+    pub detached_controller_space: Option<xr::Space>,
+
     #[expect(dead_code)]
     pub aim_action: xr::Action<xr::Posef>,
     #[expect(dead_code)]
@@ -136,6 +138,8 @@ pub struct InteractionSourcesConfig {
     pub face_tracking: Option<FaceTrackingSourcesConfig>,
     pub body_tracking: Option<BodyTrackingSourcesConfig>,
     pub prefers_multimodal_input: bool,
+    pub use_left_controller_as_fake_tracker: bool,
+    pub use_right_controller_as_fake_tracker: bool,
 }
 
 impl InteractionSourcesConfig {
@@ -160,6 +164,21 @@ impl InteractionSourcesConfig {
                 .as_option()
                 .map(|c| c.multimodal_tracking)
                 .unwrap_or(false),
+            use_left_controller_as_fake_tracker: config
+                .settings
+                .headset
+                .controllers
+                .as_option()
+                .map(|c| c.use_left_as_tracker)
+                .unwrap_or(false),
+            use_right_controller_as_fake_tracker: config
+                .settings
+                .headset
+                .controllers
+                .as_option()
+                .map(|c| c.use_right_as_tracker)
+                .unwrap_or(false),
+                
         }
     }
 }
@@ -174,6 +193,8 @@ pub struct InteractionContext {
     pub hands_interaction: [HandInteraction; 2],
     multimodal_handle: Option<MultimodalMeta>,
     pub multimodal_hands_enabled: bool,
+    pub use_left_controller_as_fake_tracker: bool,
+    pub use_right_controller_as_fake_tracker: bool,
     pub face_sources: FaceSources,
     pub body_sources: BodySources,
 }
@@ -305,34 +326,43 @@ impl InteractionContext {
 
         let left_detached_controller_pose_action;
         let right_detached_controller_pose_action;
+        let mut left_detached_controller_space = None;
+        let mut right_detached_controller_space= None;
         if multimodal_handle.is_some() {
             // Note: when multimodal input is enabled, both controllers and hands will always be active.
             // To be able to detect when controllers are actually held, we have to register detached
             // controllers pose; the controller pose will be diverted to the detached controllers when
             // they are not held. Currently the detached controllers pose is ignored
             left_detached_controller_pose_action = action_set
-                .create_action::<xr::Posef>(
-                    "left_detached_controller_pose",
-                    "Left detached controller pose",
-                    &[],
-                )
-                .unwrap();
+            .create_action::<xr::Posef>(
+                "left_detached_controller_pose",
+                "Left detached controller pose",
+                &[],
+            )
+            .unwrap();
             right_detached_controller_pose_action = action_set
-                .create_action::<xr::Posef>(
-                    "right_detached_controller_pose",
-                    "Right detached controller pose",
-                    &[],
-                )
-                .unwrap();
+            .create_action::<xr::Posef>(
+                "right_detached_controller_pose",
+                "Right detached controller pose",
+                &[],
+            )
+            .unwrap();
 
             bindings.push(binding(
                 &left_detached_controller_pose_action,
-                "/user/detached_controller_meta/left/input/grip/pose",
+                    "/user/detached_controller_meta/left/input/grip/pose",
             ));
             bindings.push(binding(
                 &right_detached_controller_pose_action,
-                "/user/detached_controller_meta/right/input/grip/pose",
+                    "/user/detached_controller_meta/right/input/grip/pose",
             ));
+
+            left_detached_controller_space = Some(left_detached_controller_pose_action
+            .create_space(xr_session.clone(), xr::Path::NULL, xr::Posef::IDENTITY)
+            .unwrap());
+            right_detached_controller_space = Some(right_detached_controller_pose_action
+            .create_space(xr_session.clone(), xr::Path::NULL, xr::Posef::IDENTITY)
+            .unwrap());
         }
 
         // Apply bindings:
@@ -438,6 +468,7 @@ impl InteractionContext {
                     pose_offset: get_controller_offset(platform, false),
                     grip_action: left_grip_action,
                     grip_space: left_grip_space,
+                    detached_controller_space: left_detached_controller_space,
                     aim_action: left_aim_action,
                     aim_space: left_aim_space,
                     vibration_action: left_vibration_action,
@@ -448,6 +479,7 @@ impl InteractionContext {
                     pose_offset: get_controller_offset(platform, true),
                     grip_action: right_grip_action,
                     grip_space: right_grip_space,
+                    detached_controller_space: right_detached_controller_space,
                     aim_action: right_aim_action,
                     aim_space: right_aim_space,
                     vibration_action: right_vibration_action,
@@ -456,6 +488,8 @@ impl InteractionContext {
             ],
             multimodal_handle,
             multimodal_hands_enabled: false,
+            use_left_controller_as_fake_tracker: false,
+            use_right_controller_as_fake_tracker: false,
             face_sources: FaceSources {
                 combined_eyes_source,
                 eye_tracker_fb: None,
@@ -529,6 +563,8 @@ impl InteractionContext {
                 }
             }
         }
+        self.use_left_controller_as_fake_tracker = config.use_left_controller_as_fake_tracker;
+        self.use_right_controller_as_fake_tracker = config.use_right_controller_as_fake_tracker;
 
         self.face_sources.eye_tracker_fb = create_ext_object(
             "EyeTrackerSocial",
@@ -731,6 +767,55 @@ pub fn get_head_data(
     };
 
     Some((motion, view_params))
+}
+
+pub fn get_controller_motion_data(
+    xr_session: &xr::Session<xr::OpenGlEs>,
+    reference_space: &xr::Space,
+    time: Duration,
+    hand_source: &HandInteraction,
+    last_controller_pose: &mut Pose,
+) -> Option<DeviceMotion> {
+    let xr_time = crate::to_xr_time(time);
+
+    let is_grip_active = hand_source.grip_action.is_active(xr_session, xr::Path::NULL).unwrap_or(false);
+
+    let location_result = if is_grip_active {
+        hand_source.grip_space.relate(reference_space, xr_time)
+    } else if let Some(space) = &hand_source.detached_controller_space {
+        space.relate(reference_space, xr_time)
+    } else {
+        Err(xr::sys::Result::ERROR_SPACE_NOT_LOCATABLE_EXT.into())
+    };
+
+    match location_result {
+        Ok((location, velocity)) => {
+            let orientation_valid = location.location_flags.contains(xr::SpaceLocationFlags::ORIENTATION_VALID);
+            let position_valid = location.location_flags.contains(xr::SpaceLocationFlags::POSITION_VALID);
+
+            if orientation_valid {
+                last_controller_pose.orientation = crate::from_xr_quat(location.pose.orientation);
+            }
+
+            if position_valid {
+                last_controller_pose.position = crate::from_xr_vec3(location.pose.position);
+            }
+
+            let pose = *last_controller_pose * hand_source.pose_offset;
+
+            let linear_velocity = crate::from_xr_vec3(velocity.linear_velocity);
+            let angular_velocity = crate::from_xr_vec3(velocity.angular_velocity);
+
+            Some(DeviceMotion {
+                pose,
+                linear_velocity,
+                angular_velocity,
+            })
+        }
+        Err(e) => {
+            None
+        }
+    }
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -303,6 +303,8 @@ pub fn entry_point() {
             face_tracking: None,
             body_tracking: Some(lobby_body_tracking_config),
             prefers_multimodal_input: true,
+            use_left_controller_as_fake_tracker: false,
+            use_right_controller_as_fake_tracker: false
         };
         interaction_context
             .write()

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -11,7 +11,8 @@ use alvr_common::{
     error,
     glam::{Quat, UVec2, Vec2},
     parking_lot::RwLock,
-    Pose, RelaxedAtomic, HAND_LEFT_ID, HAND_RIGHT_ID, HEAD_ID,
+    Pose, RelaxedAtomic, HAND_LEFT_ID, HAND_RIGHT_ID, HEAD_ID, 
+    FAKE_TRACKER_LEFT_ID, FAKE_TRACKER_RIGHT_ID,
 };
 use alvr_graphics::{
     compute_target_view_resolution, GraphicsContext, StreamRenderer, StreamViewParams,
@@ -531,15 +532,40 @@ fn stream_input_loop(
 
         // Note: When multimodal input is enabled, we are sure that when free hands are used
         // (not holding controllers) the controller data is None.
-        if int_ctx.multimodal_hands_enabled || left_hand_skeleton.is_none() {
+        if (int_ctx.multimodal_hands_enabled || left_hand_skeleton.is_none()) && !int_ctx.use_left_controller_as_fake_tracker {
             if let Some(motion) = left_hand_motion {
                 device_motions.push((*HAND_LEFT_ID, motion));
             }
         }
-        if int_ctx.multimodal_hands_enabled || right_hand_skeleton.is_none() {
+        if (int_ctx.multimodal_hands_enabled || right_hand_skeleton.is_none()) && !int_ctx.use_right_controller_as_fake_tracker {
             if let Some(motion) = right_hand_motion {
                 device_motions.push((*HAND_RIGHT_ID, motion));
             }
+        }
+
+        if int_ctx.use_left_controller_as_fake_tracker {
+            let left_detached_motion = crate::interaction::get_controller_motion_data(
+                &xr_session,
+                stage_reference_space,
+                now,
+                &int_ctx.hands_interaction[0],
+                &mut last_controller_poses[0]
+            );
+            if let Some(motion) = left_detached_motion {
+                device_motions.push((*FAKE_TRACKER_LEFT_ID, motion));
+            };
+        }
+        if int_ctx.use_right_controller_as_fake_tracker {
+            let right_detached_motion = crate::interaction::get_controller_motion_data(
+                &xr_session,
+                stage_reference_space,
+                now,
+                &int_ctx.hands_interaction[1],
+                &mut last_controller_poses[1]
+            );
+            if let Some(motion) = right_detached_motion {
+                device_motions.push((*FAKE_TRACKER_RIGHT_ID, motion));
+            };
         }
 
         let face_data = FaceData {

--- a/alvr/common/src/inputs.rs
+++ b/alvr/common/src/inputs.rs
@@ -58,6 +58,8 @@ devices! {
     (BODY_RIGHT_FOOT, "/user/body/right_foot"),
     (DETACHED_CONTROLLER_LEFT, "/user/detached_controller_meta/left"),
     (DETACHED_CONTROLLER_RIGHT, "/user/detached_controller_meta/right"),
+    (FAKE_TRACKER_LEFT, "/user/fake_tracker/left"),
+    (FAKE_TRACKER_RIGHT, "/user/fake_tracker/right"),
 }
 
 pub enum ButtonType {

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -72,6 +72,9 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
     let mut controller_is_tracker = false;
     let mut _controller_profile = 0;
     let mut use_separate_hand_trackers = false;
+    let mut use_left_controller_as_fake_tracker = false;
+    let mut use_right_controller_as_fake_tracker = false;
+
     let controllers_enabled = if let Switch::Enabled(config) = settings.headset.controllers {
         controller_is_tracker =
             matches!(config.emulation_mode, ControllersEmulationMode::ViveTracker);
@@ -94,6 +97,10 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
             .as_option()
             .map(|c| c.steamvr_input_2_0)
             .unwrap_or(false);
+
+        use_left_controller_as_fake_tracker = config.use_left_as_tracker;
+        use_right_controller_as_fake_tracker = config.use_right_as_tracker;
+
 
         true
     } else {
@@ -228,6 +235,8 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
         capture_frame_dir: settings.extra.capture.capture_frame_dir,
         amd_bitrate_corruption_fix: settings.video.bitrate.image_corruption_fix,
         use_separate_hand_trackers,
+        use_left_controller_as_fake_tracker,
+        use_right_controller_as_fake_tracker,
         _controller_profile,
         _server_impl_debug: settings.extra.logging.debug_groups.server_impl,
         _client_impl_debug: settings.extra.logging.debug_groups.client_impl,

--- a/alvr/server_openvr/cpp/alvr_server/FakeViveTracker.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/FakeViveTracker.cpp
@@ -112,7 +112,11 @@ bool FakeViveTracker::activate() {
     vr_properties->SetStringProperty(this->prop_container, vr::Prop_ResourceRoot_String, "htc");
 
     const char* name;
-    if (this->device_id == BODY_CHEST_ID) {
+    if (this->device_id == FAKE_LEFT_TRACKER_ID) {
+        name = "ALVR/tracker/fake_left_tracker";
+    } else if (this->device_id == FAKE_RIGHT_TRACKER_ID) {
+        name = "ALVR/tracker/fake_right_tracker";
+    } else if (this->device_id == BODY_CHEST_ID) {
         name = "ALVR/tracker/chest";
     } else if (this->device_id == BODY_HIPS_ID) {
         name = "ALVR/tracker/waist";

--- a/alvr/server_openvr/cpp/alvr_server/Paths.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Paths.cpp
@@ -7,6 +7,8 @@ uint64_t HAND_RIGHT_ID;
 uint64_t HAND_TRACKER_LEFT_ID;
 uint64_t HAND_TRACKER_RIGHT_ID;
 uint64_t BODY_CHEST_ID;
+uint64_t FAKE_LEFT_TRACKER_ID;
+uint64_t FAKE_RIGHT_TRACKER_ID;
 uint64_t BODY_HIPS_ID;
 uint64_t BODY_LEFT_ELBOW_ID;
 uint64_t BODY_RIGHT_ELBOW_ID;
@@ -46,6 +48,8 @@ void init_paths() {
     HAND_TRACKER_LEFT_ID = PathStringToHash("/user/hand_tracker/left");
     HAND_TRACKER_RIGHT_ID = PathStringToHash("/user/hand_tracker/right");
     BODY_CHEST_ID = PathStringToHash("/user/body/chest");
+    FAKE_LEFT_TRACKER_ID = PathStringToHash("/user/body/left_elbow");
+    FAKE_RIGHT_TRACKER_ID = PathStringToHash("/user/body/right_elbow");
     BODY_HIPS_ID = PathStringToHash("/user/body/waist");
     BODY_LEFT_ELBOW_ID = PathStringToHash("/user/body/left_elbow");
     BODY_RIGHT_ELBOW_ID = PathStringToHash("/user/body/right_elbow");

--- a/alvr/server_openvr/cpp/alvr_server/Paths.h
+++ b/alvr/server_openvr/cpp/alvr_server/Paths.h
@@ -13,6 +13,8 @@ extern uint64_t HAND_RIGHT_ID;
 extern uint64_t HAND_TRACKER_LEFT_ID;
 extern uint64_t HAND_TRACKER_RIGHT_ID;
 extern uint64_t BODY_CHEST_ID;
+extern uint64_t FAKE_LEFT_TRACKER_ID;
+extern uint64_t FAKE_RIGHT_TRACKER_ID;
 extern uint64_t BODY_HIPS_ID;
 extern uint64_t BODY_LEFT_ELBOW_ID;
 extern uint64_t BODY_RIGHT_ELBOW_ID;

--- a/alvr/server_openvr/cpp/alvr_server/Settings.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Settings.cpp
@@ -120,6 +120,9 @@ void Settings::Load() {
 
         m_useSeparateHandTrackers = config.get("use_separate_hand_trackers").get<bool>();
 
+        m_useLeftControllerAsFakeTracker = config.get("use_left_controller_as_fake_tracker").get<bool>();
+        m_useRightControllerAsFakeTracker = config.get("use_right_controller_as_fake_tracker").get<bool>();
+
         Info("Render Target: %d %d\n", m_renderWidth, m_renderHeight);
         Info("Refresh Rate: %d\n", m_refreshRate);
         m_loaded = true;

--- a/alvr/server_openvr/cpp/alvr_server/Settings.h
+++ b/alvr/server_openvr/cpp/alvr_server/Settings.h
@@ -92,4 +92,7 @@ public:
     int m_enableBodyTrackingFakeVive = false;
     int m_bodyTrackingHasLegs = false;
     bool m_useSeparateHandTrackers = false;
+
+    bool m_useLeftControllerAsFakeTracker = false;
+    bool m_useRightControllerAsFakeTracker = false;
 };

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -145,6 +145,8 @@ extern "C" void SetTracking(
     FfiDeviceMotion headMotion,
     FfiHandData leftHandData,
     FfiHandData rightHandData,
+    FfiDeviceMotion fakeLeftTrackerMotion,
+    FfiDeviceMotion fakeRightTrackerMotion,
     const FfiDeviceMotion* bodyTrackerMotions,
     int bodyTrackerMotionCount
 );

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -15,8 +15,9 @@ mod bindings {
 use bindings::*;
 
 use alvr_common::{
-    error, once_cell::sync::Lazy, parking_lot::RwLock, settings_schema::Switch, warn, BUTTON_INFO,
+    error, once_cell::sync::Lazy, parking_lot::RwLock, settings_schema::Switch, warn, BUTTON_INFO, 
     HAND_LEFT_ID, HAND_RIGHT_ID, HAND_TRACKER_LEFT_ID, HAND_TRACKER_RIGHT_ID, HEAD_ID,
+    FAKE_TRACKER_LEFT_ID, FAKE_TRACKER_RIGHT_ID, 
 };
 use alvr_filesystem as afs;
 use alvr_packets::{ButtonValue, Haptics};
@@ -115,7 +116,15 @@ fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                             .get_device_motion(*HAND_RIGHT_ID, sample_timestamp)
                             .map(|m| tracking::to_ffi_motion(*HAND_RIGHT_ID, m))
                             .filter(|_| tracked);
-
+                        let ffi_left_fake_tracker = context
+                            .get_device_motion(*FAKE_TRACKER_LEFT_ID, sample_timestamp)
+                            .map(|m| tracking::to_ffi_motion(*FAKE_TRACKER_LEFT_ID, m))
+                            .filter(|_| tracked);
+                        let ffi_right_fake_tracker = context
+                            .get_device_motion(*FAKE_TRACKER_RIGHT_ID, sample_timestamp)
+                            .map(|m| tracking::to_ffi_motion(*FAKE_TRACKER_RIGHT_ID, m))
+                            .filter(|_| tracked);
+                        
                         let (
                             ffi_left_hand_skeleton,
                             ffi_right_hand_skeleton,
@@ -213,6 +222,8 @@ fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                                 ffi_head_motion,
                                 ffi_left_hand_data,
                                 ffi_right_hand_data,
+                                ffi_left_fake_tracker.unwrap_or_default(),
+                                ffi_right_fake_tracker.unwrap_or_default(),
                                 ffi_body_tracker_motions.as_ptr(),
                                 ffi_body_tracker_motions.len() as i32,
                             )

--- a/alvr/session/src/lib.rs
+++ b/alvr/session/src/lib.rs
@@ -99,6 +99,8 @@ pub struct OpenvrConfig {
     pub capture_frame_dir: String,
     pub amd_bitrate_corruption_fix: bool,
     pub use_separate_hand_trackers: bool,
+    pub use_left_controller_as_fake_tracker: bool,
+    pub use_right_controller_as_fake_tracker: bool,
 
     // these settings are not used on the C++ side, but we need them to correctly trigger a SteamVR
     // restart

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1137,6 +1137,14 @@ Because of runtime limitations, this option is ignored when body tracking is act
     ))]
     pub multimodal_tracking: bool,
 
+    #[schema(flag = "steamvr-restart")]
+    #[schema(strings(help = r"If it is activated left controller will be used as fake tracker in steamVR"))]
+    pub use_left_as_tracker: bool,
+
+    #[schema(flag = "steamvr-restart")]
+    #[schema(strings(help = r"If it is activated right controller will be used as fake tracker in steamVR"))]
+    pub use_right_as_tracker: bool,
+
     #[schema(flag = "real-time")]
     #[schema(strings(
         help = "Enabling this allows using hand gestures to emulate controller inputs."
@@ -1894,6 +1902,8 @@ pub fn session_settings_default() -> SettingsDefault {
                         },
                     },
                     multimodal_tracking: false,
+                    use_left_as_tracker: false,
+                    use_right_as_tracker: false,
                     emulation_mode: ControllersEmulationModeDefault {
                         Custom: ControllersEmulationModeCustomDefault {
                             serial_number: "ALVR Controller".into(),


### PR DESCRIPTION
We have a VR project — a machine gun simulator — where we use a real physical model of a machine gun. Our goal is to track where the user is aiming with the real machine gun and transfer that data into the virtual world. At the same time, we also need to track the user’s hands so that the player can see their virtual hands and accurately grab the machine gun handles.

To achieve this in Unity3D, we had to treat the VR controllers as trackers, and then extract tracking data from them in Unity accordingly.
