### PR TITLE
fix: Add/restore missing fake Vive trackers

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/FakeViveTracker.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/FakeViveTracker.cpp
@@ -124,6 +124,10 @@ bool FakeViveTracker::activate() {
         name = "ALVR/tracker/left_knee";
     } else if (this->device_id == BODY_RIGHT_KNEE_ID) {
         name = "ALVR/tracker/right_knee";
+    } else if (this->device_id == BODY_LEFT_ELBOW_ID) {
+        name = "ALVR/tracker/left_elbow";
+    } else if (this->device_id == BODY_RIGHT_ELBOW_ID) {
+        name = "ALVR/tracker/right_elbow";
     } else {
         name = "ALVR/tracker/unknown";
     }


### PR DESCRIPTION
fixes #2869.

apparently, during one of refactors, those 4 lines for `/device/ALVR/tracker/left_elbow` and `/device/ALVR/tracker/right_elbow` were missed and flew under radar unnoticed since pico FBT support was ever introduced. this PR adds those missing lines, bringing back fake trackers for elbows.