### PR TITLE
refactor: :rotating_light: Fix lints

### DIFF
--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -666,16 +666,22 @@ pub fn get_head_data(
 
     let mut motion = DeviceMotion {
         pose: crate::from_xr_pose(head_location.pose),
-        linear_velocity: head_velocity
+        linear_velocity: if head_velocity
             .velocity_flags
             .contains(xr::SpaceVelocityFlags::LINEAR_VALID)
-            .then(|| crate::from_xr_vec3(head_velocity.linear_velocity))
-            .unwrap_or_default(),
-        angular_velocity: head_velocity
+        {
+            crate::from_xr_vec3(head_velocity.linear_velocity)
+        } else {
+            Vec3::ZERO
+        },
+        angular_velocity: if head_velocity
             .velocity_flags
             .contains(xr::SpaceVelocityFlags::ANGULAR_VALID)
-            .then(|| crate::from_xr_vec3(head_velocity.angular_velocity))
-            .unwrap_or_default(),
+        {
+            crate::from_xr_vec3(head_velocity.angular_velocity)
+        } else {
+            Vec3::ZERO
+        },
     };
 
     // Some headsets use wrong frame of reference for linear and angular velocities.

--- a/alvr/xtask/src/build.rs
+++ b/alvr/xtask/src/build.rs
@@ -130,10 +130,17 @@ pub fn build_streamer(
 
     // build server
     {
-        let gpl_flag = gpl.then(|| vec!["--features", "gpl"]).unwrap_or_default();
-        let profiling_flag = profiling
-            .then(|| vec!["--features", "alvr_server_core/trace-performance"])
-            .unwrap_or_default();
+        let gpl_flag = if gpl {
+            vec!["--features", "gpl"]
+        } else {
+            vec![]
+        };
+
+        let profiling_flag = if profiling {
+            vec!["--features", "alvr_server_core/trace-performance"]
+        } else {
+            vec![]
+        };
 
         let _push_guard = sh.push_dir(afs::crate_dir("server_openvr"));
         cmd!(


### PR DESCRIPTION
This can be merged before the v20.14 release. These lints only apply to the current edition 2021, just to make CI pass. There will be another PR that upgrades to edition 2024 and version Rust 1.88 after.