### PR TITLE
fix(firewall): linux firewalld zones being parsed incorrectly

### DIFF
--- a/alvr/xtask/firewall/alvr_fw_config.sh
+++ b/alvr/xtask/firewall/alvr_fw_config.sh
@@ -10,7 +10,7 @@
 
 firewalld_cfg() {
     # Iterate around each active zone
-    for zone in $(firewall-cmd --get-active-zones | grep -P '^\w+.*\w$'); do
+    for zone in $(firewall-cmd --get-active-zones | grep -P '^\w+'); do
         if [ "${1}" == 'add' ]; then
             # If running or permanent alvr service is missing, add it
             if ! firewall-cmd --zone="${zone}" --list-services | grep 'alvr' >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes #2250
Seems like it was incorrect regex being used, not parsing *all* zones from list of active zones (including public, or any that had other words in line)