### PR TITLE
refactor: :recycle: Use let-chains when applicable

### DIFF
--- a/alvr/adb/src/parse.rs
+++ b/alvr/adb/src/parse.rs
@@ -133,7 +133,10 @@ pub fn parse_forwarded_ports(line: &str) -> Option<ForwardedPorts> {
     let local = parse_port(slices.next()?);
     let remote = parse_port(slices.next()?);
 
-    if let (Some(serial), Some(local), Some(remote)) = (serial, local, remote) {
+    if let Some(serial) = serial
+        && let Some(local) = local
+        && let Some(remote) = remote
+    {
         Some(ForwardedPorts {
             local,
             remote,

--- a/alvr/audio/src/lib.rs
+++ b/alvr/audio/src/lib.rs
@@ -182,7 +182,9 @@ impl AudioDevice {
 }
 
 pub fn is_same_device(device1: &AudioDevice, device2: &AudioDevice) -> bool {
-    if let (Ok(name1), Ok(name2)) = (device1.inner.name(), device2.inner.name()) {
+    if let Ok(name1) = device1.inner.name()
+        && let Ok(name2) = device2.inner.name()
+    {
         name1 == name2
     } else {
         false

--- a/alvr/audio/src/linux.rs
+++ b/alvr/audio/src/linux.rs
@@ -52,13 +52,11 @@ pub fn play_microphone_loop_pipewire(
     });
 
     while running() {
-        let stream_audio = {
-            || {
-                if let Some(stream_state) = pw_stream_state_arc.try_lock() {
-                    *stream_state == StreamState::Streaming && running()
-                } else {
-                    false
-                }
+        let stream_audio = || {
+            if let Some(stream_state) = pw_stream_state_arc.try_lock() {
+                *stream_state == StreamState::Streaming && running()
+            } else {
+                false
             }
         };
         let receive_samples_buffer_arc = Arc::clone(&receive_samples_buffer_arc);

--- a/alvr/client_core/src/video_decoder/android.rs
+++ b/alvr/client_core/src/video_decoder/android.rs
@@ -101,11 +101,11 @@ impl VideoDecoderSource {
     pub fn dequeue_frame(&mut self) -> Option<(Duration, *mut c_void)> {
         let mut image_queue_lock = self.image_queue.lock();
 
-        if let Some(queued_image) = image_queue_lock.front() {
-            if queued_image.in_use {
-                // image is released and ready to be reused by the decoder
-                image_queue_lock.pop_front();
-            }
+        if let Some(queued_image) = image_queue_lock.front()
+            && queued_image.in_use
+        {
+            // image is released and ready to be reused by the decoder
+            image_queue_lock.pop_front();
         }
 
         // use running average to give more weight to recent samples

--- a/alvr/client_openxr/src/graphics.rs
+++ b/alvr/client_openxr/src/graphics.rs
@@ -2,6 +2,7 @@ use alvr_common::glam::UVec2;
 use alvr_graphics::GraphicsContext;
 use alvr_session::ClientsidePostProcessingConfig;
 use openxr as xr;
+use std::ptr;
 
 #[allow(unused)]
 pub fn session_create_info(ctx: &GraphicsContext) -> xr::opengles::SessionCreateInfo {
@@ -113,7 +114,7 @@ impl<'a> ProjectionLayerBuilder<'a> {
         if let Some(composition_layer_settings) = self.composition_layer_settings.as_ref() {
             unsafe {
                 xr::CompositionLayerProjection::from_raw(xr::sys::CompositionLayerProjection {
-                    next: std::ptr::from_ref(composition_layer_settings).cast(),
+                    next: ptr::from_ref(composition_layer_settings).cast(),
                     ..layer.into_raw()
                 })
             }

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -125,34 +125,31 @@ impl StreamContext {
                 .unwrap();
         }
 
-        let foveation_profile = if let Some(config) = &config.clientside_foveation_config {
-            if xr_exts.fb_swapchain_update_state.is_some()
-                && xr_exts.fb_foveation.is_some()
-                && xr_exts.fb_foveation_configuration.is_some()
-            {
-                let level;
-                let dynamic;
-                match config.mode {
-                    ClientsideFoveationMode::Static { level: lvl } => {
-                        level = lvl;
-                        dynamic = false;
-                    }
-                    ClientsideFoveationMode::Dynamic { max_level } => {
-                        level = max_level;
-                        dynamic = true;
-                    }
-                };
+        let foveation_profile = if let Some(config) = &config.clientside_foveation_config
+            && xr_exts.fb_swapchain_update_state.is_some()
+            && xr_exts.fb_foveation.is_some()
+            && xr_exts.fb_foveation_configuration.is_some()
+        {
+            let level;
+            let dynamic;
+            match config.mode {
+                ClientsideFoveationMode::Static { level: lvl } => {
+                    level = lvl;
+                    dynamic = false;
+                }
+                ClientsideFoveationMode::Dynamic { max_level } => {
+                    level = max_level;
+                    dynamic = true;
+                }
+            };
 
-                xr_session
-                    .create_foveation_profile(Some(xr::FoveationLevelProfile {
-                        level: xr::FoveationLevelFB::from_raw(level as i32),
-                        vertical_offset: config.vertical_offset_deg,
-                        dynamic: xr::FoveationDynamicFB::from_raw(dynamic as i32),
-                    }))
-                    .ok()
-            } else {
-                None
-            }
+            xr_session
+                .create_foveation_profile(Some(xr::FoveationLevelProfile {
+                    level: xr::FoveationLevelFB::from_raw(level as i32),
+                    vertical_offset: config.vertical_offset_deg,
+                    dynamic: xr::FoveationDynamicFB::from_raw(dynamic as i32),
+                }))
+                .ok()
         } else {
             None
         };
@@ -437,13 +434,13 @@ impl StreamContext {
         self.swapchains[0].release_image().unwrap();
         self.swapchains[1].release_image().unwrap();
 
-        if !buffer_ptr.is_null() {
-            if let Some(xr_now) = crate::xr_runtime_now(self.xr_session.instance()) {
-                self.core_context.report_submit(
-                    timestamp,
-                    vsync_time.saturating_sub(Duration::from_nanos(xr_now.as_nanos() as u64)),
-                );
-            }
+        if !buffer_ptr.is_null()
+            && let Some(xr_now) = crate::xr_runtime_now(self.xr_session.instance())
+        {
+            self.core_context.report_submit(
+                timestamp,
+                vsync_time.saturating_sub(Duration::from_nanos(xr_now.as_nanos() as u64)),
+            );
         }
 
         let rect = xr::Rect2Di {
@@ -588,15 +585,15 @@ fn stream_input_loop(
 
         // Note: When multimodal input is enabled, we are sure that when free hands are used
         // (not holding controllers) the controller data is None.
-        if int_ctx.multimodal_hands_enabled || left_hand_skeleton.is_none() {
-            if let Some(motion) = left_hand_motion {
-                device_motions.push((*HAND_LEFT_ID, motion));
-            }
+        if (int_ctx.multimodal_hands_enabled || left_hand_skeleton.is_none())
+            && let Some(motion) = left_hand_motion
+        {
+            device_motions.push((*HAND_LEFT_ID, motion));
         }
-        if int_ctx.multimodal_hands_enabled || right_hand_skeleton.is_none() {
-            if let Some(motion) = right_hand_motion {
-                device_motions.push((*HAND_RIGHT_ID, motion));
-            }
+        if (int_ctx.multimodal_hands_enabled || right_hand_skeleton.is_none())
+            && let Some(motion) = right_hand_motion
+        {
+            device_motions.push((*HAND_RIGHT_ID, motion));
         }
 
         let face_data = FaceData {

--- a/alvr/dashboard/src/dashboard/components/devices.rs
+++ b/alvr/dashboard/src/dashboard/components/devices.rs
@@ -84,39 +84,40 @@ impl DevicesTab {
         }
 
         ui.vertical_centered_justified(|ui| {
-            if let Some(clients) = &mut self.trusted_devices {
-                let wired_client = clients
-                    .iter()
-                    .find(|(hostname, _)| hostname == WIRED_CLIENT_HOSTNAME);
-                if let Some(request) =
-                    wired_client_section(ui, wired_client, self.adb_download_progress)
-                {
-                    requests.push(request);
-                }
-            }
-
-            ui.add_space(10.0);
-
-            if let Some(clients) = &self.new_devices {
-                if let Some(request) = new_clients_section(ui, clients) {
-                    requests.push(request);
-                }
-            }
-
-            ui.add_space(10.0);
-
-            if let Some(clients) = &mut self.trusted_devices {
-                let wireless_clients: Vec<&(String, ClientConnectionConfig)> = clients
-                    .iter()
-                    .filter(|(hostname, _)| hostname != WIRED_CLIENT_HOSTNAME)
-                    .collect();
-                if let Some(request) = trusted_clients_section(
+            if let Some(clients) = &mut self.trusted_devices
+                && let Some(request) = wired_client_section(
                     ui,
-                    wireless_clients.as_slice(),
+                    clients
+                        .iter()
+                        .find(|(hostname, _)| hostname == WIRED_CLIENT_HOSTNAME),
+                    self.adb_download_progress,
+                )
+            {
+                requests.push(request);
+            }
+
+            ui.add_space(10.0);
+
+            if let Some(clients) = &self.new_devices
+                && let Some(request) = new_clients_section(ui, clients)
+            {
+                requests.push(request);
+            }
+
+            ui.add_space(10.0);
+
+            if let Some(clients) = &mut self.trusted_devices
+                && let Some(request) = trusted_clients_section(
+                    ui,
+                    clients
+                        .iter()
+                        .filter(|(hostname, _)| hostname != WIRED_CLIENT_HOSTNAME)
+                        .collect::<Vec<_>>()
+                        .as_slice(),
                     &mut self.edit_popup_state,
-                ) {
-                    requests.push(request);
-                }
+                )
+            {
+                requests.push(request);
             }
         });
 

--- a/alvr/dashboard/src/dashboard/components/new_version_popup.rs
+++ b/alvr/dashboard/src/dashboard/components/new_version_popup.rs
@@ -20,10 +20,10 @@ impl NewVersionPopup {
         let mut launcher_path = None;
 
         let layout = crate::get_filesystem_layout();
-        if let Some(path) = layout.launcher_exe() {
-            if path.exists() {
-                launcher_path = Some(path);
-            }
+        if let Some(path) = layout.launcher_exe()
+            && path.exists()
+        {
+            launcher_path = Some(path);
         }
 
         Self {
@@ -90,19 +90,19 @@ impl NewVersionPopup {
 
         if let Some(button) = result {
             if button == no_remind_button {
-                return Some(CloseAction::CloseWithRequest(ServerRequest::SetValues(
+                Some(CloseAction::CloseWithRequest(ServerRequest::SetValues(
                     vec![PathValuePair {
                         path: alvr_packets::parse_path(
                             "session_settings.extra.new_version_popup.content.hide_while_version",
                         ),
                         value: serde_json::Value::String(self.version.clone()),
                     }],
-                )));
+                )))
             } else {
-                return Some(CloseAction::Close);
+                Some(CloseAction::Close)
             }
+        } else {
+            None
         }
-
-        None
     }
 }

--- a/alvr/dashboard/src/dashboard/components/settings_controls/choice.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/choice.rs
@@ -171,16 +171,16 @@ impl Control {
             }
         });
 
-        if let Some(control) = self.variant_controls.get_mut(&*variant_mut) {
-            if !matches!(control, SettingControl::None) {
-                ui.end_row();
+        if let Some(control) = self.variant_controls.get_mut(&*variant_mut)
+            && !matches!(control, SettingControl::None)
+        {
+            ui.end_row();
 
-                //fixes "cannot borrow `*session_variants` as mutable more than once at a time"
-                let variant = variant_mut.clone();
-                request = control
-                    .ui(ui, &mut session_variants_mut[&variant], false)
-                    .or(request);
-            }
+            //fixes "cannot borrow `*session_variants` as mutable more than once at a time"
+            let variant = variant_mut.clone();
+            request = control
+                .ui(ui, &mut session_variants_mut[&variant], false)
+                .or(request);
         }
 
         request

--- a/alvr/dashboard/src/dashboard/components/settings_controls/mod.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/mod.rs
@@ -58,15 +58,17 @@ pub fn f64_eq(f1: f64, f2: f64) -> bool {
 }
 
 pub fn json_values_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
-    if let (serde_json::Value::Number(n1), serde_json::Value::Number(n2)) = (a, b) {
-        // Note: is_f64() will exclude integers, while just as_f64() will silently do the conversion
-        if n1.is_f64() || n2.is_f64() {
-            if let (Some(f1), Some(f2)) = (n1.as_f64(), n2.as_f64()) {
-                return f64_eq(f1, f2);
-            }
-        }
+    // Note: is_f64() will exclude integers, while just as_f64() will silently do the conversion
+    if let serde_json::Value::Number(n1) = a
+        && let serde_json::Value::Number(n2) = b
+        && (n1.is_f64() || n2.is_f64())
+        && let Some(f1) = n1.as_f64()
+        && let Some(f2) = n2.as_f64()
+    {
+        f64_eq(f1, f2)
+    } else {
+        a == b
     }
-    a == b
 }
 
 #[derive(Clone)]

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
@@ -143,10 +143,10 @@ impl Control {
             ui.add_space(INDENTATION_STEP);
             ui.label(&self.name);
 
-            if let Some(string) = &self.help {
-                if ui.colored_label(INFO_LIGHT, "❓").hovered() {
-                    alvr_gui_common::tooltip(ui, &format!("{}_help_tooltip", self.name), string);
-                }
+            if let Some(string) = &self.help
+                && ui.colored_label(INFO_LIGHT, "❓").hovered()
+            {
+                alvr_gui_common::tooltip(ui, &format!("{}_help_tooltip", self.name), string);
             }
             if self.steamvr_restart_flag && ui.colored_label(WARNING_LIGHT, "⚠").hovered() {
                 alvr_gui_common::tooltip(

--- a/alvr/dashboard/src/dashboard/components/settings_controls/section.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/section.rs
@@ -114,14 +114,14 @@ impl Control {
                         label_res.on_hover_text(&*entry.id);
                     }
 
-                    if let Some(string) = &entry.help {
-                        if ui.colored_label(INFO_LIGHT, "❓").hovered() {
-                            alvr_gui_common::tooltip(
-                                ui,
-                                &format!("{}_help_tooltip", entry.id.display),
-                                string,
-                            );
-                        }
+                    if let Some(string) = &entry.help
+                        && ui.colored_label(INFO_LIGHT, "❓").hovered()
+                    {
+                        alvr_gui_common::tooltip(
+                            ui,
+                            &format!("{}_help_tooltip", entry.id.display),
+                            string,
+                        );
                     }
                     if entry.steamvr_restart_flag && ui.colored_label(WARNING_LIGHT, "⚠").hovered()
                     {

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -315,14 +315,14 @@ impl eframe::App for Dashboard {
                 .ensure_steamvr_shutdown();
         };
 
-        if let Some(popup) = &self.new_version_popup {
-            if let Some(action) = popup.ui(context, shutdown_alvr) {
-                if let CloseAction::CloseWithRequest(request) = action {
-                    requests.push(request);
-                }
-
-                self.new_version_popup = None;
+        if let Some(popup) = &self.new_version_popup
+            && let Some(action) = popup.ui(context, shutdown_alvr)
+        {
+            if let CloseAction::CloseWithRequest(request) = action {
+                requests.push(request);
             }
+
+            self.new_version_popup = None;
         }
 
         for request in requests {

--- a/alvr/dashboard/src/data_sources.rs
+++ b/alvr/dashboard/src/data_sources.rs
@@ -369,12 +369,12 @@ impl DataSources {
                                 }
                             }
                             Err(e) => {
-                                if let tungstenite::Error::Io(e) = e {
-                                    if e.kind() == ErrorKind::WouldBlock {
-                                        thread::sleep(Duration::from_millis(50));
+                                if let tungstenite::Error::Io(e) = e
+                                    && e.kind() == ErrorKind::WouldBlock
+                                {
+                                    thread::sleep(Duration::from_millis(50));
 
-                                        continue;
-                                    }
+                                    continue;
                                 }
 
                                 break;

--- a/alvr/dashboard/src/main.rs
+++ b/alvr/dashboard/src/main.rs
@@ -39,10 +39,10 @@ fn main() {
     // Kill any other dashboard instance
     let self_path = std::env::current_exe().unwrap();
     for proc in sysinfo::System::new_all().processes_by_name(OsStr::new(&afs::dashboard_fname())) {
-        if let Some(other_path) = proc.exe() {
-            if other_path != self_path {
-                proc.kill();
-            }
+        if let Some(other_path) = proc.exe()
+            && other_path != self_path
+        {
+            proc.kill();
         }
     }
 

--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -325,8 +325,7 @@ fn probe_libva_encoder_profile(
     } else if let Ok(profile) = profile_probe {
         if profile.is_empty() {
             message = format!("{profile_name} profile entrypoint is empty.");
-        }
-        if !profile.contains(&libva::VAEntrypoint::VAEntrypointEncSlice) {
+        } else if !profile.contains(&libva::VAEntrypoint::VAEntrypointEncSlice) {
             message = format!("{profile_name} profile does not contain encoding entrypoint.");
         }
     }

--- a/alvr/dashboard/src/steamvr_launcher/mod.rs
+++ b/alvr/dashboard/src/steamvr_launcher/mod.rs
@@ -120,10 +120,8 @@ impl Launcher {
             .session()
             .client_connections
             .contains_key(alvr_sockets::WIRED_CLIENT_HOSTNAME);
-        if wired_enabled {
-            if let Some(path) = adb::get_adb_path(&crate::get_filesystem_layout()) {
-                adb::kill_server(&path).ok();
-            }
+        if wired_enabled && let Some(path) = adb::get_adb_path(&crate::get_filesystem_layout()) {
+            adb::kill_server(&path).ok();
         }
 
         #[cfg(target_os = "linux")]

--- a/alvr/server_core/src/input_mapping.rs
+++ b/alvr/server_core/src/input_mapping.rs
@@ -148,15 +148,16 @@ fn map_button_pair_automatic(
         if let Some(destination_click) = destination.click {
             targets.push(passthrough(destination_click));
         }
-        if source.touch.is_none() {
-            if let Some(destination_touch) = destination.touch {
-                targets.push(passthrough(destination_touch));
-            }
+        if source.touch.is_none()
+            && let Some(destination_touch) = destination.touch
+        {
+            targets.push(passthrough(destination_touch));
         }
-        if source.value.is_none() {
-            if let Some(destination_value) = destination.value {
-                targets.push(binary_to_scalar(destination_value, click_to_value));
-            }
+
+        if source.value.is_none()
+            && let Some(destination_value) = destination.value
+        {
+            targets.push(binary_to_scalar(destination_value, click_to_value));
         }
 
         entries.push((source_click, targets));
@@ -173,35 +174,36 @@ fn map_button_pair_automatic(
         let mut remap_for_touch = false;
         let mut remap_for_force = false;
 
-        if source.click.is_none() {
-            if let Some(destination_click) = destination.click {
-                targets.push(hysteresis_threshold(
-                    destination_click,
-                    config.click_threshold,
-                ));
-            }
+        if source.click.is_none()
+            && let Some(destination_click) = destination.click
+        {
+            targets.push(hysteresis_threshold(
+                destination_click,
+                config.click_threshold,
+            ));
         }
-        if source.touch.is_none() {
-            if let Some(destination_touch) = destination.touch {
-                targets.push(hysteresis_threshold(
-                    destination_touch,
-                    config.touch_threshold,
-                ));
-                remap_for_touch = true;
-            }
+        if source.touch.is_none()
+            && let Some(destination_touch) = destination.touch
+        {
+            targets.push(hysteresis_threshold(
+                destination_touch,
+                config.touch_threshold,
+            ));
+            remap_for_touch = true;
         }
-        if source.force.is_none() {
-            if let Some(destination_force) = destination.force {
-                targets.push(remap(
-                    destination_force,
-                    Range {
-                        min: config.force_threshold,
-                        max: 1.0,
-                    },
-                ));
-                remap_for_force = true;
-            }
+        if source.force.is_none()
+            && let Some(destination_force) = destination.force
+        {
+            targets.push(remap(
+                destination_force,
+                Range {
+                    min: config.force_threshold,
+                    max: 1.0,
+                },
+            ));
+            remap_for_force = true;
         }
+
         if let Some(destination_value) = destination.value {
             if !remap_for_touch && !remap_for_force {
                 targets.push(passthrough(destination_value));

--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -380,22 +380,20 @@ impl ServerCoreContext {
                 .extra
                 .capture
                 .rolling_video_files
-            {
-                if Instant::now()
+                && Instant::now()
                     > *LAST_IDR_INSTANT.lock() + Duration::from_secs(config.duration_s)
-                {
-                    self.connection_context
-                        .events_sender
-                        .send(ServerCoreEvent::RequestIDR)
-                        .ok();
+            {
+                self.connection_context
+                    .events_sender
+                    .send(ServerCoreEvent::RequestIDR)
+                    .ok();
 
-                    if is_idr {
-                        create_recording_file(
-                            &self.connection_context,
-                            SESSION_MANAGER.read().settings(),
-                        );
-                        *LAST_IDR_INSTANT.lock() = Instant::now();
-                    }
+                if is_idr {
+                    create_recording_file(
+                        &self.connection_context,
+                        SESSION_MANAGER.read().settings(),
+                    );
+                    *LAST_IDR_INSTANT.lock() = Instant::now();
                 }
             }
 

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -456,41 +456,41 @@ pub fn tracking_loop(
         ) {
             let mut hand_gesture_manager_lock = hand_gesture_manager.lock();
 
-            if !device_motion_keys.contains(&*HAND_LEFT_ID) {
-                if let Some(hand_skeleton) = tracking.hand_skeletons[0] {
-                    ctx.events_sender
-                        .send(ServerCoreEvent::Buttons(
-                            hand_gestures::trigger_hand_gesture_actions(
-                                gestures_button_mapping_manager,
+            if !device_motion_keys.contains(&*HAND_LEFT_ID)
+                && let Some(hand_skeleton) = tracking.hand_skeletons[0]
+            {
+                ctx.events_sender
+                    .send(ServerCoreEvent::Buttons(
+                        hand_gestures::trigger_hand_gesture_actions(
+                            gestures_button_mapping_manager,
+                            *HAND_LEFT_ID,
+                            &hand_gesture_manager_lock.get_active_gestures(
+                                &hand_skeleton,
+                                gestures_config,
                                 *HAND_LEFT_ID,
-                                &hand_gesture_manager_lock.get_active_gestures(
-                                    &hand_skeleton,
-                                    gestures_config,
-                                    *HAND_LEFT_ID,
-                                ),
-                                gestures_config.only_touch,
                             ),
-                        ))
-                        .ok();
-                }
+                            gestures_config.only_touch,
+                        ),
+                    ))
+                    .ok();
             }
-            if !device_motion_keys.contains(&*HAND_RIGHT_ID) {
-                if let Some(hand_skeleton) = tracking.hand_skeletons[1] {
-                    ctx.events_sender
-                        .send(ServerCoreEvent::Buttons(
-                            hand_gestures::trigger_hand_gesture_actions(
-                                gestures_button_mapping_manager,
+            if !device_motion_keys.contains(&*HAND_RIGHT_ID)
+                && let Some(hand_skeleton) = tracking.hand_skeletons[1]
+            {
+                ctx.events_sender
+                    .send(ServerCoreEvent::Buttons(
+                        hand_gestures::trigger_hand_gesture_actions(
+                            gestures_button_mapping_manager,
+                            *HAND_RIGHT_ID,
+                            &hand_gesture_manager_lock.get_active_gestures(
+                                &hand_skeleton,
+                                gestures_config,
                                 *HAND_RIGHT_ID,
-                                &hand_gesture_manager_lock.get_active_gestures(
-                                    &hand_skeleton,
-                                    gestures_config,
-                                    *HAND_RIGHT_ID,
-                                ),
-                                gestures_config.only_touch,
                             ),
-                        ))
-                        .ok();
-                }
+                            gestures_config.only_touch,
+                        ),
+                    ))
+                    .ok();
             }
         }
 
@@ -541,22 +541,20 @@ pub fn tracking_loop(
             SESSION_MANAGER.read().settings().headset.body_tracking,
             Switch::Enabled(BodyTrackingConfig { tracked: true, .. })
         );
-        if track_body {
-            if let Some(sink) = &mut body_tracking_sink {
-                let tracking_manager_lock = ctx.tracking_manager.read();
-                let device_motions = device_motion_keys
-                    .iter()
-                    .map(move |id| {
-                        (
-                            *id,
-                            tracking_manager_lock
-                                .get_device_motion(*id, timestamp)
-                                .unwrap(),
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                sink.send_tracking(&device_motions);
-            }
+        if track_body && let Some(sink) = &mut body_tracking_sink {
+            let tracking_manager_lock = ctx.tracking_manager.read();
+            let device_motions = device_motion_keys
+                .iter()
+                .map(move |id| {
+                    (
+                        *id,
+                        tracking_manager_lock
+                            .get_device_motion(*id, timestamp)
+                            .unwrap(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            sink.send_tracking(&device_motions);
         }
     }
 }

--- a/alvr/server_core/src/web_server.rs
+++ b/alvr/server_core/src/web_server.rs
@@ -207,19 +207,18 @@ async fn http_api(
                         mut action,
                     } => {
                         let mut session_manager = SESSION_MANAGER.write();
-                        if matches!(action, ClientListAction::RemoveEntry) {
-                            if let Some(entry) = session_manager.client_list().get(&hostname) {
-                                if entry.connection_state != ConnectionState::Disconnected {
-                                    connection_context
-                                        .clients_to_be_removed
-                                        .lock()
-                                        .insert(hostname.clone());
+                        if matches!(action, ClientListAction::RemoveEntry)
+                            && let Some(entry) = session_manager.client_list().get(&hostname)
+                            && entry.connection_state != ConnectionState::Disconnected
+                        {
+                            connection_context
+                                .clients_to_be_removed
+                                .lock()
+                                .insert(hostname.clone());
 
-                                    action = ClientListAction::SetConnectionState(
-                                        ConnectionState::Disconnecting,
-                                    )
-                                };
-                            }
+                            action = ClientListAction::SetConnectionState(
+                                ConnectionState::Disconnecting,
+                            );
                         }
 
                         session_manager.update_client_list(hostname, action);

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -249,21 +249,21 @@ impl ServerSessionManager {
                 }
             }
             ClientListAction::UpdateCurrentIp(current_ip) => {
-                if let Entry::Occupied(mut entry) = maybe_client_entry {
-                    if entry.get().current_ip != current_ip {
-                        entry.get_mut().current_ip = current_ip;
+                if let Entry::Occupied(mut entry) = maybe_client_entry
+                    && entry.get().current_ip != current_ip
+                {
+                    entry.get_mut().current_ip = current_ip;
 
-                        updated = true;
-                    }
+                    updated = true;
                 }
             }
             ClientListAction::SetConnectionState(state) => {
-                if let Entry::Occupied(mut entry) = maybe_client_entry {
-                    if entry.get().connection_state != state {
-                        entry.get_mut().connection_state = state;
+                if let Entry::Occupied(mut entry) = maybe_client_entry
+                    && entry.get().connection_state != state
+                {
+                    entry.get_mut().connection_state = state;
 
-                        updated = true;
-                    }
+                    updated = true;
                 }
             }
         }

--- a/alvr/server_io/src/openvr_drivers.rs
+++ b/alvr/server_io/src/openvr_drivers.rs
@@ -51,10 +51,10 @@ pub fn get_driver_dir_from_registered() -> Result<PathBuf> {
             manifest_map.remove("name").to_any()
         }();
 
-        if let Ok(json::Value::String(str)) = maybe_driver_name {
-            if str == "alvr_server" {
-                return Ok(dir);
-            }
+        if let Ok(json::Value::String(str)) = maybe_driver_name
+            && str == "alvr_server"
+        {
+            return Ok(dir);
         }
     }
 

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -304,15 +304,15 @@ pub unsafe extern "C" fn register_buttons(instance_ptr: *mut c_void, device_id: 
 }
 
 extern "C" fn send_haptics(device_id: u64, duration_s: f32, frequency: f32, amplitude: f32) {
-    if let Ok(duration) = Duration::try_from_secs_f32(duration_s) {
-        if let Some(context) = &*SERVER_CORE_CONTEXT.read() {
-            context.send_haptics(Haptics {
-                device_id,
-                duration,
-                frequency,
-                amplitude,
-            });
-        }
+    if let Ok(duration) = Duration::try_from_secs_f32(duration_s)
+        && let Some(context) = &*SERVER_CORE_CONTEXT.read()
+    {
+        context.send_haptics(Haptics {
+            device_id,
+            duration,
+            frequency,
+            amplitude,
+        });
     }
 }
 
@@ -342,15 +342,13 @@ extern "C" fn send_video(timestamp_ns: u64, buffer_ptr: *mut u8, len: i32, is_id
 }
 
 extern "C" fn get_dynamic_encoder_params() -> FfiDynamicEncoderParams {
-    if let Some(context) = &*SERVER_CORE_CONTEXT.read() {
-        if let Some(params) = context.get_dynamic_encoder_params() {
-            FfiDynamicEncoderParams {
-                updated: 1,
-                bitrate_bps: params.bitrate_bps as u64,
-                framerate: params.framerate,
-            }
-        } else {
-            FfiDynamicEncoderParams::default()
+    if let Some(context) = &*SERVER_CORE_CONTEXT.read()
+        && let Some(params) = context.get_dynamic_encoder_params()
+    {
+        FfiDynamicEncoderParams {
+            updated: 1,
+            bitrate_bps: params.bitrate_bps as u64,
+            framerate: params.framerate,
         }
     } else {
         FfiDynamicEncoderParams::default()

--- a/alvr/sockets/src/backend/tcp.rs
+++ b/alvr/sockets/src/backend/tcp.rs
@@ -36,13 +36,13 @@ pub fn accept_from_server(
     // Uses timeout set during bind()
     let (socket, server_address) = listener.accept().handle_try_again()?;
 
-    if let Some(ip) = server_ip {
-        if server_address.ip() != ip {
-            con_bail!(
-                "Connected to wrong client: Expected: {ip}, Found {}",
-                server_address.ip()
-            );
-        }
+    if let Some(ip) = server_ip
+        && server_address.ip() != ip
+    {
+        con_bail!(
+            "Connected to wrong client: Expected: {ip}, Found {}",
+            server_address.ip()
+        );
     }
 
     socket.set_read_timeout(Some(timeout)).to_con()?;


### PR DESCRIPTION
This one might need a good eye for review. I slightly messed up when merging if statements, I realized too late that `if a { if b { } } else { }` is not the same as `if a && b { } else { }`. I went through it two times to make sure I haven't left behind bugs. We can merge ` if a { if b { } else {} } else { }` if the else blocks are identical.
I've also converted statements like `if let (Some(a), Some(b)) = (c, d)` to let chains to make them more readable