### PR TITLE
fix(audio): :bug: Fix more strings for Virtual Audio Cable

### DIFF
--- a/alvr/audio/src/lib.rs
+++ b/alvr/audio/src/lib.rs
@@ -30,11 +30,11 @@ use std::{
 
 static VIRTUAL_MICROPHONE_PAIRS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     [
+        ("Line 1", "Line 1"),
         ("CABLE Input", "CABLE Output"),
         ("VoiceMeeter Input", "VoiceMeeter Output"),
         ("VoiceMeeter Aux Input", "VoiceMeeter Aux Output"),
         ("VoiceMeeter VAIO3 Input", "VoiceMeeter VAIO3 Output"),
-        ("Virtual Cable 1", "Virtual Cable 2"),
     ]
     .into_iter()
     .collect()
@@ -59,21 +59,18 @@ fn device_from_custom_config(host: &Host, config: &CustomAudioDeviceConfig) -> R
     })
 }
 
+// Input and output devices may have the same name.
 fn microphone_pair_from_sink_name(host: &Host, sink_name: &str) -> Result<(Device, Device)> {
     let sink = host
         .output_devices()?
         .find(|d| d.name().unwrap_or_default().contains(sink_name))
-        .context("VB-CABLE or Voice Meeter not found. Please install or reinstall either one")?;
+        .context("Virtual Audio Cable, VB-CABLE or VoiceMeeter not found. Please install or reinstall one")?;
 
     if let Some(source_name) = VIRTUAL_MICROPHONE_PAIRS.get(sink_name) {
         Ok((
             sink,
             host.input_devices()?
-                .find(|d| {
-                    d.name()
-                        .map(|name| name.contains(source_name))
-                        .unwrap_or(false)
-                })
+                .find(|d| d.name().unwrap_or_default().contains(source_name))
                 .context("Matching output microphone not found. Did you rename it?")?,
         ))
     } else {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -854,7 +854,7 @@ pub struct AudioConfig {
         windows,
         schema(strings(
             display_name = "Headset microphone",
-            notice = r"To be able to use the microphone on Windows, you need to install VB-Cable or VoiceMeeter"
+            notice = r"To be able to use the microphone on Windows, you need to install Virtual Audio Cable"
         ))
     )]
     #[cfg_attr(not(windows), schema(strings(display_name = "Headset microphone")))]

--- a/wiki/Installation-guide.md
+++ b/wiki/Installation-guide.md
@@ -22,7 +22,7 @@ For any problem visit the [Troubleshooting page](https://github.com/alvr-org/ALV
 
 ## Microphone Setup on Windows
 
-To use your microphone in ALVR on Windows you need to install **VB-Audio Cable** (or equivalent software). However if VB-Audio Cable is already installed but not working with ALVR **or if you encounter any issues**, it's worth following these steps to reinstall and configure it properly.
+To use your microphone in ALVR on Windows you need to install **Virtual Audio Cable** (or equivalent software). However if Virtual Audio Cable is already installed but not working with ALVR **or if you encounter any issues**, it's worth following these steps to reinstall and configure it properly.
 
 ### **1. Install or Reinstall Virtual Audio Cable**
 1. **Download** the latest Lite version of [Virtual Audio Cable](https://software.muzychenko.net/freeware/vac470lite.zip).


### PR DESCRIPTION
The name of the VAC audio devices were wrong so the VAC microophone option was broken.

This PR would be cherry picked into the v20 branch and released as 20.14.1, together maybe with other bugfixes if needed.