### PR TITLE
don't lock anything in wait_for_vsync

### DIFF
--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -501,6 +501,16 @@ impl ServerCoreContext {
 
         self.connection_context
             .statistics_manager
+            .try_write()?
+            .as_mut()
+            .map(|stats| stats.duration_until_next_vsync())
+    }
+    //used in wait_for_vsync to check if if StatsManager is up otherwise non blocking is called
+    pub fn duration_until_next_vsync_blocking(&self) -> Option<Duration> {
+        dbg_server_core!("duration_until_next_vsync_blocking");
+
+        self.connection_context
+            .statistics_manager
             .write()
             .as_mut()
             .map(|stats| stats.duration_until_next_vsync())


### PR DESCRIPTION
i don't really think  it's worth merging but since i already wrote it
pros: 
* seems to work (hard to tell just from the graph)
* latency graph is marginally smother 

cons:
* only tested in one scenario (vrchat looking at the skybox)
* it prob breaks something

orginal:
![orginal](https://github.com/user-attachments/assets/54a8d3e2-83a3-45ab-b62e-f5ab61f9b551)
changed:
![after-change](https://github.com/user-attachments/assets/92e577de-630c-4ad3-b575-82ba165857ab)


