### PR TITLE
feat: Add PSVR2 Sense controller emulation

### DIFF
--- a/alvr/common/src/inputs.rs
+++ b/alvr/common/src/inputs.rs
@@ -20,6 +20,7 @@ interaction_profile!(PICO_NEO3, "bytedance/pico_neo3");
 interaction_profile!(PICO4, "bytedance/pico4");
 interaction_profile!(PICO4S, "bytedance/pico4s");
 interaction_profile!(PICO_G3, "bytedance/pico_g3");
+interaction_profile!(PSVR2, "sony/playstation_vr2_sense");
 interaction_profile!(FOCUS3, "htc/vive_focus3");
 interaction_profile!(YVR, "yvr/touch");
 
@@ -115,6 +116,7 @@ controller_inputs! {
     (SYSTEM_CLICK, "system/click", Binary),
     (SYSTEM_TOUCH, "system/touch", Binary),
     (MENU_CLICK, "menu/click", Binary),
+    (MENU_TOUCH, "menu/touch", Binary),
     (BACK_CLICK, "back/click", Binary),
     (A_CLICK, "a/click", Binary),
     (A_TOUCH, "a/touch", Binary),
@@ -405,6 +407,52 @@ pub static CONTROLLER_PROFILE_INFO: Lazy<HashMap<u64, InteractionProfileInfo>> =
                     *RIGHT_SQUEEZE_CLICK_ID,
                     *RIGHT_SQUEEZE_VALUE_ID,
                     *RIGHT_THUMBREST_TOUCH_ID,
+                ]
+                .into_iter()
+                .collect(),
+            },
+        ),
+        (
+            *PSVR2_CONTROLLER_PROFILE_ID,
+            InteractionProfileInfo {
+                path: PSVR2_CONTROLLER_PROFILE_PATH,
+                button_set: [
+                    *LEFT_X_CLICK_ID,
+                    *LEFT_X_TOUCH_ID,
+                    *LEFT_Y_CLICK_ID,
+                    *LEFT_Y_TOUCH_ID,
+                    *LEFT_MENU_CLICK_ID,
+                    *LEFT_MENU_TOUCH_ID,
+                    *LEFT_SYSTEM_CLICK_ID,
+                    *LEFT_SYSTEM_TOUCH_ID,
+                    *LEFT_TRIGGER_CLICK_ID,
+                    *LEFT_TRIGGER_VALUE_ID,
+                    *LEFT_TRIGGER_TOUCH_ID,
+                    *LEFT_THUMBSTICK_Y_ID,
+                    *LEFT_THUMBSTICK_X_ID,
+                    *LEFT_THUMBSTICK_CLICK_ID,
+                    *LEFT_THUMBSTICK_TOUCH_ID,
+                    *LEFT_SQUEEZE_CLICK_ID,
+                    *LEFT_SQUEEZE_VALUE_ID,
+                    *LEFT_SQUEEZE_TOUCH_ID,
+                    *RIGHT_A_CLICK_ID,
+                    *RIGHT_A_TOUCH_ID,
+                    *RIGHT_B_CLICK_ID,
+                    *RIGHT_B_TOUCH_ID,
+                    *RIGHT_SYSTEM_CLICK_ID,
+                    *RIGHT_SYSTEM_TOUCH_ID,
+                    *RIGHT_MENU_CLICK_ID,
+                    *RIGHT_MENU_TOUCH_ID,
+                    *RIGHT_TRIGGER_CLICK_ID,
+                    *RIGHT_TRIGGER_VALUE_ID,
+                    *RIGHT_TRIGGER_TOUCH_ID,
+                    *RIGHT_THUMBSTICK_Y_ID,
+                    *RIGHT_THUMBSTICK_X_ID,
+                    *RIGHT_THUMBSTICK_CLICK_ID,
+                    *RIGHT_THUMBSTICK_TOUCH_ID,
+                    *RIGHT_SQUEEZE_CLICK_ID,
+                    *RIGHT_SQUEEZE_VALUE_ID,
+                    *RIGHT_SQUEEZE_TOUCH_ID,
                 ]
                 .into_iter()
                 .collect(),

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -86,6 +86,7 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
             ControllersEmulationMode::ValveIndex => 20,
             ControllersEmulationMode::ViveWand => 40,
             ControllersEmulationMode::ViveTracker => 41,
+            ControllersEmulationMode::PSVR2Sense => 60,
             ControllersEmulationMode::Custom { .. } => 500,
         };
         use_separate_hand_trackers = config

--- a/alvr/server_core/src/input_mapping.rs
+++ b/alvr/server_core/src/input_mapping.rs
@@ -23,6 +23,11 @@ pub fn registered_button_set(
             .unwrap()
             .button_set
             .clone(),
+        ControllersEmulationMode::PSVR2Sense => CONTROLLER_PROFILE_INFO
+            .get(&PSVR2_CONTROLLER_PROFILE_ID)
+            .unwrap()
+            .button_set
+            .clone(),
         ControllersEmulationMode::ValveIndex => CONTROLLER_PROFILE_INFO
             .get(&INDEX_CONTROLLER_PROFILE_ID)
             .unwrap()
@@ -255,6 +260,18 @@ pub fn automatic_bindings(
             ));
         }
     }
