### PR TITLE
Protocol cleanup (3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_adb"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_audio"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_core"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_audio",
  "alvr_common",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_mock"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_openxr"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_common"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_dashboard"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_adb",
  "alvr_common",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_events"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_packets",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_filesystem"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "dirs",
  "once_cell",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_graphics"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_gui_common"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "egui",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_launcher"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_adb",
  "alvr_common",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_packets"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_core"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_adb",
  "alvr_audio",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_io"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_events",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_openvr"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_session"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_sockets"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_system_info"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "jni",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vrcompositor_wrapper"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vulkan_layer"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_xtask"
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 dependencies = [
  "alvr_filesystem",
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["alvr/*"]
 
 [workspace.package]
-version = "21.0.0-dev04"
+version = "21.0.0-dev05"
 edition = "2024"
 rust-version = "1.88"
 authors = ["alvr-org"]

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -550,7 +550,7 @@ pub extern "C" fn alvr_send_tracking(
                 (!hand_skeleton.is_null()).then(|| {
                     let hand_skeleton = unsafe { slice::from_raw_parts(hand_skeleton, 26) };
 
-                    let mut array = [Pose::default(); 26];
+                    let mut array = [Pose::IDENTITY; 26];
 
                     for (pose, capi_pose) in array.iter_mut().zip(hand_skeleton.iter()) {
                         *pose = Pose {
@@ -872,7 +872,7 @@ pub extern "C" fn alvr_render_stream_opengl(
                     StreamViewParams {
                         swapchain_index: left_params.swapchain_index,
                         input_view_params: ViewParams {
-                            pose: Pose::default(),
+                            pose: Pose::IDENTITY,
                             fov: from_capi_fov(left_params.fov),
                         },
                         output_view_params: ViewParams {
@@ -886,7 +886,7 @@ pub extern "C" fn alvr_render_stream_opengl(
                     StreamViewParams {
                         swapchain_index: right_params.swapchain_index,
                         input_view_params: ViewParams {
-                            pose: Pose::default(),
+                            pose: Pose::IDENTITY,
                             fov: from_capi_fov(right_params.fov),
                         },
                         output_view_params: ViewParams {

--- a/alvr/client_core/src/connection.rs
+++ b/alvr/client_core/src/connection.rs
@@ -317,7 +317,7 @@ fn connection_pipeline(
                         global_view_params_queue_lock
                             .push_back((header.timestamp, header.global_view_params));
 
-                        while global_view_params_queue_lock.len() > 1024 {
+                        while global_view_params_queue_lock.len() > 128 {
                             global_view_params_queue_lock.pop_front();
                         }
                     }

--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -270,7 +270,6 @@ impl ClientCoreContext {
                     device_motions,
                     hand_skeletons,
                     face_data,
-                    ext_str: String::new(),
                 })
                 .ok();
 

--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -78,6 +78,7 @@ pub struct ClientCoreContext {
     event_queue: Arc<Mutex<VecDeque<ClientCoreEvent>>>,
     connection_context: Arc<ConnectionContext>,
     connection_thread: Arc<Mutex<Option<JoinHandle<()>>>>,
+    last_good_global_view_params: Mutex<[ViewParams; 2]>,
 }
 
 impl ClientCoreContext {
@@ -119,6 +120,7 @@ impl ClientCoreContext {
             event_queue,
             connection_context,
             connection_thread: Arc::new(Mutex::new(Some(connection_thread))),
+            last_good_global_view_params: Mutex::new([ViewParams::default(); 2]),
         }
     }
 
@@ -212,10 +214,10 @@ impl ClientCoreContext {
     pub fn send_view_params(&self, views: [ViewParams; 2]) {
         dbg_client_core!("send_view_params");
 
-        *self.connection_context.view_params.write() = views;
-
         if let Some(sender) = &mut *self.connection_context.control_sender.lock() {
-            sender.send(&ClientControlPacket::ViewParams(views)).ok();
+            sender
+                .send(&ClientControlPacket::LocalViewParams(views))
+                .ok();
         }
     }
 
@@ -249,14 +251,6 @@ impl ClientCoreContext {
             if *id == *HEAD_ID {
                 *motion = motion.predict(poll_timestamp, target_timestamp);
 
-                let mut head_pose_queue = self.connection_context.head_pose_queue.write();
-
-                head_pose_queue.push_back((reported_timestamp, motion.pose));
-
-                while head_pose_queue.len() > 1024 {
-                    head_pose_queue.pop_front();
-                }
-
                 // This is done for backward compatibiity for the v20 protocol. Will be removed with the
                 // tracking rewrite protocol extension.
                 motion.linear_velocity = Vec3::ZERO;
@@ -276,6 +270,7 @@ impl ClientCoreContext {
                     device_motions,
                     hand_skeletons,
                     face_data,
+                    ext_str: String::new(),
                 })
                 .ok();
 
@@ -328,25 +323,15 @@ impl ClientCoreContext {
             stats.report_compositor_start(timestamp);
         }
 
-        let mut head_pose = *self.connection_context.last_good_head_pose.read();
-        for (ts, pose) in &*self.connection_context.head_pose_queue.read() {
+        let global_view_params_lock = &mut *self.last_good_global_view_params.lock();
+        for (ts, params) in &*self.connection_context.global_view_params_queue.lock() {
             if *ts == timestamp {
-                head_pose = *pose;
+                *global_view_params_lock = *params;
                 break;
             }
         }
-        let view_params = self.connection_context.view_params.read();
 
-        [
-            ViewParams {
-                pose: head_pose * view_params[0].pose,
-                fov: view_params[0].fov,
-            },
-            ViewParams {
-                pose: head_pose * view_params[1].pose,
-                fov: view_params[1].fov,
-            },
-        ]
+        *global_view_params_lock
     }
 
     pub fn report_submit(&self, timestamp: Duration, vsync_queue: Duration) {

--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -120,7 +120,7 @@ impl ClientCoreContext {
             event_queue,
             connection_context,
             connection_thread: Arc::new(Mutex::new(Some(connection_thread))),
-            last_good_global_view_params: Mutex::new([ViewParams::default(); 2]),
+            last_good_global_view_params: Mutex::new([ViewParams::DUMMY; 2]),
         }
     }
 

--- a/alvr/client_mock/src/main.rs
+++ b/alvr/client_mock/src/main.rs
@@ -1,6 +1,6 @@
 use alvr_client_core::{ClientCapabilities, ClientCoreContext, ClientCoreEvent};
 use alvr_common::{
-    DeviceMotion, Fov, HEAD_ID, Pose, RelaxedAtomic, ViewParams,
+    DeviceMotion, HEAD_ID, Pose, RelaxedAtomic, ViewParams,
     glam::{Quat, UVec2, Vec3},
     parking_lot::RwLock,
 };
@@ -145,17 +145,7 @@ fn tracking_thread(
     input: Arc<RwLock<WindowInput>>,
 ) {
     let timestamp_origin = Instant::now();
-
-    let views_params = ViewParams {
-        pose: Pose::default(),
-        fov: Fov {
-            left: -1.0,
-            right: 1.0,
-            up: 1.0,
-            down: -1.0,
-        },
-    };
-    context.send_view_params([views_params, views_params]);
+    context.send_view_params([ViewParams::DUMMY; 2]);
 
     let mut loop_deadline = Instant::now();
     while streaming.value() {

--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -57,7 +57,7 @@ fn get_controller_offset(platform: Platform, is_right_hand: bool) -> Pose {
             position: Vec3::new(0.0, 0.0, -0.02),
             orientation: Quat::IDENTITY,
         },
-        _ => Pose::default(),
+        _ => Pose::IDENTITY,
     };
 
     if is_right_hand {

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -226,7 +226,7 @@ impl StreamContext {
             stage_reference_space,
             view_reference_space,
             swapchains,
-            last_good_view_params: [ViewParams::default(); 2],
+            last_good_view_params: [ViewParams::DUMMY; 2],
             input_thread: None,
             input_thread_running,
             config,
@@ -516,9 +516,9 @@ fn stream_input_loop(
 ) {
     let platform = alvr_system_info::platform();
 
-    let mut last_controller_poses = [Pose::default(); 2];
-    let mut last_palm_poses = [Pose::default(); 2];
-    let mut last_view_params = [ViewParams::default(); 2];
+    let mut last_controller_poses = [Pose::IDENTITY; 2];
+    let mut last_palm_poses = [Pose::IDENTITY; 2];
+    let mut last_view_params = [ViewParams::DUMMY; 2];
 
     let mut deadline = Instant::now();
     let frame_interval = Duration::from_secs_f32(1.0 / refresh_rate);

--- a/alvr/common/src/primitives.rs
+++ b/alvr/common/src/primitives.rs
@@ -92,7 +92,6 @@ impl DeviceMotion {
 }
 
 // Per eye view parameters
-// todo: send together with video frame
 #[derive(Serialize, Deserialize, Clone, Copy, Default)]
 pub struct ViewParams {
     pub pose: Pose,

--- a/alvr/common/src/primitives.rs
+++ b/alvr/common/src/primitives.rs
@@ -11,24 +11,27 @@ pub struct Fov {
     pub down: f32,
 }
 
-impl Default for Fov {
-    fn default() -> Self {
-        Fov {
-            left: -1.0,
-            right: 1.0,
-            up: 1.0,
-            down: -1.0,
-        }
-    }
+impl Fov {
+    pub const DUMMY: Self = Fov {
+        left: -1.0,
+        right: 1.0,
+        up: 1.0,
+        down: -1.0,
+    };
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Default, Debug)]
 pub struct Pose {
-    pub orientation: Quat, // NB: default Quat is identity
+    pub orientation: Quat,
     pub position: Vec3,
 }
 
 impl Pose {
+    pub const IDENTITY: Self = Pose {
+        orientation: Quat::IDENTITY,
+        position: Vec3::ZERO,
+    };
+
     pub fn inverse(&self) -> Pose {
         let inverse_orientation = self.orientation.conjugate();
         Pose {
@@ -92,8 +95,15 @@ impl DeviceMotion {
 }
 
 // Per eye view parameters
-#[derive(Serialize, Deserialize, Clone, Copy, Default)]
+#[derive(Serialize, Deserialize, Clone, Copy)]
 pub struct ViewParams {
     pub pose: Pose,
     pub fov: Fov,
+}
+
+impl ViewParams {
+    pub const DUMMY: Self = ViewParams {
+        pose: Pose::IDENTITY,
+        fov: Fov::DUMMY,
+    };
 }

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -219,7 +219,6 @@ pub struct VideoPacketHeader {
     pub timestamp: Duration,
     pub global_view_params: [ViewParams; 2],
     pub is_idr: bool,
-    pub ext_str: String,
 }
 
 // Note: face_data does not respect target_timestamp.
@@ -229,7 +228,6 @@ pub struct Tracking {
     pub device_motions: Vec<(u64, DeviceMotion)>,
     pub hand_skeletons: [Option<[Pose; 26]>; 2],
     pub face_data: FaceData,
-    pub ext_str: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -143,6 +143,7 @@ impl StreamConfigPacket {
 pub struct DecoderInitializationConfig {
     pub codec: CodecType,
     pub config_buffer: Vec<u8>, // e.g. SPS + PPS NALs
+    pub ext_str: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -196,7 +197,7 @@ pub enum ClientControlPacket {
     RequestIdr,
     KeepAlive,
     StreamReady, // This flag notifies the server the client streaming socket is ready listening
-    ViewParams([ViewParams; 2]),
+    LocalViewParams([ViewParams; 2]), // Head-to_view
     Battery(BatteryInfo),
     Buttons(Vec<ButtonEntry>),
     ActiveInteractionProfile { device_id: u64, profile_id: u64 },
@@ -216,7 +217,9 @@ pub struct FaceData {
 #[derive(Serialize, Deserialize)]
 pub struct VideoPacketHeader {
     pub timestamp: Duration,
+    pub global_view_params: [ViewParams; 2],
     pub is_idr: bool,
+    pub ext_str: String,
 }
 
 // Note: face_data does not respect target_timestamp.
@@ -226,6 +229,7 @@ pub struct Tracking {
     pub device_motions: Vec<(u64, DeviceMotion)>,
     pub hand_skeletons: [Option<[Pose; 26]>; 2],
     pub face_data: FaceData,
+    pub ext_str: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/alvr/server_core/src/c_api.rs
+++ b/alvr/server_core/src/c_api.rs
@@ -117,7 +117,7 @@ pub enum AlvrEvent {
     ClientDisconnected,
     Battery(AlvrBatteryInfo),
     PlayspaceSync([f32; 2]),
-    LocalViewParams([AlvrViewParams; 2]), // Head-to-view
+    LocalViewParams([AlvrViewParams; 2]), // In relation to head
     TrackingUpdated { sample_timestamp_ns: u64 },
     ButtonsUpdated,
     RequestIDR,

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -1179,9 +1179,9 @@ fn connection_pipeline(
                         }
                         ctx.events_sender.send(ServerCoreEvent::RequestIDR).ok();
                     }
-                    ClientControlPacket::ViewParams(params) => {
+                    ClientControlPacket::LocalViewParams(params) => {
                         ctx.events_sender
-                            .send(ServerCoreEvent::ViewParams(params))
+                            .send(ServerCoreEvent::LocalViewParams(params))
                             .ok();
                     }
                     ClientControlPacket::Battery(packet) => {

--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -417,7 +417,6 @@ impl ServerCoreContext {
                         timestamp: target_timestamp,
                         global_view_params,
                         is_idr,
-                        ext_str: String::new(),
                     },
                     payload: nal_buffer,
                 });

--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -80,7 +80,7 @@ pub enum ServerCoreEvent {
     ClientDisconnected,
     Battery(BatteryInfo),
     PlayspaceSync(Vec2),
-    LocalViewParams([ViewParams; 2]), // Head-to-view
+    LocalViewParams([ViewParams; 2]), // In relation to head
     Tracking {
         sample_timestamp: Duration,
     },

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -63,8 +63,8 @@ pub struct TrackingManager {
 impl TrackingManager {
     pub fn new(max_history_size: usize) -> TrackingManager {
         TrackingManager {
-            last_head_pose: Pose::default(),
-            inverse_recentering_origin: Pose::default(),
+            last_head_pose: Pose::IDENTITY,
+            inverse_recentering_origin: Pose::IDENTITY,
             device_motions_history: HashMap::new(),
             hand_skeletons_history: [VecDeque::new(), VecDeque::new()],
             last_face_data: FaceData::default(),

--- a/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
@@ -474,7 +474,7 @@ void RegisterButton(void* instancePtr, unsigned long long buttonID) {
     ((Controller*)instancePtr)->RegisterButton(buttonID);
 }
 
-void SetViewParams(const FfiViewParams params[2]) {
+void SetLocalViewParams(const FfiViewParams params[2]) {
     if (g_driver_provider.hmd) {
         g_driver_provider.hmd->SetViewParams(params);
     }

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -158,7 +158,7 @@ extern "C" void ShutdownSteamvr();
 extern "C" void SetOpenvrProperty(void* instancePtr, FfiOpenvrProperty prop);
 extern "C" void SetOpenvrPropByDeviceID(unsigned long long deviceID, FfiOpenvrProperty prop);
 extern "C" void RegisterButton(void* instancePtr, unsigned long long buttonID);
-extern "C" void SetViewParams(const FfiViewParams params[2]);
+extern "C" void SetLocalViewParams(const FfiViewParams params[2]);
 extern "C" void SetBattery(unsigned long long deviceID, float gauge_value, bool is_plugged);
 extern "C" void SetButton(unsigned long long buttonID, FfiButtonValue value);
 

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -98,7 +98,7 @@ fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                         {
                             let mut head_pose_queue_lock = HEAD_POSE_QUEUE.lock();
                             head_pose_queue_lock.push_back((sample_timestamp, motion.pose));
-                            while head_pose_queue_lock.len() > 128 {
+                            while head_pose_queue_lock.len() > 360 {
                                 head_pose_queue_lock.pop_front();
                             }
 
@@ -344,7 +344,7 @@ extern "C" fn send_video(timestamp_ns: u64, buffer_ptr: *mut u8, len: i32, is_id
         let Some(head_pose) = HEAD_POSE_QUEUE
             .lock()
             .iter()
-            .find_map(|(ts, pose)| (*ts <= timestamp).then_some(*pose))
+            .find_map(|(ts, pose)| (*ts == timestamp).then_some(*pose))
         else {
             // We can't submit the frame without its pose
             return;

--- a/alvr/server_openvr/src/tracking.rs
+++ b/alvr/server_openvr/src/tracking.rs
@@ -94,8 +94,8 @@ fn get_hand_skeleton_offsets(config: &HeadsetConfig) -> (Pose, Pose) {
             position: Vec3::new(-t[0], t[1], t[2]),
         };
     } else {
-        left_offset = Pose::default();
-        right_offset = Pose::default();
+        left_offset = Pose::IDENTITY;
+        right_offset = Pose::IDENTITY;
     }
 
     (left_offset, right_offset)


### PR DESCRIPTION
* Rename most occurrences of `view_params` to `local_view_params`
* Pass global view params with `VideoPacketHeader`
* Add `ext_str` to `VideoPacketHeader` and `Tracking`

This PR should unblock Monado support. There is still some work to do, as currently the Monado port could have some issues with frame timing which results in jittery or untimed head position, which can be felt by strafing for example. Head orientation should work fine. For current SteamVR support I've not seen any issues in my testing.