### PR TITLE
bugfix: Velocity workaround for PFD MR headset pose

### DIFF
--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -679,7 +679,7 @@ pub fn get_head_data(
     };
 
     // Some headsets use wrong frame of reference for linear and angular velocities.
-    if platform.is_pico() || platform.is_vive() {
+    if platform.is_pico() || platform.is_vive() || platform.is_yvr() {
         let xr_future_time = crate::to_xr_time(future_time);
 
         let predicted_location = view_reference_space


### PR DESCRIPTION
Just adds YVR runtimes to the Hall of Shame, pose prediction feels much better.