+    if s_set.contains(&*LEFT_SYSTEM_CLICK_ID) {
+        let click = click(*LEFT_SYSTEM_CLICK_ID);
+        if d_set.contains(&*LEFT_SYSTEM_CLICK_ID) {
+            bindings.extend(map_button_pair_automatic(
+                click,
+                ct(s_set, *LEFT_SYSTEM_CLICK_ID, *LEFT_SYSTEM_TOUCH_ID),
+                config,
+            ));
+        } else if d_set.contains(&*LEFT_MENU_CLICK_ID) {
+            bindings.extend(map_button_pair_automatic(click, click, config));
+        }
+    }
     if s_set.contains(&*RIGHT_MENU_CLICK_ID) {
         let click = click(*RIGHT_MENU_CLICK_ID);
         if d_set.contains(&*RIGHT_MENU_CLICK_ID) {
@@ -265,6 +282,18 @@ pub fn automatic_bindings(
                 ct(s_set, *RIGHT_SYSTEM_CLICK_ID, *RIGHT_SYSTEM_TOUCH_ID),
                 config,
             ));
+        }
+    }
+    if s_set.contains(&*RIGHT_SYSTEM_CLICK_ID) {
+        let click = click(*RIGHT_SYSTEM_CLICK_ID);
+        if d_set.contains(&*RIGHT_SYSTEM_CLICK_ID) {
+            bindings.extend(map_button_pair_automatic(
+                click,
+                ct(s_set, *RIGHT_SYSTEM_CLICK_ID, *RIGHT_SYSTEM_TOUCH_ID),
+                config,
+            ));
+        } else if d_set.contains(&*RIGHT_MENU_CLICK_ID) {
+            bindings.extend(map_button_pair_automatic(click, click, config));
         }
     }
 

