### PR TITLE
refactor(client_core): :recycle: Replace Oboe with Aaudio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,6 @@ dependencies = [
  "mdns-sd",
  "ndk 0.9.0",
  "ndk-context",
- "oboe",
  "rand 0.9.0",
  "serde",
  "serde_json",

--- a/alvr/client_core/Cargo.toml
+++ b/alvr/client_core/Cargo.toml
@@ -30,9 +30,8 @@ serde_json = "1"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.14"
-ndk = { version = "0.9", features = ["api-level-26", "media"] }
+ndk = { version = "0.9", features = ["api-level-26", "audio", "media"] }
 ndk-context = "0.1"
-oboe = "0.6"                                                    # todo: remove once AudioThread shutdown crash is fixed
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 env_logger = "0.11"


### PR DESCRIPTION
This PR does not improve much on ALVR side, but in a private fork that uses Android Studio this avoid fiddling with libc++_shared.so, and recently all workarounds broke. Oboe was the last C++ dependency in the ALVR client; now it's replaced with the underlying Android API AAudio, which requires Android API level 26 which was already our minimum supported API level.

This PR supersedes #2215, and input/output audio still works when switching devices at runtime. There is no plan on fully moving the client to CPAL as that library is badly maintained and we need access to lower level apis to maybe support better audio device control in the future.