### PR TITLE
refactor: :recycle: Move C API primitives to alvr_common

### DIFF
--- a/alvr/client_core/cbindgen.toml
+++ b/alvr/client_core/cbindgen.toml
@@ -8,3 +8,8 @@ documentation_style = "c99"
 
 [enum]
 rename_variants = "QualifiedScreamingSnakeCase"
+
+[parse]
+parse_deps = true
+include = ["alvr_common"]
+

--- a/alvr/client_openxr/src/lobby.rs
+++ b/alvr/client_openxr/src/lobby.rs
@@ -3,7 +3,7 @@ use crate::{
     graphics::{self, ProjectionLayerAlphaConfig, ProjectionLayerBuilder},
     interaction::{self, InteractionContext},
 };
-use alvr_common::{Pose, glam::UVec2, parking_lot::RwLock};
+use alvr_common::{Pose, ViewParams, glam::UVec2, parking_lot::RwLock};
 use alvr_graphics::{
     BodyTrackingType, GraphicsContext, LobbyRenderer, LobbyViewParams, SDR_FORMAT_GL,
 };
@@ -192,13 +192,17 @@ impl Lobby {
         self.renderer.render(
             [
                 LobbyViewParams {
-                    pose: crate::from_xr_pose(views[0].pose),
-                    fov: crate::from_xr_fov(views[0].fov),
+                    view_params: ViewParams {
+                        pose: crate::from_xr_pose(views[0].pose),
+                        fov: crate::from_xr_fov(views[0].fov),
+                    },
                     swapchain_index: left_swapchain_idx,
                 },
                 LobbyViewParams {
-                    pose: crate::from_xr_pose(views[1].pose),
-                    fov: crate::from_xr_fov(views[1].fov),
+                    view_params: ViewParams {
+                        pose: crate::from_xr_pose(views[1].pose),
+                        fov: crate::from_xr_fov(views[1].fov),
+                    },
                     swapchain_index: right_swapchain_idx,
                 },
             ],

--- a/alvr/common/src/c_api.rs
+++ b/alvr/common/src/c_api.rs
@@ -1,0 +1,103 @@
+use glam::{Quat, Vec3};
+
+use crate::{Fov, Pose, ViewParams};
+
+#[repr(C)]
+pub struct AlvrFov {
+    /// Negative, radians
+    pub left: f32,
+    /// Positive, radians
+    pub right: f32,
+    /// Positive, radians
+    pub up: f32,
+    /// Negative, radians
+    pub down: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct AlvrQuat {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct AlvrPose {
+    pub orientation: AlvrQuat,
+    pub position: [f32; 3],
+}
+
+#[repr(C)]
+pub struct AlvrViewParams {
+    pub pose: AlvrPose,
+    pub fov: AlvrFov,
+}
+
+#[repr(u8)]
+pub enum AlvrCodecType {
+    H264 = 0,
+    Hevc = 1,
+    AV1 = 2,
+}
+
+pub fn to_capi_fov(fov: &Fov) -> AlvrFov {
+    AlvrFov {
+        left: fov.left,
+        right: fov.right,
+        up: fov.up,
+        down: fov.down,
+    }
+}
+
+pub fn from_capi_fov(fov: &AlvrFov) -> Fov {
+    Fov {
+        left: fov.left,
+        right: fov.right,
+        up: fov.up,
+        down: fov.down,
+    }
+}
+
+pub fn from_capi_quat(quat: &AlvrQuat) -> Quat {
+    Quat::from_xyzw(quat.x, quat.y, quat.z, quat.w)
+}
+
+pub fn to_capi_quat(quat: &Quat) -> AlvrQuat {
+    AlvrQuat {
+        x: quat.x,
+        y: quat.y,
+        z: quat.z,
+        w: quat.w,
+    }
+}
+
+pub fn to_capi_pose(pose: &Pose) -> AlvrPose {
+    AlvrPose {
+        orientation: to_capi_quat(&pose.orientation),
+        position: pose.position.to_array(),
+    }
+}
+
+pub fn from_capi_pose(pose: &AlvrPose) -> Pose {
+    Pose {
+        orientation: from_capi_quat(&pose.orientation),
+        position: Vec3::from_slice(&pose.position),
+    }
+}
+
+pub fn to_capi_view_params(view_params: &ViewParams) -> AlvrViewParams {
+    AlvrViewParams {
+        pose: to_capi_pose(&view_params.pose),
+        fov: to_capi_fov(&view_params.fov),
+    }
+}
+
+pub fn from_capi_view_params(view_params: &AlvrViewParams) -> ViewParams {
+    ViewParams {
+        pose: from_capi_pose(&view_params.pose),
+        fov: from_capi_fov(&view_params.fov),
+    }
+}

--- a/alvr/common/src/lib.rs
+++ b/alvr/common/src/lib.rs
@@ -1,4 +1,5 @@
 mod average;
+mod c_api;
 mod connection_result;
 mod inputs;
 mod logging;
@@ -17,6 +18,7 @@ pub use semver;
 pub use settings_schema;
 
 pub use average::*;
+pub use c_api::*;
 pub use connection_result::*;
 pub use inputs::*;
 pub use log::{debug, error, info, warn};

--- a/alvr/graphics/src/lobby.rs
+++ b/alvr/graphics/src/lobby.rs
@@ -1,6 +1,6 @@
 use super::{GraphicsContext, MAX_PUSH_CONSTANTS_SIZE, SDR_FORMAT};
 use alvr_common::{
-    DeviceMotion, Fov, Pose,
+    DeviceMotion, Pose, ViewParams,
     glam::{IVec2, Mat4, Quat, UVec2, Vec3},
 };
 use glyph_brush_layout::{
@@ -218,8 +218,7 @@ fn create_pipeline(
 
 pub struct LobbyViewParams {
     pub swapchain_index: u32,
-    pub pose: Pose,
-    pub fov: Fov,
+    pub view_params: ViewParams,
 }
 
 pub struct LobbyRenderer {
@@ -425,11 +424,11 @@ impl LobbyRenderer {
 
         for (view_idx, view_input) in view_params.iter().enumerate() {
             let view = Mat4::from_rotation_translation(
-                view_input.pose.orientation,
-                view_input.pose.position,
+                view_input.view_params.pose.orientation,
+                view_input.view_params.pose.position,
             )
             .inverse();
-            let view_proj = super::projection_from_fov(view_input.fov) * view;
+            let view_proj = super::projection_from_fov(view_input.view_params.fov) * view;
 
             let clear_color = if render_background {
                 Color {

--- a/alvr/server_core/cbindgen.toml
+++ b/alvr/server_core/cbindgen.toml
@@ -8,3 +8,7 @@ documentation_style = "c99"
 
 [enum]
 rename_variants = "QualifiedScreamingSnakeCase"
+
+[parse]
+parse_deps = true
+include = ["alvr_common"]


### PR DESCRIPTION
Just realized that this was possible thanks to some config in cbindgen.toml