### PR TITLE
Protocol cleanup (6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_adb"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_audio"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_core"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_audio",
  "alvr_common",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_mock"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_openxr"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_common"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_dashboard"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_adb",
  "alvr_common",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_events"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_packets",
@@ -321,14 +321,14 @@ dependencies = [
 
 [[package]]
 name = "alvr_filesystem"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "alvr_graphics"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_gui_common"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "egui",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_launcher"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_adb",
  "alvr_common",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_packets"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_core"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_adb",
  "alvr_audio",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_io"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_events",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_openvr"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_session"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_sockets"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_system_info"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "jni",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vrcompositor_wrapper"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vulkan_layer"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_xtask"
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 dependencies = [
  "alvr_filesystem",
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["alvr/*"]
 
 [workspace.package]
-version = "21.0.0-dev07"
+version = "21.0.0-dev08"
 edition = "2024"
 rust-version = "1.88"
 authors = ["alvr-org"]

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -490,6 +490,7 @@ pub extern "C" fn alvr_send_tracking(
                 eyes_combined,
                 ..Default::default()
             },
+            body: None,
         });
     }
 }
@@ -730,7 +731,6 @@ pub extern "C" fn alvr_render_lobby_opengl(
             renderer.render(
                 view_inputs,
                 [(None, None), (None, None)],
-                None,
                 None,
                 None,
                 render_background,

--- a/alvr/client_mock/src/main.rs
+++ b/alvr/client_mock/src/main.rs
@@ -4,7 +4,7 @@ use alvr_common::{
     glam::{Quat, UVec2, Vec3},
     parking_lot::RwLock,
 };
-use alvr_packets::TrackingData;
+use alvr_packets::{FaceData, TrackingData};
 use alvr_session::CodecType;
 use eframe::{
     Frame, NativeOptions,
@@ -174,7 +174,8 @@ fn tracking_thread(
                 },
             )],
             hand_skeletons: [None, None],
-            face: Default::default(),
+            face: FaceData::default(),
+            body: None,
         });
 
         drop(input_lock);

--- a/alvr/client_openxr/src/extra_extensions/body_tracking_bd.rs
+++ b/alvr/client_openxr/src/extra_extensions/body_tracking_bd.rs
@@ -17,14 +17,6 @@ static TYPE_BODY_JOINT_LOCATIONS_BD: LazyLock<xr::StructureType> =
 static TYPE_SYSTEM_BODY_TRACKING_PROPERTIES_BD: LazyLock<xr::StructureType> =
     LazyLock::new(|| xr::StructureType::from_raw(1000385004));
 
-pub const BODY_JOINT_PELVIS_BD: usize = 0;
-pub const BODY_JOINT_LEFT_KNEE_BD: usize = 4;
-pub const BODY_JOINT_RIGHT_KNEE_BD: usize = 5;
-pub const BODY_JOINT_SPINE3_BD: usize = 9;
-pub const BODY_JOINT_LEFT_FOOT_BD: usize = 10;
-pub const BODY_JOINT_RIGHT_FOOT_BD: usize = 11;
-pub const BODY_JOINT_LEFT_ELBOW_BD: usize = 18;
-pub const BODY_JOINT_RIGHT_ELBOW_BD: usize = 19;
 pub const BODY_JOINT_COUNT_BD: usize = 24;
 
 #[repr(transparent)]

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -299,7 +299,7 @@ pub fn entry_point() {
                     high_accuracy: true,
                     prompt_calibration_on_start: false,
                 },