--- a/alvr/server_openvr/cpp/alvr_server/Paths.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Paths.cpp
@@ -83,59 +83,63 @@ void init_paths() {
     BODY_IDS.insert(BODY_RIGHT_FOOT_ID);
 
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/system/click"),
-                                            { { "/input/system/click" }, ButtonType::Binary } });
+                                            { { "/input/system/click", "/input/left_ps/click" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/system/touch"),
-                                            { { "/input/system/touch" }, ButtonType::Binary } });
+                                            { { "/input/system/touch", "/input/left_ps/touch" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/left/input/menu/click"),
-          { { "/input/system/click", "/input/application_menu/click" }, ButtonType::Binary } }
+          { { "/input/system/click", "/input/application_menu/click", "/input/create/click" }, ButtonType::Binary } }
+    );
+    LEFT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/left/input/menu/touch"),
+          { { "/input/system/touch", "/input/application_menu/touch", "/input/create/touch" }, ButtonType::Binary } }
     );
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/a/click"),
-                                            { { "/input/a/click" }, ButtonType::Binary } });
+                                            { { "/input/a/click", "/input/cross/click" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/a/touch"),
-                                            { { "/input/a/touch" }, ButtonType::Binary } });
+                                            { { "/input/a/touch", "/input/cross/touch" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/b/click"),
-                                            { { "/input/b/click" }, ButtonType::Binary } });
+                                            { { "/input/b/click", "/input/circle/click" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/b/touch"),
-                                            { { "/input/b/touch" }, ButtonType::Binary } });
+                                            { { "/input/b/touch", "/input/circle/touch" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/x/click"),
-                                            { { "/input/x/click" }, ButtonType::Binary } });
+                                            { { "/input/x/click", "/input/square/click" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/x/touch"),
-                                            { { "/input/x/touch" }, ButtonType::Binary } });
+                                            { { "/input/x/touch", "/input/square/touch" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/y/click"),
-                                            { { "/input/y/click" }, ButtonType::Binary } });
+                                            { { "/input/y/click", "/input/triangle/click" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/y/touch"),
-                                            { { "/input/y/touch" }, ButtonType::Binary } });
+                                            { { "/input/y/touch", "/input/triangle/touch" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/squeeze/click"),
-                                            { { "/input/grip/click" }, ButtonType::Binary } });
+                                            { { "/input/grip/click", "/input/l1/click" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/squeeze/touch"),
-                                            { { "/input/grip/touch" }, ButtonType::Binary } });
+                                            { { "/input/grip/touch", "/input/l1/touch" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/squeeze/value"),
-                                            { { "/input/grip/value" },
+                                            { { "/input/grip/value", "/input/l1/value" },
                                               ButtonType::ScalarOneSided } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/squeeze/force"),
                                             { { "/input/grip/force" },
                                               ButtonType::ScalarOneSided } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/trigger/click"),
-                                            { { "/input/trigger/click" }, ButtonType::Binary } });
+                                            { { "/input/trigger/click", "/input/l2/click" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/trigger/value"),
-                                            { { "/input/trigger/value" },
+                                            { { "/input/trigger/value", "/input/l2/value" },
                                               ButtonType::ScalarOneSided } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/trigger/touch"),
-                                            { { "/input/trigger/touch" }, ButtonType::Binary } });
+                                            { { "/input/trigger/touch", "/input/l2/touch" }, ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/thumbstick/x"),
-                                            { { "/input/joystick/x", "/input/thumbstick/x" },
+                                            { { "/input/joystick/x", "/input/thumbstick/x", "/input/left_stick/x" },
                                               ButtonType::ScalarTwoSided } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/thumbstick/y"),
-                                            { { "/input/joystick/y", "/input/thumbstick/y" },
+                                            { { "/input/joystick/y", "/input/thumbstick/y", "/input/left_stick/y" },
                                               ButtonType::ScalarTwoSided } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/left/input/thumbstick/click"),
-          { { "/input/joystick/click", "/input/thumbstick/click" }, ButtonType::Binary } }
+          { { "/input/joystick/click", "/input/thumbstick/click", "/input/left_stick/click" }, ButtonType::Binary } }
     );
     LEFT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/left/input/thumbstick/touch"),
-          { { "/input/joystick/touch", "/input/thumbstick/touch" }, ButtonType::Binary } }
+          { { "/input/joystick/touch", "/input/thumbstick/touch", "/input/left_stick/touch" }, ButtonType::Binary } }
     );
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/trackpad/x"),
                                             { { "/input/trackpad/x" },
@@ -159,31 +163,35 @@ void init_paths() {
 
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/system/click"
                                              ),
-                                             { { "/input/system/click" }, ButtonType::Binary } });
+                                             { { "/input/system/click", "/input/right_ps/click" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/system/touch"
                                              ),
-                                             { { "/input/system/touch" }, ButtonType::Binary } });
+                                             { { "/input/system/touch", "/input/right_ps/touch" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/menu/click"),
-          { { "/input/system/click", "/input/application_menu/click" }, ButtonType::Binary } }
+          { { "/input/system/click", "/input/application_menu/click", "/input/options/click" }, ButtonType::Binary } }
+    );
+    RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/right/input/menu/touch"),
+          { { "/input/system/touch", "/input/application_menu/touch", "/input/options/touch" }, ButtonType::Binary } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/a/click"),
-                                             { { "/input/a/click" }, ButtonType::Binary } });
+                                             { { "/input/a/click", "/input/cross/click" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/a/touch"),
-                                             { { "/input/a/touch" }, ButtonType::Binary } });
+                                             { { "/input/a/touch", "/input/cross/touch" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/b/click"),
-                                             { { "/input/b/click" }, ButtonType::Binary } });
+                                             { { "/input/b/click", "/input/circle/click" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/b/touch"),
-                                             { { "/input/b/touch" }, ButtonType::Binary } });
+                                             { { "/input/b/touch", "/input/circle/touch" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/squeeze/click"
                                              ),
-                                             { { "/input/grip/click" }, ButtonType::Binary } });
+                                             { { "/input/grip/click", "/input/r1/click" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/squeeze/touch"
                                              ),
-                                             { { "/input/grip/touch" }, ButtonType::Binary } });
+                                             { { "/input/grip/touch", "/input/r1/touch" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/squeeze/value"),
-          { { "/input/grip/value" }, ButtonType::ScalarOneSided } }
+          { { "/input/grip/value", "/input/r1/value" }, ButtonType::ScalarOneSided } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/squeeze/force"),
@@ -191,29 +199,29 @@ void init_paths() {
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/trigger/click"
                                              ),
-                                             { { "/input/trigger/click" }, ButtonType::Binary } });
+                                             { { "/input/trigger/click", "/input/r2/click" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/trigger/value"),
-          { { "/input/trigger/value" }, ButtonType::ScalarOneSided } }
+          { { "/input/trigger/value", "/input/r2/value" }, ButtonType::ScalarOneSided } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/trigger/touch"
                                              ),
