### PR TITLE
Protocol cleanup (4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_adb"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_audio"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_core"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_audio",
  "alvr_common",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_mock"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_openxr"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_common"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_dashboard"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_adb",
  "alvr_common",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_events"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_packets",
@@ -321,14 +321,14 @@ dependencies = [
 
 [[package]]
 name = "alvr_filesystem"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "alvr_graphics"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_gui_common"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "egui",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_launcher"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_adb",
  "alvr_common",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_packets"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_core"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_adb",
  "alvr_audio",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_io"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_events",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_openvr"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_session"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_sockets"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_system_info"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "jni",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vrcompositor_wrapper"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vulkan_layer"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_xtask"
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 dependencies = [
  "alvr_filesystem",
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["alvr/*"]
 
 [workspace.package]
-version = "21.0.0-dev05"
+version = "21.0.0-dev06"
 edition = "2024"
 rust-version = "1.88"
 authors = ["alvr-org"]

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -17,7 +17,7 @@ use alvr_graphics::{
     GraphicsContext, LobbyRenderer, LobbyViewParams, SDR_FORMAT_GL, StreamRenderer,
     StreamViewParams,
 };
-use alvr_packets::{ButtonEntry, ButtonValue, FaceData};
+use alvr_packets::{ButtonEntry, ButtonValue, FaceData, TrackingData};
 use alvr_session::{
     CodecType, FoveatedEncodingConfig, MediacodecPropType, MediacodecProperty, UpscalingConfig,
 };
@@ -502,15 +502,15 @@ pub extern "C" fn alvr_send_tracking(
     };
 
     if let Some(context) = &*CLIENT_CORE_CONTEXT.lock() {
-        context.send_tracking(
-            Duration::from_nanos(poll_timestamp_ns),
+        context.send_tracking(TrackingData {
+            poll_timestamp: Duration::from_nanos(poll_timestamp_ns),
             device_motions,
             hand_skeletons,
-            FaceData {
+            face_data: FaceData {
                 eye_gazes,
                 ..Default::default()
             },
-        );
+        });
     }
 }
 

--- a/alvr/client_core/src/statistics.rs
+++ b/alvr/client_core/src/statistics.rs
@@ -16,15 +16,10 @@ pub struct StatisticsManager {
     max_history_size: usize,
     prev_vsync: Instant,
     total_pipeline_latency_average: SlidingWindowAverage<Duration>,
-    steamvr_pipeline_latency: Duration,
 }
 
 impl StatisticsManager {
-    pub fn new(
-        max_history_size: usize,
-        nominal_server_frame_interval: Duration,
-        steamvr_pipeline_frames: f32,
-    ) -> Self {
+    pub fn new(max_history_size: usize) -> Self {
         Self {
             max_history_size,
             history_buffer: VecDeque::new(),
@@ -32,9 +27,6 @@ impl StatisticsManager {
             total_pipeline_latency_average: SlidingWindowAverage::new(
                 Duration::ZERO,
                 max_history_size,
-            ),
-            steamvr_pipeline_latency: Duration::from_secs_f32(
-                steamvr_pipeline_frames * nominal_server_frame_interval.as_secs_f32(),
             ),
         }
     }
@@ -131,12 +123,5 @@ impl StatisticsManager {
     // latency used for head prediction
     pub fn average_total_pipeline_latency(&self) -> Duration {
         self.total_pipeline_latency_average.get_average()
-    }
-
-    // latency used for controllers/trackers prediction
-    pub fn tracker_prediction_offset(&self) -> Duration {
-        self.total_pipeline_latency_average
-            .get_average()
-            .saturating_sub(self.steamvr_pipeline_latency)
     }
 }

--- a/alvr/client_mock/src/main.rs
+++ b/alvr/client_mock/src/main.rs
@@ -4,7 +4,7 @@ use alvr_common::{
     glam::{Quat, UVec2, Vec3},
     parking_lot::RwLock,
 };
-use alvr_packets::FaceData;
+use alvr_packets::TrackingData;
 use alvr_session::CodecType;
 use eframe::{
     Frame, NativeOptions,
@@ -160,9 +160,9 @@ fn tracking_thread(
 
         let position = Vec3::new(0.0, input_lock.height, 0.0);
 
-        context.send_tracking(
-            timestamp_origin.elapsed(),
-            vec![(
+        context.send_tracking(TrackingData {
+            poll_timestamp: timestamp_origin.elapsed(),
+            device_motions: vec![(
                 *HEAD_ID,
                 DeviceMotion {
                     pose: Pose {
@@ -173,14 +173,9 @@ fn tracking_thread(
                     angular_velocity: Vec3::ZERO,
                 },
             )],
-            [None, None],
-            FaceData {
-                eye_gazes: [None, None],
-                fb_face_expression: None,
-                htc_eye_expression: None,
-                htc_lip_expression: None,
-            },
-        );
+            hand_skeletons: [None, None],
+            face_data: Default::default(),
+        });
 
         drop(input_lock);
 

--- a/alvr/client_openxr/src/lobby.rs
+++ b/alvr/client_openxr/src/lobby.rs
@@ -89,7 +89,7 @@ impl Lobby {
     }
 
     pub fn render(&mut self, vsync_time: Duration) -> ProjectionLayerBuilder {
-        let xr_vsync_time = xr::Time::from_nanos(vsync_time.as_nanos() as _);
+        let xr_vsync_time = crate::to_xr_time(vsync_time);
 
         let (flags, maybe_views) = self
             .xr_session

--- a/alvr/common/src/primitives.rs
+++ b/alvr/common/src/primitives.rs
@@ -77,6 +77,12 @@ fn difference_seconds(from: Duration, to: Duration) -> f32 {
 }
 
 impl DeviceMotion {
+    pub const IDENTITY: Self = DeviceMotion {
+        pose: Pose::IDENTITY,
+        linear_velocity: Vec3::ZERO,
+        angular_velocity: Vec3::ZERO,
+    };
+
     pub fn predict(&self, from_timestamp: Duration, to_timestamp: Duration) -> Self {
         let delta_time_s = difference_seconds(from_timestamp, to_timestamp);
 

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -223,8 +223,8 @@ pub struct VideoPacketHeader {
 
 // Note: face_data does not respect target_timestamp.
 #[derive(Serialize, Deserialize, Default)]
-pub struct Tracking {
-    pub target_timestamp: Duration,
+pub struct TrackingData {
+    pub poll_timestamp: Duration,
     pub device_motions: Vec<(u64, DeviceMotion)>,
     pub hand_skeletons: [Option<[Pose; 26]>; 2],
     pub face_data: FaceData,

--- a/alvr/server_core/src/c_api.rs
+++ b/alvr/server_core/src/c_api.rs
@@ -274,9 +274,9 @@ pub unsafe extern "C" fn alvr_poll_event(out_event: *mut AlvrEvent, timeout_ns: 
                     alvr_common::to_capi_view_params(&config[1]),
                 ])
             },
-            ServerCoreEvent::Tracking { sample_timestamp } => unsafe {
+            ServerCoreEvent::Tracking { poll_timestamp } => unsafe {
                 *out_event = AlvrEvent::TrackingUpdated {
-                    sample_timestamp_ns: sample_timestamp.as_nanos() as u64,
+                    sample_timestamp_ns: poll_timestamp.as_nanos() as u64,
                 };
             },
             ServerCoreEvent::Buttons(entries) => {

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -22,7 +22,7 @@ use alvr_packets::{
     AUDIO, ClientConnectionResult, ClientControlPacket, ClientListAction, ClientStatistics,
     HAPTICS, NegotiatedStreamingConfig, NegotiatedStreamingConfigExt, RealTimeConfig,
     ReservedClientControlPacket, STATISTICS, ServerControlPacket, StreamConfigPacket, TRACKING,
-    Tracking, VIDEO, VideoPacketHeader,
+    TrackingData, VIDEO, VideoPacketHeader,
 };
 use alvr_session::{
     BodyTrackingBDConfig, BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize,
@@ -835,7 +835,7 @@ fn connection_pipeline(
     let mut microphone_receiver: alvr_sockets::StreamReceiver<()> =
         stream_socket.subscribe_to_stream(AUDIO, MAX_UNREAD_PACKETS);
     let tracking_receiver =
-        stream_socket.subscribe_to_stream::<Tracking>(TRACKING, MAX_UNREAD_PACKETS);
+        stream_socket.subscribe_to_stream::<TrackingData>(TRACKING, MAX_UNREAD_PACKETS);
     let haptics_sender = stream_socket.request_stream(HAPTICS);
     let mut statics_receiver =
         stream_socket.subscribe_to_stream::<ClientStatistics>(STATISTICS, MAX_UNREAD_PACKETS);

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -20,7 +20,7 @@ use alvr_common::{
     parking_lot::Mutex,
 };
 use alvr_events::{EventType, TrackingEvent};
-use alvr_packets::{FaceData, Tracking};
+use alvr_packets::{FaceData, TrackingData};
 use alvr_session::{
     BodyTrackingConfig, HeadsetConfig, PositionRecenteringMode, RotationRecenteringMode, Settings,
     VMCConfig, settings_schema::Switch,
@@ -316,7 +316,7 @@ pub fn tracking_loop(
     ctx: &ConnectionContext,
     initial_settings: Settings,
     hand_gesture_manager: Arc<Mutex<HandGestureManager>>,
-    mut tracking_receiver: StreamReceiver<Tracking>,
+    mut tracking_receiver: StreamReceiver<TrackingData>,
     is_streaming: impl Fn() -> bool,
 ) {
     let mut gestures_button_mapping_manager =
@@ -364,7 +364,7 @@ pub fn tracking_loop(
             return;
         };
 
-        let timestamp = tracking.target_timestamp;
+        let timestamp = tracking.poll_timestamp;
 
         if let Some(stats) = &mut *ctx.statistics_manager.write() {
             stats.report_tracking_received(timestamp);
@@ -486,7 +486,7 @@ pub fn tracking_loop(
 
         ctx.events_sender
             .send(ServerCoreEvent::Tracking {
-                sample_timestamp: tracking.target_timestamp,
+                poll_timestamp: tracking.poll_timestamp,
             })
             .ok();
 


### PR DESCRIPTION
* Move prediction to server side
* Rename `Tracking` to `TrackingData`
* Refactor names of timestamp variables and fields

This PR improves the architecture for potential Monado support, by moving prediction to the server side. Also this PR supersedes https://github.com/alvr-org/ALVR/pull/2481. Video frames must still be pushed with the original tracking poll timestamp, otherwise the code to calculate the total latency breaks. The final step of the tracking rewrite is to remove timestamps as IDs altogether and use pose inter/extrapolation searching to determine their timestamps.

Tested on Quest 3/Windows

This is a breakaway PR from #2901