### PR TITLE
make it possible to change refresh rate without steamvr restart

### DIFF
--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -801,8 +801,8 @@ pub unsafe extern "C" fn alvr_start_stream_opengl(config: AlvrStreamConfig) {
         edge_threshold: config.upscaling_edge_threshold,
         upscale_factor: config.upscale_factor,
     });
-
     STREAM_RENDERER.set(Some(StreamRenderer::new(
+        
         GRAPHICS_CONTEXT.with_borrow(|c| c.as_ref().unwrap().clone()),
         view_resolution,
         compute_target_view_resolution(view_resolution, &upscaling),

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -802,7 +802,6 @@ pub unsafe extern "C" fn alvr_start_stream_opengl(config: AlvrStreamConfig) {
         upscale_factor: config.upscale_factor,
     });
     STREAM_RENDERER.set(Some(StreamRenderer::new(
-        
         GRAPHICS_CONTEXT.with_borrow(|c| c.as_ref().unwrap().clone()),
         view_resolution,
         compute_target_view_resolution(view_resolution, &upscaling),

--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -42,7 +42,7 @@ keystore_password = "alvrclient"
 
 [package.metadata.android.sdk]
 min_sdk_version = 26
-target_sdk_version = 29
+target_sdk_version = 32
 
 [[package.metadata.android.uses_feature]]
 name = "android.hardware.microphone"

--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -42,7 +42,7 @@ keystore_password = "alvrclient"
 
 [package.metadata.android.sdk]
 min_sdk_version = 26
-target_sdk_version = 32
+target_sdk_version = 29
 
 [[package.metadata.android.uses_feature]]
 name = "android.hardware.microphone"

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -448,6 +448,10 @@ pub fn entry_point() {
                         } else if config.passthrough.is_none() && passthrough_layer.is_some() {
                             passthrough_layer = None;
                         }
+                        let xr_exts = xr_session.instance().exts();
+                        if xr_exts.fb_display_refresh_rate.is_some() {
+                            xr_session.request_display_refresh_rate(config.client_fps).unwrap();
+                        }
 
                         if let Some(stream) = &mut stream_context {
                             stream.update_real_time_config(&config);

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -450,7 +450,9 @@ pub fn entry_point() {
                         }
                         let xr_exts = xr_session.instance().exts();
                         if xr_exts.fb_display_refresh_rate.is_some() {
-                            xr_session.request_display_refresh_rate(config.client_fps).unwrap();
+                            xr_session
+                                .request_display_refresh_rate(config.client_fps)
+                                .unwrap();
                         }
 
                         if let Some(stream) = &mut stream_context {

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -122,7 +122,7 @@ impl StreamContext {
 
         if xr_exts.fb_display_refresh_rate.is_some() {
             let refresh_rate={
-                if config.client_refresh_rate>=config.refresh_rate_hint{ //todo:try to actually fix jittering when client refresh rate is lower then server's
+                if config.client_refresh_rate>=config.refresh_rate_hint{ //todo:try to fix jittering when client refresh rate is lower then server's
                     config.client_refresh_rate
                 }else{
                     config.refresh_rate_hint
@@ -339,6 +339,7 @@ impl StreamContext {
     pub fn update_real_time_config(&mut self, config: &RealTimeConfig) {
         self.config.passthrough = config.passthrough.clone();
         self.config.clientside_post_processing = config.clientside_post_processing.clone();
+        self.config.refresh_rate_hint=config.server_fps;
     }
 
     pub fn render(

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -36,6 +36,7 @@ const DECODER_MAX_TIMEOUT_MULTIPLIER: f32 = 0.8;
 pub struct ParsedStreamConfig {
     pub view_resolution: UVec2,
     pub refresh_rate_hint: f32,
+    pub client_refresh_rate: f32,
     pub use_full_range: bool,
     pub encoding_gamma: f32,
     pub enable_hdr: bool,
@@ -83,6 +84,7 @@ impl ParsedStreamConfig {
             buffering_history_weight: config.settings.video.buffering_history_weight,
             decoder_options: config.settings.video.mediacodec_extra_options.clone(),
             interaction_sources: InteractionSourcesConfig::new(config),
+            client_refresh_rate: config.negotiated_config.client_refresh_rate,
         }
     }
 }
@@ -119,8 +121,15 @@ impl StreamContext {
         let xr_exts = xr_session.instance().exts();
 
         if xr_exts.fb_display_refresh_rate.is_some() {
+            let refresh_rate={
+                if config.client_refresh_rate>=config.refresh_rate_hint{ //todo:try to actually fix jittering when client refresh rate is lower then server's
+                    config.client_refresh_rate
+                }else{
+                    config.refresh_rate_hint
+                }
+            };
             xr_session
-                .request_display_refresh_rate(config.refresh_rate_hint)
+                .request_display_refresh_rate(refresh_rate)
                 .unwrap();
         }
 

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -121,10 +121,11 @@ impl StreamContext {
         let xr_exts = xr_session.instance().exts();
 
         if xr_exts.fb_display_refresh_rate.is_some() {
-            let refresh_rate={
-                if config.client_refresh_rate>=config.refresh_rate_hint{ //todo:try to fix jittering when client refresh rate is lower then server's
+            let refresh_rate = {
+                if config.client_refresh_rate >= config.refresh_rate_hint {
+                    //todo:try to fix jittering when client refresh rate is lower then server's
                     config.client_refresh_rate
-                }else{
+                } else {
                     config.refresh_rate_hint
                 }
             };
@@ -339,7 +340,7 @@ impl StreamContext {
     pub fn update_real_time_config(&mut self, config: &RealTimeConfig) {
         self.config.passthrough = config.passthrough.clone();
         self.config.clientside_post_processing = config.clientside_post_processing.clone();
-        self.config.refresh_rate_hint=config.server_fps;
+        self.config.refresh_rate_hint = config.server_fps;
     }
 
     pub fn render(

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -126,6 +126,7 @@ pub enum ClientConnectionResult {
 pub struct NegotiatedStreamingConfig {
     pub view_resolution: UVec2,
     pub refresh_rate_hint: f32,
+    pub client_refresh_rate: f32,
     pub game_audio_sample_rate: u32,
     pub enable_foveated_encoding: bool,
     // This is needed to detect when to use SteamVR hand trackers. This does NOT imply if multimodal
@@ -181,6 +182,7 @@ pub fn decode_stream_config(packet: &StreamConfigPacket) -> Result<StreamConfig>
     let encoding_gamma = json::from_value(negotiated_json["encoding_gamma"].clone()).unwrap_or(1.0);
     let enable_hdr = json::from_value(negotiated_json["enable_hdr"].clone()).unwrap_or(false);
     let wired = json::from_value(negotiated_json["wired"].clone()).unwrap_or(false);
+    let client_refresh_rate = json::from_value(negotiated_json["client_refresh_rate"].clone()).unwrap_or(refresh_rate_hint);
 
     Ok(StreamConfig {
         server_version: session_config.server_version,
@@ -195,6 +197,7 @@ pub fn decode_stream_config(packet: &StreamConfigPacket) -> Result<StreamConfig>
             encoding_gamma,
             enable_hdr,
             wired,
+            client_refresh_rate:client_refresh_rate,
         },
     })
 }
@@ -414,6 +417,7 @@ pub enum ServerRequest {
 pub struct RealTimeConfig {
     pub passthrough: Option<PassthroughMode>,
     pub clientside_post_processing: Option<ClientsidePostProcessingConfig>,
+    pub client_fps: f32,
 }
 
 impl RealTimeConfig {
@@ -427,7 +431,19 @@ impl RealTimeConfig {
         Ok(bincode::deserialize(buffer)?)
     }
 
-    pub fn from_settings(settings: &Settings) -> Self {
+    pub fn from_settings(settings: &Settings,streaming_caps:&VideoStreamingCapabilities) -> Self {
+        fn round_fps(streaming_caps:&VideoStreamingCapabilities,preffered:f32)->f32{ 
+            let mut best_match = 0_f32;
+            let mut min_diff = f32::MAX;
+            for rate in &streaming_caps.supported_refresh_rates {
+                let diff = (*rate - (  preffered)).abs();
+                if diff < min_diff {
+                    best_match = *rate;
+                    min_diff = diff;
+                }
+            }
+            best_match
+        }
         Self {
             passthrough: settings.video.passthrough.clone().into_option(),
             clientside_post_processing: settings
@@ -435,6 +451,14 @@ impl RealTimeConfig {
                 .clientside_post_processing
                 .clone()
                 .into_option(),
+                client_fps:round_fps(streaming_caps, match settings.video.use_server_refresh_rate {
+                    true => settings.video.preferred_fps,
+                    false => if settings.video.preferred_client_fps>=settings.video.preferred_fps{ //todo:try to actually fix jittering when client refresh rate is lower then server's
+                        settings.video.preferred_client_fps
+                    }else{
+                        settings.video.preferred_fps
+                    },
+                })
         }
     }
 }

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -198,7 +198,7 @@ pub fn decode_stream_config(packet: &StreamConfigPacket) -> Result<StreamConfig>
             encoding_gamma,
             enable_hdr,
             wired,
-            client_refresh_rate: client_refresh_rate,
+            client_refresh_rate,
         },
     })
 }

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -418,6 +418,7 @@ pub struct RealTimeConfig {
     pub passthrough: Option<PassthroughMode>,
     pub clientside_post_processing: Option<ClientsidePostProcessingConfig>,
     pub client_fps: f32,
+    pub server_fps: f32,
 }
 
 impl RealTimeConfig {
@@ -458,7 +459,8 @@ impl RealTimeConfig {
                     }else{
                         settings.video.preferred_fps
                     },
-                })
+                }),
+            server_fps: round_fps(streaming_caps, settings.video.preferred_fps),
         }
     }
 }

--- a/alvr/server_core/src/bitrate.rs
+++ b/alvr/server_core/src/bitrate.rs
@@ -13,6 +13,7 @@ const UPDATE_INTERVAL: Duration = Duration::from_secs(1);
 pub struct DynamicEncoderParams {
     pub bitrate_bps: f32,
     pub framerate: f32,
+    pub target_framerate: f32,
 }
 
 pub struct BitrateManager {
@@ -58,7 +59,10 @@ impl BitrateManager {
             update_needed: true,
         }
     }
-
+    pub fn update_framerate(&mut self, framerate: f32) {
+        self.nominal_frame_interval = Duration::from_secs_f32(1. / framerate);
+        self.update_needed = true;
+    }
     // Note: This is used to calculate the framerate/frame interval. The frame present is the most
     // accurate event for this use.
     pub fn report_frame_present(&mut self, config: &Switch<BitrateAdaptiveFramerateConfig>) {
@@ -245,6 +249,7 @@ impl BitrateManager {
             DynamicEncoderParams {
                 bitrate_bps,
                 framerate: 1.0 / f32::min(frame_interval.as_secs_f32(), 1.0),
+                target_framerate: 1. / self.nominal_frame_interval.as_secs_f32(),
             },
             bitrate_directives,
         ))

--- a/alvr/server_core/src/c_api.rs
+++ b/alvr/server_core/src/c_api.rs
@@ -145,6 +145,7 @@ pub struct AlvrDeviceConfig {
 pub struct AlvrDynamicEncoderParams {
     bitrate_bps: f32,
     framerate: f32,
+    target_framerate: f32,
 }
 
 fn pose_to_capi(pose: &Pose) -> AlvrPose {
@@ -506,6 +507,7 @@ pub unsafe extern "C" fn alvr_get_dynamic_encoder_params(
         if let Some(params) = context.get_dynamic_encoder_params() {
             (*out_params).bitrate_bps = params.bitrate_bps;
             (*out_params).framerate = params.framerate;
+            (*out_params).target_framerate = params.target_framerate;
 
             true
         } else {

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -1107,6 +1107,7 @@ fn connection_pipeline(
                             .as_mut()
                             .unwrap()
                             .new_server_refresh_rate(settings_fps);
+                        ctx.bitrate_manager.lock().update_framerate(settings_fps);
                     }
                     RealTimeConfig::from_settings(settings, &streaming_caps) //todo: prob don't store 60..120 range using a float and don't allow settings inncorect values
                 };

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -19,10 +19,14 @@ use alvr_common::{
 };
 use alvr_events::{AdbEvent, ButtonEvent, EventType};
 use alvr_packets::{
-    ClientConnectionResult, ClientControlPacket, ClientListAction, ClientStatistics, NegotiatedStreamingConfig, RealTimeConfig, ReservedClientControlPacket, ServerControlPacket, Tracking, VideoPacketHeader, VideoStreamingCapabilities, AUDIO, HAPTICS, STATISTICS, TRACKING, VIDEO
+    ClientConnectionResult, ClientControlPacket, ClientListAction, ClientStatistics,
+    NegotiatedStreamingConfig, RealTimeConfig, ReservedClientControlPacket, ServerControlPacket,
+    Tracking, VideoPacketHeader, VideoStreamingCapabilities, AUDIO, HAPTICS, STATISTICS, TRACKING,
+    VIDEO,
 };
 use alvr_session::{
-    BodyTrackingBDConfig, BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize, H264Profile, OpenvrConfig, SessionConfig, SocketProtocol
+    BodyTrackingBDConfig, BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize,
+    H264Profile, OpenvrConfig, SessionConfig, SocketProtocol,
 };
 use alvr_sockets::{
     PeerType, ProtoControlSocket, StreamSocketBuilder, CONTROL_PORT, KEEPALIVE_INTERVAL,
@@ -612,11 +616,11 @@ fn connection_pipeline(
             .clone(),
         streaming_caps.default_view_resolution,
     );
-    fn round_fps(streaming_caps:&VideoStreamingCapabilities,preffered:f32)->f32{
+    fn round_fps(streaming_caps: &VideoStreamingCapabilities, preffered: f32) -> f32 {
         let mut best_match = 0_f32;
         let mut min_diff = f32::MAX;
         for rate in &streaming_caps.supported_refresh_rates {
-            let diff = (*rate - (  preffered)).abs();
+            let diff = (*rate - (preffered)).abs();
             if diff < min_diff {
                 best_match = *rate;
                 min_diff = diff;
@@ -624,19 +628,13 @@ fn connection_pipeline(
         }
         best_match
     }
-    // let server_fps =get_fps(&streaming_caps, initial_settings.video.preferred_fps);
-    let server_fps =initial_settings.video.preferred_fps;
-    let client_fps=match initial_settings.video.use_server_refresh_rate{
-        true => server_fps,
-        false => round_fps(&streaming_caps, initial_settings.video.preferred_client_fps),
-    };
+    let server_fps = round_fps(&streaming_caps, initial_settings.video.preferred_fps);
+    let client_fps = round_fps(&streaming_caps, initial_settings.video.preferred_client_fps);
 
-    if initial_settings.video.preferred_fps!=server_fps
-    {
+    if initial_settings.video.preferred_fps != server_fps {
         warn!("Chosen server refresh rate not supported. Using {server_fps}Hz");
     }
-    if initial_settings.video.preferred_client_fps!=client_fps
-    {
+    if initial_settings.video.preferred_client_fps != client_fps {
         warn!("Chosen server refresh rate not supported. Using {client_fps}Hz");
     }
 
@@ -1096,16 +1094,25 @@ fn connection_pipeline(
                 let config = {
                     let session_manager_lock = SESSION_MANAGER.read();
                     let settings = session_manager_lock.settings();
-                    let server_fps=ctx.statistics_manager.read().as_ref().unwrap().get_refresh_rate();
-                    let settings_fps=round_fps(&streaming_caps, settings.video.preferred_fps);
-                    if server_fps!=settings_fps{
-                        ctx.statistics_manager.write().as_mut().unwrap().new_server_refresh_rate(settings_fps);   
+                    let server_fps = ctx
+                        .statistics_manager
+                        .read()
+                        .as_ref()
+                        .unwrap()
+                        .get_refresh_rate();
+                    let settings_fps = round_fps(&streaming_caps, settings.video.preferred_fps);
+                    if server_fps != settings_fps {
+                        ctx.statistics_manager
+                            .write()
+                            .as_mut()
+                            .unwrap()
+                            .new_server_refresh_rate(settings_fps);
                     }
-                    RealTimeConfig::from_settings(settings,&streaming_caps) //todo: prob don't store 60..120 range using a float and don't allow settings inncorect values
+                    RealTimeConfig::from_settings(settings, &streaming_caps) //todo: prob don't store 60..120 range using a float and don't allow settings inncorect values
                 };
-                    if let Ok(config) = config.encode(){
-                            control_sender.lock().send(&config).ok();
-                    }
+                if let Ok(config) = config.encode() {
+                    control_sender.lock().send(&config).ok();
+                }
                 thread::sleep(REAL_TIME_UPDATE_INTERVAL);
             }
         }

--- a/alvr/server_core/src/statistics.rs
+++ b/alvr/server_core/src/statistics.rs
@@ -92,11 +92,11 @@ impl StatisticsManager {
             last_throughput_directives: BitrateDirectives::default(),
         }
     }
-    pub fn new_server_refresh_rate(&mut self,refresh_rate:f32){
-        self.frame_interval=Duration::from_secs_f32(1.0/refresh_rate);
+    pub fn new_server_refresh_rate(&mut self, refresh_rate: f32) {
+        self.frame_interval = Duration::from_secs_f32(1.0 / refresh_rate);
     }
-    pub fn get_refresh_rate(&self)->f32{
-        1.0/self.frame_interval.as_secs_f32()
+    pub fn get_refresh_rate(&self) -> f32 {
+        1.0 / self.frame_interval.as_secs_f32()
     }
     pub fn report_tracking_received(&mut self, target_timestamp: Duration) {
         if !self

--- a/alvr/server_core/src/statistics.rs
+++ b/alvr/server_core/src/statistics.rs
@@ -92,7 +92,12 @@ impl StatisticsManager {
             last_throughput_directives: BitrateDirectives::default(),
         }
     }
-
+    pub fn new_server_refresh_rate(&mut self,refresh_rate:f32){
+        self.frame_interval=Duration::from_secs_f32(1.0/refresh_rate);
+    }
+    pub fn get_refresh_rate(&self)->f32{
+        1.0/self.frame_interval.as_secs_f32()
+    }
     pub fn report_tracking_received(&mut self, target_timestamp: Duration) {
         if !self
             .history_buffer

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -82,6 +82,7 @@ struct FfiDynamicEncoderParams {
     unsigned int updated;
     unsigned long long bitrate_bps;
     float framerate;
+    float target_framerate;
 };
 
 extern "C" const unsigned char* FRAME_RENDER_VS_CSO_PTR;

--- a/alvr/server_openvr/cpp/platform/win32/VideoEncoderAMF.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/VideoEncoderAMF.cpp
@@ -731,14 +731,17 @@ void VideoEncoderAMF::Transmit(
 
     auto params = GetDynamicEncoderParams();
     if (params.updated) {
+        m_refreshRate=params.target_framerate;
         amf_int64 bitRateIn = params.bitrate_bps / params.framerate * m_refreshRate; // in bits
         if (m_codec == ALVR_CODEC_H264) {
+            m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_FRAMERATE, m_refreshRate);
             m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE, bitRateIn);
             m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE, bitRateIn);
             m_amfComponents.back()->SetProperty(
                 AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, bitRateIn / m_refreshRate * 1.1
             );
         } else {
+            m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMERATE, m_refreshRate);
             m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, bitRateIn);
             m_amfComponents.back()->SetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, bitRateIn);
             m_amfComponents.back()->SetProperty(

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -348,6 +348,7 @@ extern "C" fn get_dynamic_encoder_params() -> FfiDynamicEncoderParams {
                 updated: 1,
                 bitrate_bps: params.bitrate_bps as u64,
                 framerate: params.framerate,
+                target_framerate: params.target_framerate,
             }
         } else {
             FfiDynamicEncoderParams::default()

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -790,7 +790,7 @@ If you want to reduce the amount of pixelation on the edges, increase the center
 
     #[schema(strings(display_name = "Preferred Server FPS"))]
     #[schema(gui(slider(min = 60.0, max = 120.0)), suffix = "Hz")]
-    #[schema(flag = "steamvr-restart")]
+    #[schema(flag = "real-time")]
     pub preferred_fps: f32,
     #[schema(strings(display_name = "Use server's refresh rate"))]
     #[schema(flag = "steamvr-restart")]

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -788,10 +788,20 @@ If you want to reduce the amount of pixelation on the edges, increase the center
     #[schema(flag = "steamvr-restart")]
     pub emulated_headset_view_resolution: FrameSize,
 
-    #[schema(strings(display_name = "Preferred FPS"))]
+    #[schema(strings(display_name = "Preferred Server FPS"))]
     #[schema(gui(slider(min = 60.0, max = 120.0)), suffix = "Hz")]
     #[schema(flag = "steamvr-restart")]
     pub preferred_fps: f32,
+    #[schema(strings(display_name = "Use server's refresh rate"))]
+    #[schema(flag = "steamvr-restart")]
+    pub use_server_refresh_rate: bool,
+    #[schema(strings(
+        display_name = "Preferred Client FPS",
+        help="if the value is lower then Preferred Server FPS it will be used instead"
+    ))]
+    #[schema(gui(slider(min = 60.0, max = 120.0)), suffix = "Hz")]
+    #[schema(flag = "real-time")]
+    pub preferred_client_fps: f32,
 
     #[cfg_attr(not(target_os = "windows"), schema(flag = "hidden"))]
     #[schema(strings(
@@ -1662,6 +1672,8 @@ pub fn session_settings_default() -> SettingsDefault {
             transcoding_view_resolution: view_resolution.clone(),
             emulated_headset_view_resolution: view_resolution,
             preferred_fps: 72.,
+            use_server_refresh_rate:true,
+            preferred_client_fps: 72.,
             max_buffering_frames: 2.0,
             buffering_history_weight: 0.90,
             enforce_server_frame_pacing: true,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -792,9 +792,6 @@ If you want to reduce the amount of pixelation on the edges, increase the center
     #[schema(gui(slider(min = 60.0, max = 120.0)), suffix = "Hz")]
     #[schema(flag = "real-time")]
     pub preferred_fps: f32,
-    #[schema(strings(display_name = "Use server's refresh rate"))]
-    #[schema(flag = "steamvr-restart")]
-    pub use_server_refresh_rate: bool,
     #[schema(strings(
         display_name = "Preferred Client FPS",
         help="if the value is lower then Preferred Server FPS it will be used instead"
@@ -1672,7 +1669,6 @@ pub fn session_settings_default() -> SettingsDefault {
             transcoding_view_resolution: view_resolution.clone(),
             emulated_headset_view_resolution: view_resolution,
             preferred_fps: 72.,
-            use_server_refresh_rate:true,
             preferred_client_fps: 72.,
             max_buffering_frames: 2.0,
             buffering_history_weight: 0.90,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -794,7 +794,7 @@ If you want to reduce the amount of pixelation on the edges, increase the center
     pub preferred_fps: f32,
     #[schema(strings(
         display_name = "Preferred Client FPS",
-        help="if the value is lower then Preferred Server FPS it will be used instead"
+        help = "if the value is lower then Preferred Server FPS it will be used instead"
     ))]
     #[schema(gui(slider(min = 60.0, max = 120.0)), suffix = "Hz")]
     #[schema(flag = "real-time")]


### PR DESCRIPTION
make it possible to independently* set headset and pc fps and change them without restarting steamvr
it pretty much breaks buffering depending on the settings
*well unless headset is set to lower then pc's then it defaults to pc's

i had issues getting android build to work without changing sdk-target from 32 to 29 so changes to that can be ignored