-                                             { { "/input/trigger/touch" }, ButtonType::Binary } });
+                                             { { "/input/trigger/touch", "/input/r2/touch" }, ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/thumbstick/x"),
-          { { "/input/joystick/x", "/input/thumbstick/x" }, ButtonType::ScalarTwoSided } }
+          { { "/input/joystick/x", "/input/thumbstick/x", "/input/right_stick/x" }, ButtonType::ScalarTwoSided } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/thumbstick/y"),
-          { { "/input/joystick/y", "/input/thumbstick/y" }, ButtonType::ScalarTwoSided } }
+          { { "/input/joystick/y", "/input/thumbstick/y", "/input/right_stick/y" }, ButtonType::ScalarTwoSided } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/thumbstick/click"),
-          { { "/input/joystick/click", "/input/thumbstick/click" }, ButtonType::Binary } }
+          { { "/input/joystick/click", "/input/thumbstick/click", "/input/right_stick/click" }, ButtonType::Binary } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/thumbstick/touch"),
-          { { "/input/joystick/touch", "/input/thumbstick/touch" }, ButtonType::Binary } }
+          { { "/input/joystick/touch", "/input/thumbstick/touch", "/input/right_stick/touch" }, ButtonType::Binary } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/trackpad/x"),
                                              { { "/input/trackpad/x" },

--- a/alvr/server_openvr/cpp/alvr_server/Paths.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/Paths.cpp
@@ -83,37 +83,51 @@ void init_paths() {
     BODY_IDS.insert(BODY_RIGHT_FOOT_ID);
 
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/system/click"),
-                                            { { "/input/system/click", "/input/left_ps/click" }, ButtonType::Binary } });
+                                            { { "/input/system/click", "/input/left_ps/click" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/system/touch"),
-                                            { { "/input/system/touch", "/input/left_ps/touch" }, ButtonType::Binary } });
+                                            { { "/input/system/touch", "/input/left_ps/touch" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/left/input/menu/click"),
-          { { "/input/system/click", "/input/application_menu/click", "/input/create/click" }, ButtonType::Binary } }
+          { { "/input/system/click", "/input/application_menu/click", "/input/create/click" },
+            ButtonType::Binary } }
     );
     LEFT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/left/input/menu/touch"),