-                ..Default::default()
+                meta: Default::default(),
             })
         } else {
             None

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -8,7 +8,6 @@ mod stream;
 
 use crate::stream::ParsedStreamConfig;
 use alvr_client_core::{ClientCapabilities, ClientCoreContext, ClientCoreEvent};
-use alvr_common::settings_schema::Switch;
 use alvr_common::{
     Fov, HAND_LEFT_ID, Pose, error,
     glam::{Quat, UVec2, Vec3},
@@ -292,16 +291,22 @@ pub fn entry_point() {
             default_view_resolution,
             &last_lobby_message,
         );
-        let lobby_body_tracking_config = BodyTrackingSourcesConfig {
-            body_tracking_fb: Switch::Disabled,
-            body_tracking_bd: Switch::Enabled(BodyTrackingBDConfig::BodyTracking {
-                high_accuracy: true,
-                prompt_calibration_on_start: false,
-            }),
+
+        // For Meta/Quest enabling body tracking would disable multimodal input
+        let lobby_body_tracking_config = if platform.is_pico() {
+            Some(BodyTrackingSourcesConfig {
+                bd: BodyTrackingBDConfig::BodyTracking {
+                    high_accuracy: true,
+                    prompt_calibration_on_start: false,
+                },
+                ..Default::default()
+            })
+        } else {
+            None
         };
         let lobby_interaction_sources = InteractionSourcesConfig {
             face_tracking: None,
-            body_tracking: Some(lobby_body_tracking_config),
+            body_tracking: lobby_body_tracking_config,
             prefers_multimodal_input: true,
         };
         interaction_context

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -601,25 +601,13 @@ fn stream_input_loop(
             now,
         );
 
-        if let Some((tracker, joint_count)) = &int_ctx.body_sources.body_tracker_fb {
-            device_motions.append(&mut interaction::get_fb_body_tracking_points(
-                stage_reference_space,
-                now,
-                tracker,
-                *joint_count,
-            ));
-        }
+        let body = int_ctx
+            .body_source
+            .as_ref()
+            .and_then(|source| interaction::get_body_skeleton(source, stage_reference_space, now));
 
-        if let Some(tracker) = &int_ctx.body_sources.body_tracker_bd {
-            device_motions.append(&mut interaction::get_bd_body_tracking_points(
-                stage_reference_space,
-                now,
-                tracker,
-            ));
-        }
-
-        if let Some(tracker) = &int_ctx.body_sources.motion_tracker_bd {
-            device_motions.append(&mut interaction::get_bd_motion_trackers(now, tracker));
+        if let Some(source) = &int_ctx.body_source {
+            device_motions.append(&mut interaction::get_bd_motion_trackers(source, now));
         }
 
         // Even though the server is already adding the motion-to-photon latency, here we use
@@ -632,6 +620,7 @@ fn stream_input_loop(
             device_motions,
             hand_skeletons: [left_hand_skeleton, right_hand_skeleton],
             face,
+            body,
         });
 
         let button_entries = interaction::update_buttons(&xr_session, &int_ctx.button_actions);

--- a/alvr/common/src/inputs.rs
+++ b/alvr/common/src/inputs.rs
@@ -60,6 +60,9 @@ devices! {
     (BODY_RIGHT_FOOT, "/user/body/right_foot"),
     (DETACHED_CONTROLLER_LEFT, "/user/detached_controller_meta/left"),
     (DETACHED_CONTROLLER_RIGHT, "/user/detached_controller_meta/right"),
+    (GENERIC_TRACKER_1, "/user/generic_tracker/1"),
+    (GENERIC_TRACKER_2, "/user/generic_tracker/2"),
+    (GENERIC_TRACKER_3, "/user/generic_tracker/3"),
 }
 
 pub enum ButtonType {

--- a/alvr/common/src/primitives.rs
+++ b/alvr/common/src/primitives.rs
@@ -113,3 +113,18 @@ impl ViewParams {
         fov: Fov::DUMMY,
     };
 }
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct BodySkeletonFb {
+    pub upper_body: [Option<Pose>; 18],
+    pub lower_body: Option<[Option<Pose>; 14]>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct BodySkeletonBd(pub [Option<Pose>; 24]);
+
+#[derive(Serialize, Deserialize, Clone)]
+pub enum BodySkeleton {
+    Fb(Box<BodySkeletonFb>),
+    Bd(Box<BodySkeletonBd>),
+}

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -1,5 +1,5 @@
 use alvr_common::{
-    ConnectionState, DeviceMotion, LogEntry, LogSeverity, Pose, ViewParams,
+    BodySkeleton, ConnectionState, DeviceMotion, LogEntry, LogSeverity, Pose, ViewParams,
     anyhow::Result,
     glam::{Quat, UVec2, Vec2},
     semver::Version,
@@ -232,6 +232,7 @@ pub struct TrackingData {
     pub device_motions: Vec<(u64, DeviceMotion)>,
     pub hand_skeletons: [Option<[Pose; 26]>; 2],
     pub face: FaceData,
+    pub body: Option<BodySkeleton>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -25,8 +25,8 @@ use alvr_packets::{
     TrackingData, VIDEO, VideoPacketHeader,
 };
 use alvr_session::{
-    BodyTrackingBDConfig, BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize,
-    H264Profile, OpenvrConfig, SessionConfig, SocketProtocol,
+    BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize, H264Profile,
+    OpenvrConfig, SessionConfig, SocketProtocol,
 };
 use alvr_sockets::{
     CONTROL_PORT, KEEPALIVE_INTERVAL, KEEPALIVE_TIMEOUT, PeerType, ProtoControlSocket,
@@ -111,16 +111,7 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
         .headset
         .body_tracking
         .as_option()
-        .and_then(|c| c.sources.body_tracking_fb.as_option().cloned())
-        .map(|c| c.full_body)
-        .or_else(|| {
-            settings.headset.body_tracking.as_option().map(|c| {
-                matches!(
-                    c.sources.body_tracking_bd.as_option(),
-                    Some(BodyTrackingBDConfig::BodyTracking { .. })
-                )
-            })
-        })
+        .map(|c| c.sources.meta.prefer_full_body)
         .unwrap_or(false);
 
     let mut foveation_center_size_x = 0.0;

--- a/alvr/server_core/src/tracking/body.rs
+++ b/alvr/server_core/src/tracking/body.rs
@@ -1,11 +1,29 @@
 use alvr_common::{
     BODY_CHEST_ID, BODY_HIPS_ID, BODY_LEFT_ELBOW_ID, BODY_LEFT_FOOT_ID, BODY_LEFT_KNEE_ID,
-    BODY_RIGHT_ELBOW_ID, BODY_RIGHT_FOOT_ID, BODY_RIGHT_KNEE_ID, DeviceMotion, HEAD_ID,
-    anyhow::Result,
+    BODY_RIGHT_ELBOW_ID, BODY_RIGHT_FOOT_ID, BODY_RIGHT_KNEE_ID, BodySkeleton, DeviceMotion,
+    GENERIC_TRACKER_1_ID, GENERIC_TRACKER_2_ID, GENERIC_TRACKER_3_ID, HEAD_ID, anyhow::Result,
+    glam::Vec3,
 };
 use alvr_session::BodyTrackingSinkConfig;
 use rosc::{OscMessage, OscPacket, OscType};
 use std::{collections::HashMap, net::UdpSocket, sync::LazyLock};
+
+const CHEST_FB: usize = 5;
+const HIPS_FB: usize = 1;
+const LEFT_ARM_LOWER_FB: usize = 11;
+const RIGHT_ARM_LOWER_FB: usize = 16;
+const LEFT_LOWER_LEG_META: usize = 1;
+const LEFT_FOOT_BALL_META: usize = 6;
+const RIGHT_LOWER_LEG_META: usize = 8;
+const RIGHT_FOOT_BALL_META: usize = 13;
+const PELVIS_BD: usize = 0;
+const LEFT_KNEE_BD: usize = 4;
+const RIGHT_KNEE_BD: usize = 5;
+const SPINE3_BD: usize = 9;
+const LEFT_FOOT_BD: usize = 10;
+const RIGHT_FOOT_BD: usize = 11;
+const LEFT_ELBOW_BD: usize = 18;
+const RIGHT_ELBOW_BD: usize = 19;
 
 static BODY_TRACKER_OSC_PATH_MAP: LazyLock<HashMap<u64, &'static str>> = LazyLock::new(|| {
     HashMap::from([
@@ -85,4 +103,113 @@ impl BodyTrackingSink {
             BodyTrackingSinkConfig::FakeViveTracker => {}
         }
     }
+}
+
+// TODO: make this customizable
+pub fn get_default_body_trackers_from_motion_trackers_bd(
+    device_motions: &[(u64, DeviceMotion)],
+) -> Vec<(u64, DeviceMotion)> {
+    let mut poses = Vec::new();
+    for (id, motion) in device_motions {
+        if *id == *GENERIC_TRACKER_1_ID {
+            poses.push((*BODY_HIPS_ID, *motion));
+        } else if *id == *GENERIC_TRACKER_2_ID {
+            poses.push((*BODY_LEFT_FOOT_ID, *motion));
+        } else if *id == *GENERIC_TRACKER_3_ID {
+            poses.push((*BODY_RIGHT_FOOT_ID, *motion));
+        }
+    }
+
+    poses
+}
+
+// Obtain predefined joints as trackers
+// TODO: make this customizable
+pub fn extract_default_trackers(skeleton: &BodySkeleton) -> Vec<(u64, DeviceMotion)> {
+    let mut poses = Vec::new();
+
+    match skeleton {
+        BodySkeleton::Fb(skeleton) => {
+            if let Some(pose) = skeleton.upper_body[CHEST_FB] {
+                poses.push((*BODY_CHEST_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.upper_body[HIPS_FB] {
+                poses.push((*BODY_HIPS_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.upper_body[LEFT_ARM_LOWER_FB] {
+                poses.push((*BODY_LEFT_ELBOW_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.upper_body[RIGHT_ARM_LOWER_FB] {
+                poses.push((*BODY_RIGHT_ELBOW_ID, pose));
+            }
+
+            if let Some(lower_body) = skeleton.lower_body {
+                if let Some(pose) = lower_body[LEFT_LOWER_LEG_META] {
+                    poses.push((*BODY_LEFT_KNEE_ID, pose));
+                }
+
+                if let Some(pose) = lower_body[LEFT_FOOT_BALL_META] {
+                    poses.push((*BODY_LEFT_FOOT_ID, pose));
+                }
+
+                if let Some(pose) = lower_body[RIGHT_LOWER_LEG_META] {
+                    poses.push((*BODY_RIGHT_KNEE_ID, pose));
+                }
+
+                if let Some(pose) = lower_body[RIGHT_FOOT_BALL_META] {
+                    poses.push((*BODY_RIGHT_FOOT_ID, pose));
+                }
+            }
+        }
+        BodySkeleton::Bd(skeleton) => {
+            if let Some(pose) = skeleton.0[SPINE3_BD] {
+                poses.push((*BODY_HIPS_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.0[PELVIS_BD] {
+                poses.push((*BODY_CHEST_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.0[LEFT_ELBOW_BD] {
+                poses.push((*BODY_LEFT_ELBOW_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.0[RIGHT_ELBOW_BD] {
+                poses.push((*BODY_RIGHT_ELBOW_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.0[LEFT_KNEE_BD] {
+                poses.push((*BODY_LEFT_KNEE_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.0[LEFT_FOOT_BD] {
+                poses.push((*BODY_LEFT_FOOT_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.0[RIGHT_KNEE_BD] {
+                poses.push((*BODY_RIGHT_KNEE_ID, pose));
+            }
+
+            if let Some(pose) = skeleton.0[RIGHT_FOOT_BD] {
+                poses.push((*BODY_RIGHT_FOOT_ID, pose));
+            }
+        }
+    }
+
+    poses
+        .iter()
+        .map(|(id, pose)| {
+            (
+                *id,
+                DeviceMotion {
+                    pose: *pose,
+                    linear_velocity: Vec3::ZERO,
+                    angular_velocity: Vec3::ZERO,
+                },
+            )
+        })
+        .collect()
 }

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -344,7 +344,7 @@ pub fn tracking_loop(
             Err(ConnectionError::TryAgain(_)) => continue,
             Err(ConnectionError::Other(_)) => return,
         };
-        let Ok(tracking) = data.get_header() else {
+        let Ok(mut tracking) = data.get_header() else {
             return;
         };
 
@@ -368,6 +368,15 @@ pub fn tracking_loop(
             let mut tracking_manager_lock = ctx.tracking_manager.write();
             let session_manager_lock = SESSION_MANAGER.read();
             let headset_config = &session_manager_lock.settings().headset;
+
+            tracking.device_motions.extend_from_slice(
+                &body::get_default_body_trackers_from_motion_trackers_bd(&tracking.device_motions),
+            );
+            if let Some(skeleton) = &tracking.body {
+                tracking
+                    .device_motions
+                    .extend_from_slice(&body::extract_default_trackers(skeleton));
+            }
 
             let device_motion_keys = tracking
                 .device_motions

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -896,25 +896,12 @@ pub struct FaceTrackingConfig {
     pub sink: FaceTrackingSinkConfig,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
-pub struct BodyTrackingSourcesConfig {
-    pub body_tracking_fb: Switch<BodyTrackingFBConfig>,
-    #[schema(strings(
-        help = "It's recommended to set Tracking Mode to Full-Body Tracking in Motion Tracker app settings on your Pico headset."
-    ))]
-    pub body_tracking_bd: Switch<BodyTrackingBDConfig>,
-    // todo:
-    // pub detached_controllers_as_feet: bool,
-    // unfortunately multimodal is incompatible with body tracking. To make this usable we need to
-    // at least add support for an android client as 3dof waist tracker.
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Default)]
+pub struct BodyTrackingMetaConfig {
+    pub prefer_full_body: bool,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
-pub struct BodyTrackingFBConfig {
-    pub full_body: bool,
-}
-
-#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[schema(gui = "button_group")]
 pub enum BodyTrackingBDConfig {
     #[schema(strings(display_name = "Body Tracking"))]
@@ -928,8 +915,16 @@ pub enum BodyTrackingBDConfig {
         ))]
         prompt_calibration_on_start: bool,
     },
+
+    #[default]
     #[schema(strings(display_name = "Object Tracking"))]
     ObjectTracking,
+}
+
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Default)]
+pub struct BodyTrackingSourcesConfig {
+    pub meta: BodyTrackingMetaConfig,
+    pub bd: BodyTrackingBDConfig,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -1893,19 +1888,15 @@ pub fn session_settings_default() -> SettingsDefault {
                 content: BodyTrackingConfigDefault {
                     gui_collapsed: true,
                     sources: BodyTrackingSourcesConfigDefault {
-                        body_tracking_fb: SwitchDefault {
-                            enabled: true,
-                            content: BodyTrackingFBConfigDefault { full_body: true },
+                        meta: BodyTrackingMetaConfigDefault {
+                            prefer_full_body: true,
                         },
-                        body_tracking_bd: SwitchDefault {
-                            enabled: true,
-                            content: BodyTrackingBDConfigDefault {
-                                BodyTracking: BodyTrackingBDConfigBodyTrackingDefault {
-                                    high_accuracy: true,
-                                    prompt_calibration_on_start: true,
-                                },
-                                variant: BodyTrackingBDConfigDefaultVariant::BodyTracking,
+                        bd: BodyTrackingBDConfigDefault {
+                            BodyTracking: BodyTrackingBDConfigBodyTrackingDefault {
+                                high_accuracy: true,
+                                prompt_calibration_on_start: true,
                             },
+                            variant: BodyTrackingBDConfigDefaultVariant::BodyTracking,
                         },
                     },
                     sink: BodyTrackingSinkConfigDefault {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -901,7 +901,7 @@ pub struct BodyTrackingMetaConfig {
     pub prefer_full_body: bool,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Default)]
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
 #[schema(gui = "button_group")]
 pub enum BodyTrackingBDConfig {
     #[schema(strings(display_name = "Body Tracking"))]
@@ -916,12 +916,11 @@ pub enum BodyTrackingBDConfig {
         prompt_calibration_on_start: bool,
     },
 
-    #[default]
     #[schema(strings(display_name = "Object Tracking"))]
     ObjectTracking,
 }
 
-#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq, Default)]
+#[derive(SettingsSchema, Serialize, Deserialize, Clone, PartialEq)]
 pub struct BodyTrackingSourcesConfig {
     pub meta: BodyTrackingMetaConfig,
     pub bd: BodyTrackingBDConfig,


### PR DESCRIPTION
* Use body skeleton inside TrackingData and extract default trackers on the server side
* Send Pico motion trackers as generic trackers and assign default trackers on the server side

This is the last piece from #2901

Tested on Quest 3/Windows