### PR TITLE
feat(dashboard): :sparkles: Add new version popup

### DIFF
--- a/alvr/dashboard/src/data_sources.rs
+++ b/alvr/dashboard/src/data_sources.rs
@@ -1,7 +1,13 @@
-use alvr_common::{debug, error, info, parking_lot::Mutex, semver::Version, warn, RelaxedAtomic};
+use alvr_common::{
+    debug, error, info,
+    parking_lot::Mutex,
+    semver::{Version, VersionReq},
+    warn, RelaxedAtomic,
+};
 use alvr_events::{Event, EventType};
 use alvr_packets::ServerRequest;
 use alvr_server_io::ServerSessionManager;
+use alvr_session::NewVersionPopupConfig;
 use eframe::egui;
 use std::{
     io::ErrorKind,
@@ -16,7 +22,7 @@ use tungstenite::{
     http::{HeaderValue, Uri},
 };
 
-const REQUEST_TIMEOUT: Duration = Duration::from_millis(200);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 
 enum SessionSource {
     Local(Box<ServerSessionManager>),
@@ -67,6 +73,7 @@ pub struct DataSources {
     requests_sender: mpsc::Sender<ServerRequest>,
     events_receiver: mpsc::Receiver<PolledEvent>,
     server_connected: Arc<RelaxedAtomic>,
+    version_check_thread: Option<JoinHandle<()>>,
     requests_thread: Option<JoinHandle<()>>,
     events_thread: Option<JoinHandle<()>>,
     ping_thread: Option<JoinHandle<()>>,
@@ -87,6 +94,72 @@ impl DataSources {
         let session_manager = get_local_session_source();
         let port = session_manager.settings().connection.web_server_port;
         let session_source = Arc::new(Mutex::new(SessionSource::Local(Box::new(session_manager))));
+
+        let version_check_thread = thread::spawn({
+            let context = context.clone();
+            let session_source = Arc::clone(&session_source);
+            let events_sender = events_sender.clone();
+            move || {
+                let version_requirement = {
+                    // Best-effort: the check will succeed only when the server is not already running,
+                    // no retries
+                    let SessionSource::Local(session_manager_lock) = &mut *session_source.lock()
+                    else {
+                        return;
+                    };
+
+                    match &session_manager_lock.settings().extra.new_version_popup {
+                        NewVersionPopupConfig::Show => VersionReq::STAR,
+                        NewVersionPopupConfig::HideWhileVersion(version) => {
+                            VersionReq::parse(&format!(">{version}")).unwrap()
+                        }
+                        NewVersionPopupConfig::AlwaysHide => return,
+                    }
+                };
+
+                let request_agent: ureq::Agent = ureq::Agent::config_builder()
+                    .timeout_global(Some(REQUEST_TIMEOUT))
+                    .build()
+                    .into();
+                if let Ok(response) = request_agent
+                    .get("https://api.github.com/repos/alvr-org/ALVR/releases/latest")
+                    .call()
+                {
+                    let Ok(version_data) = response.into_body().read_json::<serde_json::Value>()
+                    else {
+                        return;
+                    };
+
+                    let Some(version_str) = version_data
+                        .get("tag_name")
+                        .and_then(|v| Some(v.as_str()?.trim_start_matches("v")))
+                    else {
+                        return;
+                    };
+
+                    let version = version_str.parse::<Version>().ok();
+
+                    if version
+                        .map(|v| version_requirement.matches(&v))
+                        .unwrap_or(false)
+                    {
+                        let message = version_data
+                            .get("body")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("Error parsing release body");
+
+                        report_event_local(
+                            &context,
+                            &events_sender,
+                            EventType::NewVersionFound {
+                                version: version_str.to_string(),
+                                message: message.to_string(),
+                            },
+                        );
+                    }
+                }
+            }
+        });
 
         let requests_thread = thread::spawn({
             let running = Arc::clone(&running);
@@ -347,6 +420,7 @@ impl DataSources {
             events_receiver,
             server_connected,
             running,
+            version_check_thread: Some(version_check_thread),
             requests_thread: Some(requests_thread),
             events_thread: Some(events_thread),
             ping_thread: Some(ping_thread),
@@ -370,6 +444,7 @@ impl Drop for DataSources {
     fn drop(&mut self) {
         self.running.set(false);
 
+        self.version_check_thread.take().unwrap().join().ok();
         self.requests_thread.take().unwrap().join().ok();
         self.events_thread.take().unwrap().join().ok();
         self.ping_thread.take().unwrap().join().ok();

--- a/alvr/events/src/lib.rs
+++ b/alvr/events/src/lib.rs
@@ -96,6 +96,7 @@ pub enum EventType {
     DriversList(Vec<PathBuf>),
     ServerRequestsSelfRestart,
     Adb(AdbEvent),
+    NewVersionFound { version: String, message: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -124,6 +125,7 @@ impl Event {
             EventType::DriversList(_) => "DRV LIST".to_string(),
             EventType::ServerRequestsSelfRestart => "RESTART".to_string(),
             EventType::Adb(_) => "ADB".to_string(),
+            EventType::NewVersionFound { .. } => "NEW VER".to_string(),
         }
     }
 
@@ -140,6 +142,7 @@ impl Event {
             EventType::DriversList(drivers) => serde_json::to_string(drivers).unwrap(),
             EventType::ServerRequestsSelfRestart => "Request for server restart".into(),
             EventType::Adb(adb) => serde_json::to_string(adb).unwrap(),
+            EventType::NewVersionFound { version, .. } => version.clone(),
         }
     }
 }

--- a/alvr/gui_common/src/basic_components/modal.rs
+++ b/alvr/gui_common/src/basic_components/modal.rs
@@ -25,32 +25,38 @@ pub fn modal(
     title: &str,
     content: Option<impl FnOnce(&mut Ui)>,
     buttons: &[ModalButton],
+    width: Option<f32>,
 ) -> Option<ModalButton> {
     let mut response = None;
 
-    Window::new(title)
+    let mut window = Window::new(title)
         .anchor(Align2::CENTER_CENTER, (0.0, 0.0))
         .collapsible(false)
-        .resizable(false)
-        .show(context, |ui| {
-            ui.vertical_centered_justified(|ui| {
-                if let Some(content) = content {
-                    ui.add_space(10.0);
-                    content(ui);
-                    ui.add_space(10.0);
-                }
+        .resizable(false);
 
-                ui.columns(buttons.len(), |cols| {
-                    for (idx, response_type) in buttons.iter().enumerate() {
-                        cols[idx].with_layout(Layout::top_down_justified(Align::Center), |ui| {
-                            if ui.button(response_type.to_string()).clicked() {
-                                response = Some(response_type.clone());
-                            }
-                        });
-                    }
-                });
+    if let Some(w) = width {
+        window = window.min_width(w);
+    }
+
+    window.show(context, |ui| {
+        ui.vertical_centered_justified(|ui| {
+            if let Some(content) = content {
+                ui.add_space(10.0);
+                content(ui);
+                ui.add_space(10.0);
+            }
+
+            ui.columns(buttons.len(), |cols| {
+                for (idx, response_type) in buttons.iter().enumerate() {
+                    cols[idx].with_layout(Layout::top_down_justified(Align::Center), |ui| {
+                        if ui.button(response_type.to_string()).clicked() {
+                            response = Some(response_type.clone());
+                        }
+                    });
+                }
             });
         });
+    });
 
     response
 }

--- a/alvr/launcher/src/ui.rs
+++ b/alvr/launcher/src/ui.rs
@@ -146,6 +146,7 @@ impl Launcher {
                 })
             },
             &[ModalButton::Cancel, ModalButton::Custom("Install".into())],
+            None,
         );
 
         match response {
@@ -191,6 +192,7 @@ impl Launcher {
                 });
             }),
             &[ModalButton::Close],
+            None,
         );
 
         if delete_version {
@@ -218,6 +220,7 @@ impl Launcher {
                 ModalButton::Cancel,
                 ModalButton::Custom("Delete version".into()),
             ],
+            None,
         );
 
         match response {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1548,6 +1548,13 @@ pub struct Patches {
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
+pub enum NewVersionPopupConfig {
+    Show,
+    HideWhileVersion(String),
+    AlwaysHide,
+}
+
+#[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 pub struct ExtraConfig {
     pub steamvr_launcher: SteamvrLauncher,
     pub capture: CaptureConfig,
@@ -1562,6 +1569,7 @@ It does not update in real time.")
     pub velocities_multiplier: f32,
 
     pub open_setup_wizard: bool,
+    pub new_version_popup: NewVersionPopupConfig,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -2190,6 +2198,14 @@ pub fn session_settings_default() -> SettingsDefault {
             },
             velocities_multiplier: 1.0,
             open_setup_wizard: alvr_common::is_stable() || alvr_common::is_nightly(),
+            new_version_popup: NewVersionPopupConfigDefault {
+                variant: if alvr_common::is_stable() {
+                    NewVersionPopupConfigDefaultVariant::Show
+                } else {
+                    NewVersionPopupConfigDefaultVariant::AlwaysHide
+                },
+                HideWhileVersion: "0.0.0".into(),
+            },
         },
     }
 }


### PR DESCRIPTION
Add new setting to show popup, always hide it or hide it while a specific version is latest.
The popup does expand vertically and horizontally to accomodate the changelog message.

<img width="607" alt="Screenshot 2025-06-15 at 11 13 58 pm" src="https://github.com/user-attachments/assets/ae702d18-addc-4ef6-8a9a-183418b69878" />