-          { { "/input/system/touch", "/input/application_menu/touch", "/input/create/touch" }, ButtonType::Binary } }
+          { { "/input/system/touch", "/input/application_menu/touch", "/input/create/touch" },
+            ButtonType::Binary } }
     );
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/a/click"),
-                                            { { "/input/a/click", "/input/cross/click" }, ButtonType::Binary } });
+                                            { { "/input/a/click", "/input/cross/click" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/a/touch"),
-                                            { { "/input/a/touch", "/input/cross/touch" }, ButtonType::Binary } });
+                                            { { "/input/a/touch", "/input/cross/touch" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/b/click"),
-                                            { { "/input/b/click", "/input/circle/click" }, ButtonType::Binary } });
+                                            { { "/input/b/click", "/input/circle/click" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/b/touch"),
-                                            { { "/input/b/touch", "/input/circle/touch" }, ButtonType::Binary } });
+                                            { { "/input/b/touch", "/input/circle/touch" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/x/click"),
-                                            { { "/input/x/click", "/input/square/click" }, ButtonType::Binary } });
+                                            { { "/input/x/click", "/input/square/click" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/x/touch"),
-                                            { { "/input/x/touch", "/input/square/touch" }, ButtonType::Binary } });
+                                            { { "/input/x/touch", "/input/square/touch" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/y/click"),
-                                            { { "/input/y/click", "/input/triangle/click" }, ButtonType::Binary } });
+                                            { { "/input/y/click", "/input/triangle/click" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/y/touch"),
-                                            { { "/input/y/touch", "/input/triangle/touch" }, ButtonType::Binary } });
+                                            { { "/input/y/touch", "/input/triangle/touch" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/squeeze/click"),
-                                            { { "/input/grip/click", "/input/l1/click" }, ButtonType::Binary } });
+                                            { { "/input/grip/click", "/input/l1/click" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/squeeze/touch"),
-                                            { { "/input/grip/touch", "/input/l1/touch" }, ButtonType::Binary } });
+                                            { { "/input/grip/touch", "/input/l1/touch" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/squeeze/value"),
                                             { { "/input/grip/value", "/input/l1/value" },
                                               ButtonType::ScalarOneSided } });
@@ -121,25 +135,33 @@ void init_paths() {
                                             { { "/input/grip/force" },
                                               ButtonType::ScalarOneSided } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/trigger/click"),
-                                            { { "/input/trigger/click", "/input/l2/click" }, ButtonType::Binary } });
+                                            { { "/input/trigger/click", "/input/l2/click" },
+                                              ButtonType::Binary } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/trigger/value"),
                                             { { "/input/trigger/value", "/input/l2/value" },
                                               ButtonType::ScalarOneSided } });
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/trigger/touch"),
-                                            { { "/input/trigger/touch", "/input/l2/touch" }, ButtonType::Binary } });
-    LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/thumbstick/x"),
-                                            { { "/input/joystick/x", "/input/thumbstick/x", "/input/left_stick/x" },
-                                              ButtonType::ScalarTwoSided } });
-    LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/thumbstick/y"),
-                                            { { "/input/joystick/y", "/input/thumbstick/y", "/input/left_stick/y" },
-                                              ButtonType::ScalarTwoSided } });
+                                            { { "/input/trigger/touch", "/input/l2/touch" },
+                                              ButtonType::Binary } });
+    LEFT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/left/input/thumbstick/x"),
+          { { "/input/joystick/x", "/input/thumbstick/x", "/input/left_stick/x" },
+            ButtonType::ScalarTwoSided } }
+    );
+    LEFT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/left/input/thumbstick/y"),
+          { { "/input/joystick/y", "/input/thumbstick/y", "/input/left_stick/y" },
+            ButtonType::ScalarTwoSided } }
+    );
     LEFT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/left/input/thumbstick/click"),
-          { { "/input/joystick/click", "/input/thumbstick/click", "/input/left_stick/click" }, ButtonType::Binary } }
+          { { "/input/joystick/click", "/input/thumbstick/click", "/input/left_stick/click" },
+            ButtonType::Binary } }
     );
     LEFT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/left/input/thumbstick/touch"),
-          { { "/input/joystick/touch", "/input/thumbstick/touch", "/input/left_stick/touch" }, ButtonType::Binary } }
+          { { "/input/joystick/touch", "/input/thumbstick/touch", "/input/left_stick/touch" },
+            ButtonType::Binary } }
     );
     LEFT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/left/input/trackpad/x"),
                                             { { "/input/trackpad/x" },
@@ -161,34 +183,44 @@ void init_paths() {
                                             ),
                                             { { "/input/thumbrest/touch" }, ButtonType::Binary } });
 
