### PR TITLE
Remove PrefersNonDefaultGPU from desktop files

### DIFF
--- a/alvr/xtask/flatpak/com.valvesoftware.Steam.Utility.alvr.desktop
+++ b/alvr/xtask/flatpak/com.valvesoftware.Steam.Utility.alvr.desktop
@@ -8,6 +8,4 @@ Exec=/usr/bin/flatpak run --command=/app/utils/alvr/bin/alvr_launcher com.valves
 Icon=application-alvr-launcher
 Categories=Game;
 StartupNotify=true
-PrefersNonDefaultGPU=true
-X-KDE-RunOnDiscreteGpu=true
 StartupWMClass=ALVR

--- a/alvr/xtask/resources/alvr.desktop
+++ b/alvr/xtask/resources/alvr.desktop
@@ -8,6 +8,4 @@ Exec=alvr_dashboard
 Icon=alvr
 Categories=Game;
 StartupNotify=true
-PrefersNonDefaultGPU=true
-X-KDE-RunOnDiscreteGpu=true
 StartupWMClass=alvr.dashboard


### PR DESCRIPTION
PrefersNonDefaultGPU is currently very broken, see https://github.com/ValveSoftware/steam-for-linux/issues/9940, and X-KDE-RunOnDiscreteGpu (which uses the same behavior) has been deprecated in favor of PrefersNonDefaultGPU