### PR TITLE
fix(audio): :bug: Fix input/output audio device handling

### DIFF
--- a/alvr/audio/src/windows.rs
+++ b/alvr/audio/src/windows.rs
@@ -6,11 +6,11 @@ use windows::{
         Devices::FunctionDiscovery::PKEY_Device_FriendlyName,
         Media::Audio::{
             DEVICE_STATE_ACTIVE, Endpoints::IAudioEndpointVolume, IMMDevice, IMMDeviceEnumerator,
-            MMDeviceEnumerator, eAll,
+            IMMEndpoint, MMDeviceEnumerator, eAll, eRender,
         },
         System::Com::{self, CLSCTX_ALL, COINIT_MULTITHREADED, STGM_READ},
     },
-    core::GUID,
+    core::{GUID, Interface},
 };
 
 fn get_windows_device(device: &AudioDevice) -> Result<IMMDevice> {
@@ -34,7 +34,9 @@ fn get_windows_device(device: &AudioDevice) -> Result<IMMDevice> {
                 .GetValue(&PKEY_Device_FriendlyName)?
                 .to_string();
 
-            if imm_device_name == device_name {
+            let is_output = imm_device.cast::<IMMEndpoint>()?.GetDataFlow()? == eRender;
+
+            if imm_device_name == device_name && device.is_output == is_output {
                 return Ok(imm_device);
             }
         }

--- a/alvr/dashboard/src/dashboard/components/settings.rs
+++ b/alvr/dashboard/src/dashboard/components/settings.rs
@@ -113,11 +113,10 @@ impl SettingsTab {
     }
 
     pub fn update_audio_devices(&mut self, list: AudioDevicesList) {
-        let mut all_devices = list.output.clone();
-        all_devices.extend(list.input);
+        let output_devices = list.output.clone();
 
         if let Some(json) = &self.session_settings_json {
-            let mut preset = PresetControl::new(builtin_schema::game_audio_schema(all_devices));
+            let mut preset = PresetControl::new(builtin_schema::game_audio_schema(output_devices));
             preset.update_session_settings(json);
             self.game_audio_preset = Some(preset);
 


### PR DESCRIPTION
Closes #2906

The code in alvr_audio had weird handling of `AudioDevice::is_output`. Previously there was some confusion of the meaning, either if the device is a output device (ie WASAPI eRender) or the role is output (used to record game sound). I've clarified this with the former definition. Also to make things consistent I have removed input devices from the Headset speaker preset dropdown in the dashboard. Also I've fixed device equality functions to account for the audio direction instead of just the device name.
This PR is a temporary fix until we have support in CPAL for accessing the underlying IMMDevice, which would allow to discriminate devices with same name and same audio direction.

This should be the last fix for v20.14.1, but first it will need to be tested by some others in the community with nightly.

Tested on Quest 3/Windows