-    RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/system/click"
-                                             ),
-                                             { { "/input/system/click", "/input/right_ps/click" }, ButtonType::Binary } });
-    RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/system/touch"
-                                             ),
-                                             { { "/input/system/touch", "/input/right_ps/touch" }, ButtonType::Binary } });
+    RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/right/input/system/click"),
+          { { "/input/system/click", "/input/right_ps/click" }, ButtonType::Binary } }
+    );
+    RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/right/input/system/touch"),
+          { { "/input/system/touch", "/input/right_ps/touch" }, ButtonType::Binary } }
+    );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/menu/click"),
-          { { "/input/system/click", "/input/application_menu/click", "/input/options/click" }, ButtonType::Binary } }
+          { { "/input/system/click", "/input/application_menu/click", "/input/options/click" },
+            ButtonType::Binary } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/menu/touch"),
-          { { "/input/system/touch", "/input/application_menu/touch", "/input/options/touch" }, ButtonType::Binary } }
+          { { "/input/system/touch", "/input/application_menu/touch", "/input/options/touch" },
+            ButtonType::Binary } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/a/click"),
-                                             { { "/input/a/click", "/input/cross/click" }, ButtonType::Binary } });
+                                             { { "/input/a/click", "/input/cross/click" },
+                                               ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/a/touch"),
-                                             { { "/input/a/touch", "/input/cross/touch" }, ButtonType::Binary } });
+                                             { { "/input/a/touch", "/input/cross/touch" },
+                                               ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/b/click"),
-                                             { { "/input/b/click", "/input/circle/click" }, ButtonType::Binary } });
+                                             { { "/input/b/click", "/input/circle/click" },
+                                               ButtonType::Binary } });
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/b/touch"),
-                                             { { "/input/b/touch", "/input/circle/touch" }, ButtonType::Binary } });
-    RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/squeeze/click"
-                                             ),
-                                             { { "/input/grip/click", "/input/r1/click" }, ButtonType::Binary } });
-    RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/squeeze/touch"
-                                             ),
-                                             { { "/input/grip/touch", "/input/r1/touch" }, ButtonType::Binary } });
+                                             { { "/input/b/touch", "/input/circle/touch" },
+                                               ButtonType::Binary } });
+    RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/right/input/squeeze/click"),
+          { { "/input/grip/click", "/input/r1/click" }, ButtonType::Binary } }
+    );
+    RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/right/input/squeeze/touch"),
+          { { "/input/grip/touch", "/input/r1/touch" }, ButtonType::Binary } }
+    );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/squeeze/value"),
           { { "/input/grip/value", "/input/r1/value" }, ButtonType::ScalarOneSided } }
@@ -197,31 +229,37 @@ void init_paths() {
         { PathStringToHash("/user/hand/right/input/squeeze/force"),
           { { "/input/grip/force" }, ButtonType::ScalarOneSided } }
     );
-    RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/trigger/click"
-                                             ),
-                                             { { "/input/trigger/click", "/input/r2/click" }, ButtonType::Binary } });
+    RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/right/input/trigger/click"),
+          { { "/input/trigger/click", "/input/r2/click" }, ButtonType::Binary } }
+    );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/trigger/value"),
           { { "/input/trigger/value", "/input/r2/value" }, ButtonType::ScalarOneSided } }
     );
