### PR TITLE
Client-side OpenXR post-processing

### DIFF
--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -15,9 +15,9 @@ use alvr_common::{
     Pose, RelaxedAtomic, ALVR_VERSION,
 };
 use alvr_packets::{
-    ClientConnectionResult, ClientControlPacket, ClientStatistics, Haptics, ServerControlPacket,
-    StreamConfigPacket, Tracking, VideoPacketHeader, VideoStreamingCapabilities, ViewParams, AUDIO,
-    HAPTICS, STATISTICS, TRACKING, VIDEO,
+    ClientConnectionResult, ClientControlPacket, ClientStatistics, Haptics, RealTimeConfig,
+    ServerControlPacket, StreamConfigPacket, Tracking, VideoPacketHeader,
+    VideoStreamingCapabilities, ViewParams, AUDIO, HAPTICS, STATISTICS, TRACKING, VIDEO,
 };
 use alvr_session::{settings_schema::Switch, SocketProtocol};
 use alvr_sockets::{
@@ -494,7 +494,7 @@ fn connection_pipeline(
                     Ok(ServerControlPacket::ReservedBuffer(buffer)) => {
                         // NB: it's normal for deserialization to fail if server has different
                         // version
-                        if let Ok(config) = alvr_packets::decode_real_time_config(&buffer) {
+                        if let Ok(config) = RealTimeConfig::decode(&buffer) {
                             event_queue
                                 .lock()
                                 .push_back(ClientCoreEvent::RealTimeConfig(config));

--- a/alvr/client_openxr/src/graphics.rs
+++ b/alvr/client_openxr/src/graphics.rs
@@ -1,5 +1,6 @@
 use alvr_common::glam::UVec2;
 use alvr_graphics::GraphicsContext;
+use alvr_session::ClientsidePostProcessingConfig;
 use openxr as xr;
 
 #[allow(unused)]
@@ -63,7 +64,7 @@ pub struct ProjectionLayerBuilder<'a> {
     reference_space: &'a xr::Space,
     layers: [xr::CompositionLayerProjectionView<'a, xr::OpenGlEs>; 2],
     alpha: Option<ProjectionLayerAlphaConfig>,
-    composition_layer_settings: Option<&'a xr::sys::CompositionLayerSettingsFB>,
+    composition_layer_settings: Option<xr::sys::CompositionLayerSettingsFB>,
 }
 
 impl<'a> ProjectionLayerBuilder<'a> {
@@ -71,8 +72,20 @@ impl<'a> ProjectionLayerBuilder<'a> {
         reference_space: &'a xr::Space,
         layers: [xr::CompositionLayerProjectionView<'a, xr::OpenGlEs>; 2],
         alpha: Option<ProjectionLayerAlphaConfig>,
-        composition_layer_settings: Option<&'a xr::sys::CompositionLayerSettingsFB>,
+        clientside_post_processing_config: Option<ClientsidePostProcessingConfig>,
     ) -> Self {
+        let composition_layer_settings = clientside_post_processing_config
+            .map(|post_processing| {
+                xr::CompositionLayerSettingsFlagsFB::from_raw(
+                    (post_processing.sharpening as u64) | (post_processing.super_sampling as u64),
+                )
+            })
+            .filter(|&flags| flags != xr::CompositionLayerSettingsFlagsFB::EMPTY)
+            .map(|flags| xr::sys::CompositionLayerSettingsFB {
+                ty: xr::StructureType::COMPOSITION_LAYER_SETTINGS_FB,
+                next: std::ptr::null(),
+                layer_flags: flags,
+            });
         Self {
             reference_space,
             layers,
@@ -97,11 +110,8 @@ impl<'a> ProjectionLayerBuilder<'a> {
             .space(self.reference_space)
             .views(&self.layers);
 
-        if let Some(composition_layer_settings) = self.composition_layer_settings {
+        if let Some(composition_layer_settings) = self.composition_layer_settings.as_ref() {
             unsafe {
-                // The entire result of the default build() is moved into this one, so this should be safe as long as:
-                // - the layer would have been correctly built without the `next` pointer
-                // - the data referred to by the `next` pointer outlives the built layer
                 xr::CompositionLayerProjection::from_raw(xr::sys::CompositionLayerProjection {
                     next: std::ptr::from_ref(composition_layer_settings).cast(),
                     ..layer.into_raw()

--- a/alvr/client_openxr/src/graphics.rs
+++ b/alvr/client_openxr/src/graphics.rs
@@ -1,6 +1,7 @@
 use alvr_common::glam::UVec2;
 use alvr_graphics::GraphicsContext;
 use openxr as xr;
+use std::ffi::c_void;
 
 #[allow(unused)]
 pub fn session_create_info(ctx: &GraphicsContext) -> xr::opengles::SessionCreateInfo {
@@ -79,6 +80,13 @@ impl<'a> ProjectionLayerBuilder<'a> {
     }
 
     pub fn build(&self) -> xr::CompositionLayerProjection<xr::OpenGlEs> {
+        xr::CompositionLayerProjection::new()
+            .layer_flags(self.flags())
+            .space(self.reference_space)
+            .views(&self.layers)
+    }
+
+    fn flags(&self) -> xr::CompositionLayerFlags {
         let mut flags = xr::CompositionLayerFlags::EMPTY;
 
         if let Some(alpha) = &self.alpha {
@@ -89,9 +97,24 @@ impl<'a> ProjectionLayerBuilder<'a> {
             }
         }
 
-        xr::CompositionLayerProjection::new()
-            .layer_flags(flags)
-            .space(self.reference_space)
-            .views(&self.layers)
+        flags
+    }
+
+    /// The `next` pointer necessary to specify layer settings is not available from the builder,
+    /// and it is not accessible to mutate once built either.
+    /// The only way to set it is by creating the layer with `from_raw`.
+    ///
+    /// To make things easier on us, we build the layer with the tried and tested `build`,
+    /// before immediately dismantling its raw content and re-assembling it with the added `next` field.  
+    pub fn build_chain(&self, next: *const c_void) -> xr::CompositionLayerProjection<xr::OpenGlEs> {
+        unsafe {
+            // The entire result of the default build() is moved into this one, so this should be safe as long as:
+            // - the layer would have been correctly built without the `next` pointer
+            // - the data referred to by the `next` pointer outlives the built layer
+            xr::CompositionLayerProjection::from_raw(xr::sys::CompositionLayerProjection {
+                next,
+                ..self.build().into_raw()
+            })
+        }
     }
 }

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -485,7 +485,7 @@ pub fn entry_point() {
             let layer_settings = xr_instance
                 .exts()
                 .fb_composition_layer_settings
-                .and_then(|_| stream_context.as_ref())
+                .and(stream_context.as_ref())
                 .map(|context| context.composition_layer_flags())
                 .filter(|&flags| flags > 0)
                 .map(|flags| xr::sys::CompositionLayerSettingsFB {

--- a/alvr/client_openxr/src/lobby.rs
+++ b/alvr/client_openxr/src/lobby.rs
@@ -246,6 +246,7 @@ impl Lobby {
             Some(ProjectionLayerAlphaConfig {
                 premultiplied: true,
             }),
+            None,
         )
     }
 }

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -101,7 +101,6 @@ pub struct StreamContext {
     target_view_resolution: UVec2,
     renderer: StreamRenderer,
     decoder: Option<(VideoDecoderConfig, VideoDecoderSource)>,
-    composition_layer_settings: Option<xr::sys::CompositionLayerSettingsFB>,
 }
 
 impl StreamContext {
@@ -224,9 +223,6 @@ impl StreamContext {
             xr::ReferenceSpaceType::VIEW,
         ));
 
-        let composition_layer_settings =
-            build_composition_layer_settings(xr_exts, config.clientside_post_processing.as_ref());
-
         let mut this = StreamContext {
             core_context: core_ctx,
             xr_session,
@@ -241,7 +237,6 @@ impl StreamContext {
             target_view_resolution,
             renderer,
             decoder: None,
-            composition_layer_settings,
         };
 
         this.update_reference_space();
@@ -335,10 +330,6 @@ impl StreamContext {
     pub fn update_real_time_config(&mut self, config: &RealTimeConfig) {
         self.config.passthrough = config.passthrough.clone();
         self.config.clientside_post_processing = config.clientside_post_processing.clone();
-        self.composition_layer_settings = build_composition_layer_settings(
-            self.xr_session.instance().exts(),
-            config.clientside_post_processing.as_ref(),
-        );
     }
 
     pub fn render(
@@ -422,6 +413,13 @@ impl StreamContext {
             },
         };
 
+        let clientside_post_processing = self
+            .xr_session
+            .instance()
+            .exts()
+            .fb_composition_layer_settings
+            .and(self.config.clientside_post_processing.clone());
+
         let layer = ProjectionLayerBuilder::new(
             &self.stage_reference_space,
             [
@@ -457,7 +455,7 @@ impl StreamContext {
                             | PassthroughMode::HsvChromaKey(_)
                     ),
                 }),
-            self.composition_layer_settings.as_ref(),
+            clientside_post_processing,
         );
 
         (layer, timestamp)
@@ -610,21 +608,4 @@ fn stream_input_loop(
         deadline += frame_interval / 3;
         thread::sleep(deadline.saturating_duration_since(Instant::now()));
     }
-}
-
-#[inline]
-fn build_composition_layer_settings(
-    xr_exts: &xr::InstanceExtensions,
-    config: Option<&ClientsidePostProcessingConfig>,
-) -> Option<xr::sys::CompositionLayerSettingsFB> {
-    xr_exts
-        .fb_composition_layer_settings
-        .and(config)
-        .map(|post_processing| post_processing.flags())
-        .filter(|&flags| flags > 0)
-        .map(|flags| xr::sys::CompositionLayerSettingsFB {
-            ty: xr::StructureType::COMPOSITION_LAYER_SETTINGS_FB,
-            next: ptr::null(),
-            layer_flags: xr::CompositionLayerSettingsFlagsFB::from_raw(flags),
-        })
 }

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -19,7 +19,7 @@ use alvr_graphics::{
 use alvr_packets::{FaceData, RealTimeConfig, StreamConfig, ViewParams};
 use alvr_session::{
     ClientsideFoveationConfig, ClientsideFoveationMode, CodecType, FoveatedEncodingConfig,
-    MediacodecProperty, PassthroughMode, UpscalingConfig,
+    MediacodecProperty, PassthroughMode, PostProcessingConfig, UpscalingConfig,
 };
 use alvr_system_info::Platform;
 use openxr as xr;
@@ -42,6 +42,7 @@ pub struct ParsedStreamConfig {
     pub passthrough: Option<PassthroughMode>,
     pub foveated_encoding_config: Option<FoveatedEncodingConfig>,
     pub clientside_foveation_config: Option<ClientsideFoveationConfig>,
+    pub clientside_post_processing: PostProcessingConfig,
     pub upscaling: Option<UpscalingConfig>,
     pub force_software_decoder: bool,
     pub max_buffering_frames: f32,
@@ -64,6 +65,7 @@ impl ParsedStreamConfig {
                 .enable_foveated_encoding
                 .then(|| config.settings.video.foveated_encoding.as_option().cloned())
                 .flatten(),
+            clientside_post_processing: config.settings.video.clientside_post_processing.clone(),
             clientside_foveation_config: config
                 .settings
                 .video
@@ -239,6 +241,11 @@ impl StreamContext {
 
     pub fn uses_passthrough(&self) -> bool {
         self.config.passthrough.is_some()
+    }
+
+    pub fn composition_layer_flags(&self) -> u64 {
+        (self.config.clientside_post_processing.sharpening as u64)
+            | (self.config.clientside_post_processing.super_sampling as u64)
     }
 
     pub fn update_reference_space(&mut self) {

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -4,7 +4,9 @@ use alvr_common::{
     semver::Version,
     ConnectionState, DeviceMotion, Fov, LogEntry, LogSeverity, Pose, ToAny,
 };
-use alvr_session::{CodecType, PassthroughMode, SessionConfig, Settings};
+use alvr_session::{
+    ClientsidePostProcessingConfig, CodecType, PassthroughMode, SessionConfig, Settings,
+};
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 use std::{
@@ -411,16 +413,30 @@ pub enum ServerRequest {
 #[derive(Serialize, Deserialize)]
 pub struct RealTimeConfig {
     pub passthrough: Option<PassthroughMode>,
+    pub clientside_post_processing: Option<ClientsidePostProcessingConfig>,
 }
 
-pub fn encode_real_time_config(config: &RealTimeConfig) -> Result<ServerControlPacket> {
-    Ok(ServerControlPacket::ReservedBuffer(bincode::serialize(
-        config,
-    )?))
-}
+impl RealTimeConfig {
+    pub fn encode(&self) -> Result<ServerControlPacket> {
+        Ok(ServerControlPacket::ReservedBuffer(bincode::serialize(
+            self,
+        )?))
+    }
 
-pub fn decode_real_time_config(buffer: &[u8]) -> Result<RealTimeConfig> {
-    Ok(bincode::deserialize(buffer)?)
+    pub fn decode(buffer: &[u8]) -> Result<Self> {
+        Ok(bincode::deserialize(buffer)?)
+    }
+
+    pub fn from_settings(settings: &Settings) -> Self {
+        Self {
+            passthrough: settings.video.passthrough.clone().into_option(),
+            clientside_post_processing: settings
+                .video
+                .clientside_post_processing
+                .clone()
+                .into_option(),
+        }
+    }
 }
 
 // Per eye view parameters

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -1089,12 +1089,10 @@ fn connection_pipeline(
                     let session_manager_lock = SESSION_MANAGER.read();
                     let settings = session_manager_lock.settings();
 
-                    RealTimeConfig {
-                        passthrough: settings.video.passthrough.clone().into_option(),
-                    }
+                    RealTimeConfig::from_settings(settings)
                 };
 
-                if let Ok(config) = alvr_packets::encode_real_time_config(&config) {
+                if let Ok(config) = config.encode() {
                     control_sender.lock().send(&config).ok();
                 }
 

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -688,12 +688,6 @@ pub struct ClientsidePostProcessingConfig {
     pub sharpening: ClientsidePostProcessingSharpeningMode,
 }
 
-impl ClientsidePostProcessingConfig {
-    pub fn flags(&self) -> u64 {
-        (self.sharpening as u64) | (self.super_sampling as u64)
-    }
-}
-
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct UpscalingConfig {
     #[schema(strings(

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -688,6 +688,12 @@ pub struct ClientsidePostProcessingConfig {
     pub sharpening: ClientsidePostProcessingSharpeningMode,
 }
 
+impl ClientsidePostProcessingConfig {
+    pub fn flags(&self) -> u64 {
+        (self.sharpening as u64) | (self.super_sampling as u64)
+    }
+}
+
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct UpscalingConfig {
     #[schema(strings(
@@ -784,6 +790,7 @@ If you want to reduce the amount of pixelation on the edges, increase the center
         display_name = "Client-side post-processing",
         help = "Hardware optimized algorithms, available on Quest and Pico headsets"
     ))]
+    #[schema(flag = "real-time")]
     pub clientside_post_processing: Switch<ClientsidePostProcessingConfig>,
 
     #[schema(strings(help = "Snapdragon Game Super Resolution client-side upscaling"))]
@@ -1619,10 +1626,10 @@ pub fn session_settings_default() -> SettingsDefault {
                 enabled: false,
                 content: ClientsidePostProcessingConfigDefault {
                     super_sampling: ClientsidePostProcessingSuperSamplingModeDefault {
-                        variant: ClientsidePostProcessingSuperSamplingModeDefaultVariant::Disabled,
+                        variant: ClientsidePostProcessingSuperSamplingModeDefaultVariant::Quality,
                     },
                     sharpening: ClientsidePostProcessingSharpeningModeDefault {
-                        variant: ClientsidePostProcessingSharpeningModeDefaultVariant::Disabled,
+                        variant: ClientsidePostProcessingSharpeningModeDefaultVariant::Quality,
                     },
                 },
             },

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -661,7 +661,7 @@ This is a similar effect to AR glasses."
 #[repr(u8)]
 #[derive(SettingsSchema, Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 #[schema(gui = "button_group")]
-pub enum PostProcessingSuperSamplingMode {
+pub enum ClientsidePostProcessingSuperSamplingMode {
     Disabled = 0,
     Normal = 1 << 0,
     Quality = 1 << 1,
@@ -670,22 +670,22 @@ pub enum PostProcessingSuperSamplingMode {
 #[repr(u8)]
 #[derive(SettingsSchema, Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 #[schema(gui = "button_group")]
-pub enum PostProcessingSharpeningMode {
+pub enum ClientsidePostProcessingSharpeningMode {
     Disabled = 0,
     Normal = 1 << 2,
     Quality = 1 << 3,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Debug)]
-pub struct PostProcessingConfig {
+pub struct ClientsidePostProcessingConfig {
     #[schema(strings(
         help = "Reduce flicker for high contrast edges.\nUseful when the input resolution is high compared to the headset display"
     ))]
-    pub super_sampling: PostProcessingSuperSamplingMode,
+    pub super_sampling: ClientsidePostProcessingSuperSamplingMode,
     #[schema(strings(
         help = "Improve clarity of high contrast edges and counteract blur.\nUseful when the input resolution is low compared to the headset display"
     ))]
-    pub sharpening: PostProcessingSharpeningMode,
+    pub sharpening: ClientsidePostProcessingSharpeningMode,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Debug)]
@@ -780,8 +780,11 @@ If you want to reduce the amount of pixelation on the edges, increase the center
 
     pub clientside_foveation: Switch<ClientsideFoveationConfig>,
 
-    #[schema(strings(display_name = "OpenXR client-side post-processing"))]
-    pub clientside_post_processing: PostProcessingConfig,
+    #[schema(strings(
+        display_name = "Client-side post-processing",
+        help = "Hardware optimized algorithms, available on Quest and Pico headsets"
+    ))]
+    pub clientside_post_processing: Switch<ClientsidePostProcessingConfig>,
 
     #[schema(strings(help = "Snapdragon Game Super Resolution client-side upscaling"))]
     pub upscaling: Switch<UpscalingConfig>,
@@ -1612,12 +1615,15 @@ pub fn session_settings_default() -> SettingsDefault {
                     },
                 },
             },
-            clientside_post_processing: PostProcessingConfigDefault {
-                super_sampling: PostProcessingSuperSamplingModeDefault {
-                    variant: PostProcessingSuperSamplingModeDefaultVariant::Disabled,
-                },
-                sharpening: PostProcessingSharpeningModeDefault {
-                    variant: PostProcessingSharpeningModeDefaultVariant::Disabled,
+            clientside_post_processing: SwitchDefault {
+                enabled: false,
+                content: ClientsidePostProcessingConfigDefault {
+                    super_sampling: ClientsidePostProcessingSuperSamplingModeDefault {
+                        variant: ClientsidePostProcessingSuperSamplingModeDefaultVariant::Disabled,
+                    },
+                    sharpening: ClientsidePostProcessingSharpeningModeDefault {
+                        variant: ClientsidePostProcessingSharpeningModeDefaultVariant::Disabled,
+                    },
                 },
             },
             upscaling: SwitchDefault {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -658,6 +658,36 @@ This is a similar effect to AR glasses."
     HsvChromaKey(#[schema(flag = "real-time")] HsvChromaKeyConfig),
 }
 
+#[repr(u8)]
+#[derive(SettingsSchema, Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[schema(gui = "button_group")]
+pub enum PostProcessingSuperSamplingMode {
+    Disabled = 0,
+    Normal = 1 << 0,
+    Quality = 1 << 1,
+}
+
+#[repr(u8)]
+#[derive(SettingsSchema, Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+#[schema(gui = "button_group")]
+pub enum PostProcessingSharpeningMode {
+    Disabled = 0,
+    Normal = 1 << 2,
+    Quality = 1 << 3,
+}
+
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct PostProcessingConfig {
+    #[schema(strings(
+        help = "Reduce flicker for high contrast edges.\nUseful when the input resolution is high compared to the headset display"
+    ))]
+    pub super_sampling: PostProcessingSuperSamplingMode,
+    #[schema(strings(
+        help = "Improve clarity of high contrast edges and counteract blur.\nUseful when the input resolution is low compared to the headset display"
+    ))]
+    pub sharpening: PostProcessingSharpeningMode,
+}
+
 #[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct UpscalingConfig {
     #[schema(strings(
@@ -749,6 +779,9 @@ If you want to reduce the amount of pixelation on the edges, increase the center
     pub adapter_index: u32,
 
     pub clientside_foveation: Switch<ClientsideFoveationConfig>,
+
+    #[schema(strings(display_name = "OpenXR client-side post-processing"))]
+    pub clientside_post_processing: PostProcessingConfig,
 
     #[schema(strings(help = "Snapdragon Game Super Resolution client-side upscaling"))]
     pub upscaling: Switch<UpscalingConfig>,
@@ -1577,6 +1610,14 @@ pub fn session_settings_default() -> SettingsDefault {
                         value_end_min: 1.0,
                         value_end_max: 1.1,
                     },
+                },
+            },
+            clientside_post_processing: PostProcessingConfigDefault {
+                super_sampling: PostProcessingSuperSamplingModeDefault {
+                    variant: PostProcessingSuperSamplingModeDefaultVariant::Disabled,
+                },
+                sharpening: PostProcessingSharpeningModeDefault {
+                    variant: PostProcessingSharpeningModeDefaultVariant::Disabled,
                 },
             },
             upscaling: SwitchDefault {


### PR DESCRIPTION
This is an implementation of Meta’s [composition layer filtering OpenXR extension](https://developers.meta.com/horizon/documentation/native/android/mobile-openxr-composition-layer-filtering/).
It simply consists in detecting said extension, enabling it if available, and adding a set flags on each submitted composition layer to specify the desired level of super sampling and/or sharpening.

I tested it successfully on my Quest 3, and from tests on other OpenXR tools, this should also work at least on Pico headsets.
If the extension is unavailable on the target headset, or if both post-processing settings are left to Disabled in the dashboard, it will fallback to the current existing behavior.

This is my first time working with production-level Rust code, so please correct me on all my non-idiomatic code!