### PR TITLE
Protocol cleanup (7): Reserved to normal packet variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_adb"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_audio"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_core"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_audio",
  "alvr_common",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_mock"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_openxr"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_common"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_dashboard"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_adb",
  "alvr_common",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_events"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_packets",
@@ -321,14 +321,14 @@ dependencies = [
 
 [[package]]
 name = "alvr_filesystem"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "alvr_graphics"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_gui_common"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "egui",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_launcher"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_adb",
  "alvr_common",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_packets"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_core"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_adb",
  "alvr_audio",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_io"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_events",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_openvr"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_session"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_sockets"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_system_info"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "jni",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vrcompositor_wrapper"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vulkan_layer"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_xtask"
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 dependencies = [
  "alvr_filesystem",
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["alvr/*"]
 
 [workspace.package]
-version = "21.0.0-dev08"
+version = "21.0.0-dev09"
 edition = "2024"
 rust-version = "1.88"
 authors = ["alvr-org"]

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -367,21 +367,19 @@ pub extern "C" fn alvr_send_playspace(width: f32, height: f32) {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn alvr_send_active_interaction_profile(device_id: u64, profile_id: u64) {
-    if let Some(context) = &*CLIENT_CORE_CONTEXT.lock() {
-        context.send_active_interaction_profile(device_id, profile_id);
-    }
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn alvr_send_custom_interaction_profile(
+pub extern "C" fn alvr_send_active_interaction_profile(
     device_id: u64,
+    profile_id: u64,
     input_ids_ptr: *const u64,
     input_ids_count: u64,
 ) {
     let input_ids = unsafe { slice::from_raw_parts(input_ids_ptr, input_ids_count as usize) };
     if let Some(context) = &*CLIENT_CORE_CONTEXT.lock() {
-        context.send_custom_interaction_profile(device_id, input_ids.iter().cloned().collect());
+        context.send_active_interaction_profile(
+            device_id,
+            profile_id,
+            input_ids.iter().cloned().collect(),
+        );
     }
 }
 

--- a/alvr/client_core/src/c_api.rs
+++ b/alvr/client_core/src/c_api.rs
@@ -373,7 +373,12 @@ pub extern "C" fn alvr_send_active_interaction_profile(
     input_ids_ptr: *const u64,
     input_ids_count: u64,
 ) {
-    let input_ids = unsafe { slice::from_raw_parts(input_ids_ptr, input_ids_count as usize) };
+    let input_ids = if !input_ids_ptr.is_null() {
+        unsafe { slice::from_raw_parts(input_ids_ptr, input_ids_count as usize) }
+    } else {
+        &[]
+    };
+
     if let Some(context) = &*CLIENT_CORE_CONTEXT.lock() {
         context.send_active_interaction_profile(
             device_id,

--- a/alvr/client_core/src/lib.rs
+++ b/alvr/client_core/src/lib.rs
@@ -24,8 +24,7 @@ use alvr_common::{
     warn,
 };
 use alvr_packets::{
-    BatteryInfo, ButtonEntry, ClientControlPacket, RealTimeConfig, ReservedClientControlPacket,
-    StreamConfig, TrackingData,
+    BatteryInfo, ButtonEntry, ClientControlPacket, RealTimeConfig, StreamConfig, TrackingData,
 };
 use alvr_session::CodecType;
 use connection::{ConnectionContext, DecoderCallback};
@@ -173,7 +172,12 @@ impl ClientCoreContext {
         }
     }
 
-    pub fn send_active_interaction_profile(&self, device_id: u64, profile_id: u64) {
+    pub fn send_active_interaction_profile(
+        &self,
+        device_id: u64,
+        profile_id: u64,
+        input_ids: HashSet<u64>,
+    ) {
         dbg_client_core!("send_active_interaction_profile");
 
         if let Some(sender) = &mut *self.connection_context.control_sender.lock() {
@@ -181,22 +185,8 @@ impl ClientCoreContext {
                 .send(&ClientControlPacket::ActiveInteractionProfile {
                     device_id,
                     profile_id,
+                    input_ids,
                 })
-                .ok();
-        }
-    }
-
-    pub fn send_custom_interaction_profile(&self, device_id: u64, input_ids: HashSet<u64>) {
-        dbg_client_core!("send_custom_interaction_profile");
-
-        if let Some(sender) = &mut *self.connection_context.control_sender.lock() {
-            sender
-                .send(&alvr_packets::encode_reserved_client_control_packet(
-                    &ReservedClientControlPacket::CustomInteractionProfile {
-                        device_id,
-                        input_ids,
-                    },
-                ))
                 .ok();
         }
     }

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -199,14 +199,19 @@ impl StreamContext {
             config.upscaling.clone(),
         );
 
-        core_ctx.send_active_interaction_profile(
-            *HAND_LEFT_ID,
-            interaction_ctx.read().hands_interaction[0].controllers_profile_id,
-        );
-        core_ctx.send_active_interaction_profile(
-            *HAND_RIGHT_ID,
-            interaction_ctx.read().hands_interaction[1].controllers_profile_id,
-        );
+        {
+            let int_ctx = interaction_ctx.read();
+            core_ctx.send_active_interaction_profile(
+                *HAND_LEFT_ID,
+                int_ctx.hands_interaction[0].controllers_profile_id,
+                int_ctx.hands_interaction[0].input_ids.clone(),
+            );
+            core_ctx.send_active_interaction_profile(
+                *HAND_RIGHT_ID,
+                int_ctx.hands_interaction[1].controllers_profile_id,
+                int_ctx.hands_interaction[1].input_ids.clone(),
+            );
+        }
 
         let input_thread_running = Arc::new(RelaxedAtomic::new(false));
 

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -152,7 +152,7 @@ pub enum ServerControlPacket {
     DecoderConfig(DecoderInitializationConfig),
     Restarting,
     KeepAlive,
-    ServerPredictionAverage(Duration), // todo: remove
+    RealTimeConfig(RealTimeConfig),
     Reserved(String),
     ReservedBuffer(Vec<u8>),
 }
@@ -176,32 +176,24 @@ pub struct ButtonEntry {
     pub value: ButtonValue,
 }
 
-// to be de/serialized with ClientControlPacket::Reserved()
-#[derive(Serialize, Deserialize)]
-pub enum ReservedClientControlPacket {
-    CustomInteractionProfile {
-        device_id: u64,
-        input_ids: HashSet<u64>,
-    },
-}
-
-pub fn encode_reserved_client_control_packet(
-    packet: &ReservedClientControlPacket,
-) -> ClientControlPacket {
-    ClientControlPacket::Reserved(json::to_string(packet).unwrap())
-}
-
 #[derive(Serialize, Deserialize)]
 pub enum ClientControlPacket {
     PlayspaceSync(Option<Vec2>),
     RequestIdr,
     KeepAlive,
     StreamReady, // This flag notifies the server the client streaming socket is ready listening
-    LocalViewParams([ViewParams; 2]), // Head-to_view
+    LocalViewParams([ViewParams; 2]), // In relation to head
     Battery(BatteryInfo),
     Buttons(Vec<ButtonEntry>),
-    ActiveInteractionProfile { device_id: u64, profile_id: u64 },
-    Log { level: LogSeverity, message: String },
+    ActiveInteractionProfile {
+        device_id: u64,
+        profile_id: u64,
+        input_ids: HashSet<u64>,
+    },
+    Log {
+        level: LogSeverity,
+        message: String,
+    },
     Reserved(String),
     ReservedBuffer(Vec<u8>),
 }
@@ -356,23 +348,14 @@ pub enum ServerRequest {
 
 // Note: server sends a packet to the client at low frequency, binary encoding, without ensuring
 // compatibility between different versions, even if within the same major version.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Clone)]
 pub struct RealTimeConfig {
     pub passthrough: Option<PassthroughMode>,
     pub clientside_post_processing: Option<ClientsidePostProcessingConfig>,
+    pub ext_str: String,
 }
 
 impl RealTimeConfig {
-    pub fn encode(&self) -> Result<ServerControlPacket> {
-        Ok(ServerControlPacket::ReservedBuffer(bincode::serialize(
-            self,
-        )?))
-    }
-
-    pub fn decode(buffer: &[u8]) -> Result<Self> {
-        Ok(bincode::deserialize(buffer)?)
-    }
-
     pub fn from_settings(settings: &Settings) -> Self {
         Self {
             passthrough: settings.video.passthrough.clone().into_option(),
@@ -381,6 +364,7 @@ impl RealTimeConfig {
                 .clientside_post_processing
                 .clone()
                 .into_option(),
+            ext_str: String::new(), // No extensions for now
         }
     }
 }

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -1068,20 +1068,17 @@ fn connection_pipeline(
                     RealTimeConfig::from_settings(settings)
                 };
 
-                if let Some(previous_config) = &previous_config
-                    && config != *previous_config
-                {
-                    thread::sleep(REAL_TIME_UPDATE_INTERVAL);
-                } else {
+                let same_config = previous_config.as_ref().is_some_and(|prev| config == *prev);
+                if !same_config {
                     previous_config = Some(config.clone());
 
                     control_sender
                         .lock()
                         .send(&ServerControlPacket::RealTimeConfig(config))
                         .ok();
-
-                    thread::sleep(REAL_TIME_UPDATE_INTERVAL);
                 }
+
+                thread::sleep(REAL_TIME_UPDATE_INTERVAL);
             }
         }
     });

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -20,9 +20,8 @@ use alvr_common::{
 use alvr_events::{AdbEvent, ButtonEvent, EventType};
 use alvr_packets::{
     AUDIO, ClientConnectionResult, ClientControlPacket, ClientListAction, ClientStatistics,
-    HAPTICS, NegotiatedStreamingConfig, NegotiatedStreamingConfigExt, RealTimeConfig,
-    ReservedClientControlPacket, STATISTICS, ServerControlPacket, StreamConfigPacket, TRACKING,
-    TrackingData, VIDEO, VideoPacketHeader,
+    HAPTICS, NegotiatedStreamingConfig, NegotiatedStreamingConfigExt, RealTimeConfig, STATISTICS,
+    ServerControlPacket, StreamConfigPacket, TRACKING, TrackingData, VIDEO, VideoPacketHeader,
 };
 use alvr_session::{
     BodyTrackingSinkConfig, CodecType, ControllersEmulationMode, FrameSize, H264Profile,
@@ -1060,6 +1059,7 @@ fn connection_pipeline(
         let control_sender = Arc::clone(&control_sender);
         let client_hostname = client_hostname.clone();
         move || {
+            let mut previous_config = None;
             while is_streaming(&client_hostname) {
                 let config = {
                     let session_manager_lock = SESSION_MANAGER.read();
@@ -1068,11 +1068,20 @@ fn connection_pipeline(
                     RealTimeConfig::from_settings(settings)
                 };
 
-                if let Ok(config) = config.encode() {
-                    control_sender.lock().send(&config).ok();
-                }
+                if let Some(previous_config) = &previous_config
+                    && config != *previous_config
+                {
+                    thread::sleep(REAL_TIME_UPDATE_INTERVAL);
+                } else {
+                    previous_config = Some(config.clone());
 
-                thread::sleep(REAL_TIME_UPDATE_INTERVAL);
+                    control_sender
+                        .lock()
+                        .send(&ServerControlPacket::RealTimeConfig(config))
+                        .ok();
+
+                    thread::sleep(REAL_TIME_UPDATE_INTERVAL);
+                }
             }
         }
     });
@@ -1232,23 +1241,20 @@ fn connection_pipeline(
                             }
                         };
                     }
-                    ClientControlPacket::ActiveInteractionProfile { profile_id, .. } => {
+                    ClientControlPacket::ActiveInteractionProfile { input_ids, .. } => {
                         controller_button_mapping_manager = if let Switch::Enabled(config) =
                             &SESSION_MANAGER.read().settings().headset.controllers
                         {
                             if let Some(mappings) = &config.button_mappings {
                                 Some(ButtonMappingManager::new_manual(mappings))
-                            } else if let Some(profile_info) =
-                                CONTROLLER_PROFILE_INFO.get(&profile_id)
-                                && let Some(emulation_mode) = &controllers_emulation_mode
-                            {
-                                Some(ButtonMappingManager::new_automatic(
-                                    &profile_info.button_set,
-                                    emulation_mode,
-                                    &config.button_mapping_config,
-                                ))
                             } else {
-                                None
+                                controllers_emulation_mode.as_ref().map(|emulation_mode| {
+                                    ButtonMappingManager::new_automatic(
+                                        &input_ids,
+                                        emulation_mode,
+                                        &config.button_mapping_config,
+                                    )
+                                })
                             }
                         } else {
                             None
@@ -1257,45 +1263,8 @@ fn connection_pipeline(
                     ClientControlPacket::Log { level, message } => {
                         info!("Client {client_hostname}: [{level:?}] {message}")
                     }
-                    ClientControlPacket::Reserved(json_string) => {
-                        let reserved: ReservedClientControlPacket = match serde_json::from_str(
-                            &json_string,
-                        ) {
-                            Ok(reserved) => reserved,
-                            Err(e) => {
-                                info!(
-                                    "Failed to parse reserved packet: {e}. Packet: {json_string}"
-                                );
-                                continue;
-                            }
-                        };
-
-                        match reserved {
-                            ReservedClientControlPacket::CustomInteractionProfile {
-                                input_ids,
-                                ..
-                            } => {
-                                controller_button_mapping_manager = if let Switch::Enabled(config) =
-                                    &SESSION_MANAGER.read().settings().headset.controllers
-                                {
-                                    if let Some(mappings) = &config.button_mappings {
-                                        Some(ButtonMappingManager::new_manual(mappings))
-                                    } else {
-                                        controllers_emulation_mode.as_ref().map(|emulation_mode| {
-                                            ButtonMappingManager::new_automatic(
-                                                &input_ids,
-                                                emulation_mode,
-                                                &config.button_mapping_config,
-                                            )
-                                        })
-                                    }
-                                } else {
-                                    None
-                                };
-                            }
-                        }
-                    }
-                    _ => (),
+                    ClientControlPacket::KeepAlive | ClientControlPacket::StreamReady => (),
+                    ClientControlPacket::Reserved(_) | ClientControlPacket::ReservedBuffer(_) => (),
                 }
 
                 disconnection_deadline = Instant::now() + KEEPALIVE_TIMEOUT;


### PR DESCRIPTION
* Merge "active_interaction_profile" and "custom_interaction_profile"
* Add `RealTimeConfig` variant
* Don't send RealTimeConfig if not changed (Note: packets are sent with reliable ControlSocket)
* Explicit all matched packet variants even if unused

Tested