-    RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/trigger/touch"
-                                             ),
-                                             { { "/input/trigger/touch", "/input/r2/touch" }, ButtonType::Binary } });
+    RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
+        { PathStringToHash("/user/hand/right/input/trigger/touch"),
+          { { "/input/trigger/touch", "/input/r2/touch" }, ButtonType::Binary } }
+    );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/thumbstick/x"),
-          { { "/input/joystick/x", "/input/thumbstick/x", "/input/right_stick/x" }, ButtonType::ScalarTwoSided } }
+          { { "/input/joystick/x", "/input/thumbstick/x", "/input/right_stick/x" },
+            ButtonType::ScalarTwoSided } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/thumbstick/y"),
-          { { "/input/joystick/y", "/input/thumbstick/y", "/input/right_stick/y" }, ButtonType::ScalarTwoSided } }
+          { { "/input/joystick/y", "/input/thumbstick/y", "/input/right_stick/y" },
+            ButtonType::ScalarTwoSided } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/thumbstick/click"),
-          { { "/input/joystick/click", "/input/thumbstick/click", "/input/right_stick/click" }, ButtonType::Binary } }
+          { { "/input/joystick/click", "/input/thumbstick/click", "/input/right_stick/click" },
+            ButtonType::Binary } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert(
         { PathStringToHash("/user/hand/right/input/thumbstick/touch"),
-          { { "/input/joystick/touch", "/input/thumbstick/touch", "/input/right_stick/touch" }, ButtonType::Binary } }
+          { { "/input/joystick/touch", "/input/thumbstick/touch", "/input/right_stick/touch" },
+            ButtonType::Binary } }
     );
     RIGHT_CONTROLLER_BUTTON_MAPPING.insert({ PathStringToHash("/user/hand/right/input/trackpad/x"),
                                              { { "/input/trackpad/x" },

--- a/alvr/server_openvr/src/props.rs
+++ b/alvr/server_openvr/src/props.rs
@@ -134,6 +134,7 @@ fn serial_number(device_id: u64) -> String {
                 ControllersEmulationMode::QuestPro => "230YXXXXXXXXXX_Controller", // 230YT left, 230YV right
                 ControllersEmulationMode::RiftSTouch
                 | ControllersEmulationMode::Pico4
+                | ControllersEmulationMode::PSVR2Sense
                 | ControllersEmulationMode::ValveIndex
                 | ControllersEmulationMode::ViveWand
                 | ControllersEmulationMode::ViveTracker => "ALVR Remote Controller",
@@ -419,6 +420,33 @@ pub extern "C" fn set_device_openvr_props(instance_ptr: *mut c_void, device_id: 
                     set_prop(
                         InputProfilePathString,
                         "{vrlink}/input/pico_controller_profile.json",
+                    );
+                }
+                ControllersEmulationMode::PSVR2Sense => {
+                    set_prop(TrackingSystemNameString, "playstation_vr2");
+                    if left_hand {
+                        set_prop(ModelNumberString, "PlayStation VR2 Sense Left");
+                        set_prop(SerialNumberString, "playstation_vr2_sense_controller_left");
+                        set_prop(
+                            RenderModelNameString,
+                            "{playstation_vr2}/rendermodels/playstation_vr2_sense_left",
+                        );
+                        set_icons("{playstation_vr2}/icons/left_controller_status");
+                    } else if right_hand {
+                        set_prop(ModelNumberString, "PlayStation VR2 Sense Right");
+                        set_prop(SerialNumberString, "playstation_vr2_sense_controller_right");
+                        set_prop(
+                            RenderModelNameString,
+                            "{playstation_vr2}/rendermodels/playstation_vr2_sense_right",
+                        );
+                        set_icons("{playstation_vr2}/icons/right_controller_status");
+                    }
+                    set_prop(TrackingFirmwareVersionString, "0303");
+                    set_prop(HardwareRevisionString, "MP");
+                    set_prop(ControllerTypeString, "playstation_vr2_sense");
+                    set_prop(
+                        InputProfilePathString,
+                        "{playstation_vr2}/input/playstation_vr2_sense_controller_profile.json",
                     );
                 }
                 ControllersEmulationMode::ValveIndex => {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1011,7 +1011,7 @@ pub enum ControllersEmulationMode {
     QuestPro,
     #[schema(strings(display_name = "Pico 4"))]
     Pico4,
-     #[schema(strings(display_name = "PSVR2 Sense Controller"))]
+    #[schema(strings(display_name = "PSVR2 Sense Controller"))]
     PSVR2Sense,
     #[schema(strings(display_name = "Valve Index"))]
     ValveIndex,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1011,6 +1011,8 @@ pub enum ControllersEmulationMode {
     QuestPro,
     #[schema(strings(display_name = "Pico 4"))]
     Pico4,
+     #[schema(strings(display_name = "PSVR2 Sense Controller"))]
+    PSVR2Sense,
     #[schema(strings(display_name = "Valve Index"))]
     ValveIndex,
     #[schema(strings(display_name = "Vive Wand"))]


### PR DESCRIPTION
Technically this is a partial implementation because it doesn't include the grip and trigger hover, but Apple didn't implement it so I can't actually implement it fully anyway.

Other notes:
- PSVR2 reports touch support for all buttons, so menu touch was added
- The automatic mapping was missing left system and right menu, so I added those. These mappings operate the opposite of left menu and right system in their mapping priority, the mappings seem to work fine for Quest controllers.
- Added a lot of PSVR2 mappings in Paths.cpp, because Sony is kind of annoying about their names
- The PSVR2 props were pulled from their PCVR driver, they're not very interesting
- For now, visionOS will present the PSVR2 controllers as Quest controllers, but I'll probably swap it to the PSVR2 profile later. visionOS itself presents the buttons as A/B/Menu/Grip/Trigger instead of Sony's names, so the PSVR2 profile button set is accurate here. Again, missing grip/trigger hover for now.