### PR TITLE
fix: :bug: Make VAC default; soft-fix microphone issues

### DIFF
--- a/alvr/audio/src/lib.rs
+++ b/alvr/audio/src/lib.rs
@@ -137,6 +137,9 @@ impl AudioDevice {
 
                 pair?
             }
+            MicrophoneDevicesConfig::VAC => {
+                microphone_pair_from_sink_name(&host, "Virtual Cable 1")?
+            }
             MicrophoneDevicesConfig::VBCable => {
                 microphone_pair_from_sink_name(&host, "CABLE Input")?
             }
@@ -148,9 +151,6 @@ impl AudioDevice {
             }
             MicrophoneDevicesConfig::VoiceMeeterVaio3 => {
                 microphone_pair_from_sink_name(&host, "VoiceMeeter VAIO3 Input")?
-            }
-            MicrophoneDevicesConfig::VAC => {
-                microphone_pair_from_sink_name(&host, "Virtual Cable 1")?
             }
             MicrophoneDevicesConfig::Custom { sink, source } => (
                 device_from_custom_config(&host, &sink)?,

--- a/alvr/dashboard/src/dashboard/components/logs.rs
+++ b/alvr/dashboard/src/dashboard/components/logs.rs
@@ -90,13 +90,10 @@ impl LogsTab {
             }
             if ui.button("Open logs directory").clicked() {
                 let log_dir = crate::get_filesystem_layout().log_dir;
-                ui.output_mut(|out| {
-                    out.commands
-                        .push(OutputCommand::OpenUrl(OpenUrl::same_tab(format!(
-                            "file://{}",
-                            log_dir.to_string_lossy()
-                        ))));
-                });
+                ui.ctx().open_url(OpenUrl::same_tab(format!(
+                    "file://{}",
+                    log_dir.to_string_lossy()
+                )));
             }
         });
 

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
@@ -364,11 +364,11 @@ pub fn microphone_schema() -> PresetSchemaNode {
     if cfg!(windows) {
         for (key, display_name) in [
             ("Automatic", "Automatic"),
+            ("VAC", "Virtual Audio Cable"),
             ("VBCable", "VB Cable"),
             ("VoiceMeeter", "VoiceMeeter"),
             ("VoiceMeeterAux", "VoiceMeeter Aux"),
             ("VoiceMeeterVaio3", "VoiceMeeter VAIO3"),
-            ("VAC", "Virtual Audio Cable"),
         ] {
             microhone_options.push(HigherOrderChoiceOption {
                 display_name: display_name.into(),

--- a/alvr/dashboard/src/dashboard/components/setup_wizard.rs
+++ b/alvr/dashboard/src/dashboard/components/setup_wizard.rs
@@ -113,7 +113,7 @@ Make sure you have at least one output audio device.",
                 ui,
                 "Software requirements",
                 if cfg!(windows) {
-                    r"To stream the headset microphone on Windows you need to install VB-Cable, Voicemeeter, or Virtual Audio Cable."
+                    r"To stream the headset microphone on Windows you need to install Virtual Audio Cable, VB-Cable, Voicemeeter"
                 } else if cfg!(target_os = "linux") {
                     r"You need the PipeWire (0.3.49+ version) audio system to be able to stream audio and use microphone."
                 } else {
@@ -122,9 +122,9 @@ Make sure you have at least one output audio device.",
                 #[allow(unused_variables)]
                 |ui| {
                     #[cfg(windows)]
-                    if ui.button("Download VB-Cable").clicked() {
-                        ui.ctx().open_url(crate::dashboard::egui::OpenUrl::same_tab(
-                            "https://vb-audio.com/Cable/",
+                    if ui.button("Download Virtual Audio Cable (Lite)").clicked() {
+                        ui.ctx().open_url(eframe::egui::OpenUrl::same_tab(
+                            "https://software.muzychenko.net/freeware/vac470lite.zip",
                         ));
                     }
                 },

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -743,7 +743,8 @@ fn connection_pipeline(
                 .to_con()?;
                 if matches!(
                     microphone_config.devices,
-                    alvr_session::MicrophoneDevicesConfig::VBCable
+                    alvr_session::MicrophoneDevicesConfig::VAC
+                        | alvr_session::MicrophoneDevicesConfig::VBCable
                 ) {
                     // VoiceMeeter and Custom devices may have arbitrary internal routing.
                     // Therefore, we cannot detect the loopback issue without knowing the routing.

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -850,6 +850,8 @@ pub struct GameAudioConfig {
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 pub enum MicrophoneDevicesConfig {
     Automatic,
+    #[schema(strings(display_name = "Virtual Audio Cable"))]
+    VAC,
     #[schema(strings(display_name = "VB Cable"))]
     VBCable,
     #[schema(strings(display_name = "VoiceMeeter"))]
@@ -858,8 +860,6 @@ pub enum MicrophoneDevicesConfig {
     VoiceMeeterAux,
     #[schema(strings(display_name = "VoiceMeeter VAIO3"))]
     VoiceMeeterVaio3,
-    #[schema(strings(display_name = "Virtual Audio Cable"))]
-    VAC,
     Custom {
         #[schema(strings(help = "This device is used by ALVR to output microphone audio"))]
         sink: CustomAudioDeviceConfig,

--- a/wiki/Installation-guide.md
+++ b/wiki/Installation-guide.md
@@ -24,20 +24,15 @@ For any problem visit the [Troubleshooting page](https://github.com/alvr-org/ALV
 
 To use your microphone in ALVR on Windows you need to install **VB-Audio Cable** (or equivalent software). However if VB-Audio Cable is already installed but not working with ALVR **or if you encounter any issues**, it's worth following these steps to reinstall and configure it properly.
 
-### **1. Install or Reinstall VB-Audio Cable**
-1. **Download** the latest version of [VB-Audio Cable](https://download.vb-audio.com/Download_CABLE/VBCABLE_Driver_Pack45.zip).
+### **1. Install or Reinstall Virtual Audio Cable**
+1. **Download** the latest Lite version of [Virtual Audio Cable](https://software.muzychenko.net/freeware/vac470lite.zip).
 2. **Extract** the ZIP archive.
-3. Open the extracted folder and run **"VBCABLE_Setup_x64.exe"** as administrator.
-
-- **If you already have VB-Audio Cable installed and ALVR doesn’t detect it**:
-   - Click **"Remove Driver"** then restart your PC when prompted.
-
-4. Click **"Install Driver"** then restart your PC when prompted.
+3. Open the extracted folder and run **"setup64.exe"** as administrator.
 
 ### **2. Configure Windows Sound Settings**
 1. **Open** Windows Sound Settings (`Win + I` → "Sound").
 2. **Under Output Devices**:
-   - **Do not set any "VB-Audio Virtual Cable" as the default output**, or you’ll hear yourself. Select your headphone or whatever you're using.
+   - **Do not set any "Virtual Audio Cable" as the default output**, or you’ll hear yourself. Select your headphone or whatever you're using.
 
 ### **3. Configure ALVR**
 1. **Open ALVR** and go to **Settings**.


### PR DESCRIPTION
Not long ago I thought of completely replacing the microphone support on Windows with just Virtual Audio Cable, as it seems to be actually working, while VB Cable doesn't sometimes (it doesn't work when just installed, it requires a system restart, but better go with the more robust solution).

In this PR I keep VB Cable and VoiceMeeter as second options still. If after user testing VAC results stable and reliable, should I go ahead and make it the only preset option? (I would still allow for custom audio devices by substring)