### PR TITLE
fix(dashboard): :bug: Remove devices from Headset speaker dropdown

### DIFF
--- a/alvr/dashboard/src/dashboard/components/settings.rs
+++ b/alvr/dashboard/src/dashboard/components/settings.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use crate::dashboard::ServerRequest;
 use alvr_gui_common::{DisplayString, theme};
-use alvr_packets::AudioDevicesList;
 use alvr_session::{SessionSettings, Settings};
 use eframe::egui::{self, Align, Frame, Grid, Layout, RichText, ScrollArea, Ui};
 #[cfg(target_arch = "wasm32")]
@@ -30,8 +29,8 @@ pub struct SettingsTab {
     encoder_preset: PresetControl,
     foveation_preset: PresetControl,
     codec_preset: PresetControl,
-    game_audio_preset: Option<PresetControl>,
-    microphone_preset: Option<PresetControl>,
+    game_audio_preset: PresetControl,
+    microphone_preset: PresetControl,
     hand_tracking_interaction_preset: PresetControl,
     eye_face_tracking_preset: PresetControl,
     top_level_entries: Vec<TopLevelEntry>,
@@ -75,8 +74,8 @@ impl SettingsTab {
             encoder_preset: PresetControl::new(builtin_schema::encoder_preset_schema()),
             foveation_preset: PresetControl::new(builtin_schema::foveation_preset_schema()),
             codec_preset: PresetControl::new(builtin_schema::codec_preset_schema()),
-            game_audio_preset: None,
-            microphone_preset: None,
+            game_audio_preset: PresetControl::new(builtin_schema::game_audio_schema()),
+            microphone_preset: PresetControl::new(builtin_schema::microphone_schema()),
             hand_tracking_interaction_preset: PresetControl::new(
                 builtin_schema::hand_tracking_interaction_schema(),
             ),
@@ -98,32 +97,16 @@ impl SettingsTab {
         self.foveation_preset
             .update_session_settings(&settings_json);
         self.codec_preset.update_session_settings(&settings_json);
-        if let Some(preset) = self.game_audio_preset.as_mut() {
-            preset.update_session_settings(&settings_json)
-        }
-        if let Some(preset) = self.microphone_preset.as_mut() {
-            preset.update_session_settings(&settings_json)
-        }
+        self.game_audio_preset
+            .update_session_settings(&settings_json);
+        self.microphone_preset
+            .update_session_settings(&settings_json);
         self.hand_tracking_interaction_preset
             .update_session_settings(&settings_json);
         self.eye_face_tracking_preset
             .update_session_settings(&settings_json);
 
         self.session_settings_json = Some(settings_json);
-    }
-
-    pub fn update_audio_devices(&mut self, list: AudioDevicesList) {
-        let output_devices = list.output.clone();
-
-        if let Some(json) = &self.session_settings_json {
-            let mut preset = PresetControl::new(builtin_schema::game_audio_schema(output_devices));
-            preset.update_session_settings(json);
-            self.game_audio_preset = Some(preset);
-
-            let mut preset = PresetControl::new(builtin_schema::microphone_schema());
-            preset.update_session_settings(json);
-            self.microphone_preset = Some(preset);
-        }
     }
 
     pub fn ui(&mut self, ui: &mut Ui) -> Vec<ServerRequest> {
@@ -133,10 +116,6 @@ impl SettingsTab {
         if now > self.last_update_instant + DATA_UPDATE_INTERVAL {
             if self.session_settings_json.is_none() {
                 requests.push(ServerRequest::GetSession);
-            }
-
-            if self.game_audio_preset.is_none() {
-                requests.push(ServerRequest::GetAudioDevices);
             }
 
             self.last_update_instant = now;
@@ -189,15 +168,11 @@ impl SettingsTab {
                             path_value_pairs.extend(self.codec_preset.ui(ui));
                             ui.end_row();
 
-                            if let Some(preset) = &mut self.game_audio_preset {
-                                path_value_pairs.extend(preset.ui(ui));
-                                ui.end_row();
-                            }
+                            path_value_pairs.extend(self.game_audio_preset.ui(ui));
+                            ui.end_row();
 
-                            if let Some(preset) = &mut self.microphone_preset {
-                                path_value_pairs.extend(preset.ui(ui));
-                                ui.end_row();
-                            }
+                            path_value_pairs.extend(self.microphone_preset.ui(ui));
+                            ui.end_row();
 
                             path_value_pairs.extend(self.hand_tracking_interaction_preset.ui(ui));
                             ui.end_row();

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
@@ -231,7 +231,7 @@ shutterring and high encode/decode latency!"
 }
 
 #[cfg(target_os = "linux")]
-pub fn game_audio_schema(_: Vec<String>) -> PresetSchemaNode {
+pub fn game_audio_schema() -> PresetSchemaNode {
     PresetSchemaNode::HigherOrderChoice(HigherOrderChoiceSchema {
         name: "Headset speaker".into(),
         strings: HashMap::new(),
@@ -293,60 +293,42 @@ pub fn microphone_schema() -> PresetSchemaNode {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn game_audio_schema(devices: Vec<String>) -> PresetSchemaNode {
-    let mut game_audio_options = vec![
-        HigherOrderChoiceOption {
-            display_name: "Disabled".into(),
-            modifiers: vec![bool_modifier(
-                "session_settings.audio.game_audio.enabled",
-                false,
-            )],
-            content: None,
-        },
-        HigherOrderChoiceOption {
-            display_name: "System Default".to_owned(),
-            modifiers: vec![
-                bool_modifier("session_settings.audio.game_audio.enabled", true),
-                bool_modifier(
-                    "session_settings.audio.game_audio.content.device.set",
-                    false,
-                ),
-            ],
-            content: None,
-        },
-    ];
-
-    for name in devices {
-        game_audio_options.push(HigherOrderChoiceOption {
-            display_name: name.clone(),
-            modifiers: vec![
-                bool_modifier("session_settings.audio.game_audio.enabled", true),
-                bool_modifier("session_settings.audio.game_audio.content.device.set", true),
-                string_modifier(
-                    "session_settings.audio.game_audio.content.device.content.variant",
-                    "NameSubstring",
-                ),
-                string_modifier(
-                    "session_settings.audio.game_audio.content.device.content.NameSubstring",
-                    &name,
-                ),
-            ],
-            content: None,
-        })
-    }
-
+pub fn game_audio_schema() -> PresetSchemaNode {
     PresetSchemaNode::HigherOrderChoice(HigherOrderChoiceSchema {
         name: "Headset speaker".into(),
         strings: [(
-            "help".into(),
-            "You should keep this as default. Change the default audio device from the global OS settings".into(),
+            "notice".into(),
+            "You can change the default audio device from the system taskbar tray (bottom right)"
+                .into(),
         )]
         .into_iter()
         .collect(),
         flags: HashSet::new(),
-        options: game_audio_options.into_iter().collect(),
+        options: vec![
+            HigherOrderChoiceOption {
+                display_name: "Disabled".into(),
+                modifiers: vec![bool_modifier(
+                    "session_settings.audio.game_audio.enabled",
+                    false,
+                )],
+                content: None,
+            },
+            HigherOrderChoiceOption {
+                display_name: "System Default".to_owned(),
+                modifiers: vec![
+                    bool_modifier("session_settings.audio.game_audio.enabled", true),
+                    bool_modifier(
+                        "session_settings.audio.game_audio.content.device.set",
+                        false,
+                    ),
+                ],
+                content: None,
+            },
+        ]
+        .into_iter()
+        .collect(),
         default_option_display_name: "System Default".into(),
-        gui: ChoiceControlType::Dropdown,
+        gui: ChoiceControlType::ButtonGroup,
     })
 }
 

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::schema::{HigherOrderChoiceSchema, PresetModifierOperation};
-use crate::dashboard::components::{self, INDENTATION_STEP, NestingInfo, SettingControl};
+use crate::dashboard::components::{self, INDENTATION_STEP, NestingInfo, SettingControl, notice};
 use alvr_gui_common::theme::{
     OK_GREEN,
     log_colors::{INFO_LIGHT, WARNING_LIGHT},
@@ -14,6 +14,7 @@ use settings_schema::{SchemaEntry, SchemaNode};
 pub struct Control {
     name: String,
     help: Option<String>,
+    notice: Option<String>,
     steamvr_restart_flag: bool,
     real_time_flag: bool,
     modifiers: HashMap<String, Vec<PathValuePair>>,
@@ -25,7 +26,7 @@ impl Control {
     pub fn new(schema: HigherOrderChoiceSchema) -> Self {
         let name = components::get_display_name(&schema.name, &schema.strings);
         let help = schema.strings.get("help").cloned();
-        // let notice = entry.strings.get("notice").cloned();
+        let notice = schema.strings.get("notice").cloned();
         let steamvr_restart_flag = schema.flags.contains("steamvr-restart");
         let real_time_flag = schema.flags.contains("real-time");
 
@@ -86,6 +87,7 @@ impl Control {
         Self {
             name,
             help,
+            notice,
             steamvr_restart_flag,
             real_time_flag,
             modifiers,
@@ -168,6 +170,15 @@ impl Control {
                 );
             }
         });
+
+        if let Some(string) = &self.notice {
+            notice::notice(ui, string);
+
+            ui.end_row();
+
+            ui.label(" ");
+        }
+
         response = self
             .control
             .ui(ui, &mut self.preset_json, true)

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -51,7 +51,6 @@ impl Dashboard {
     pub fn new(creation_context: &eframe::CreationContext<'_>, data_sources: DataSources) -> Self {
         alvr_gui_common::theme::set_theme(&creation_context.egui_ctx);
 
-        // Audio devices need to be queried early to mitigate buggy/slow hardware queries on Linux.
         data_sources.request(ServerRequest::GetSession);
 
         Self {

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -53,7 +53,6 @@ impl Dashboard {
 
         // Audio devices need to be queried early to mitigate buggy/slow hardware queries on Linux.
         data_sources.request(ServerRequest::GetSession);
-        data_sources.request(ServerRequest::GetAudioDevices);
 
         Self {
             data_sources,
@@ -152,7 +151,6 @@ impl eframe::App for Dashboard {
                     self.session = Some(*session);
                 }
                 EventType::ServerRequestsSelfRestart => self.restart_steamvr(&mut requests),
-                EventType::AudioDevices(list) => self.settings_tab.update_audio_devices(list),
                 #[cfg(not(target_arch = "wasm32"))]
                 EventType::DriversList(list) => self.installation_tab.update_drivers(list),
                 EventType::Adb(adb_event) => self

--- a/alvr/dashboard/src/data_sources.rs
+++ b/alvr/dashboard/src/data_sources.rs
@@ -239,15 +239,6 @@ impl DataSources {
 
                                     report_session_local(&context, &events_sender, session_manager);
                                 }
-                                ServerRequest::GetAudioDevices => {
-                                    if let Ok(list) = session_manager.get_audio_devices_list() {
-                                        report_event_local(
-                                            &context,
-                                            &events_sender,
-                                            EventType::AudioDevices(list),
-                                        )
-                                    }
-                                }
                                 ServerRequest::FirewallRules(action) => {
                                     if alvr_server_io::firewall_rules(action, &filesystem_layout)
                                         .is_ok()

--- a/alvr/events/src/lib.rs
+++ b/alvr/events/src/lib.rs
@@ -1,5 +1,5 @@
 use alvr_common::{DeviceMotion, LogEntry, LogSeverity, Pose, info};
-use alvr_packets::{AudioDevicesList, ButtonValue, FaceData};
+use alvr_packets::{ButtonValue, FaceData};
 use alvr_session::SessionConfig;
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, time::Duration};
@@ -87,7 +87,6 @@ pub enum EventType {
     Tracking(Box<TrackingEvent>),
     Buttons(Vec<ButtonEvent>),
     Haptics(HapticsEvent),
-    AudioDevices(AudioDevicesList),
     DriversList(Vec<PathBuf>),
     ServerRequestsSelfRestart,
     Adb(AdbEvent),
@@ -116,7 +115,6 @@ impl Event {
             EventType::Tracking(_) => "TRACKING".to_string(),
             EventType::Buttons(_) => "BUTTONS".to_string(),
             EventType::Haptics(_) => "HAPTICS".to_string(),
-            EventType::AudioDevices(_) => "AUDIO DEV".to_string(),
             EventType::DriversList(_) => "DRV LIST".to_string(),
             EventType::ServerRequestsSelfRestart => "RESTART".to_string(),
             EventType::Adb(_) => "ADB".to_string(),
@@ -133,7 +131,6 @@ impl Event {
             EventType::Tracking(tracking) => serde_json::to_string(tracking).unwrap(),
             EventType::Buttons(buttons) => serde_json::to_string(buttons).unwrap(),
             EventType::Haptics(haptics) => serde_json::to_string(haptics).unwrap(),
-            EventType::AudioDevices(devices) => serde_json::to_string(devices).unwrap(),
             EventType::DriversList(drivers) => serde_json::to_string(drivers).unwrap(),
             EventType::ServerRequestsSelfRestart => "Request for server restart".into(),
             EventType::Adb(adb) => serde_json::to_string(adb).unwrap(),

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -250,12 +250,6 @@ pub struct Haptics {
     pub amplitude: f32,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct AudioDevicesList {
-    pub output: Vec<String>,
-    pub input: Vec<String>,
-}
-
 #[derive(Serialize, Deserialize, Clone)]
 pub enum PathSegment {
     Name(String),
@@ -341,7 +335,6 @@ pub enum ServerRequest {
         hostname: String,
         action: ClientListAction,
     },
-    GetAudioDevices,
     CaptureFrame,
     InsertIdr,
     StartRecording,

--- a/alvr/server_core/src/web_server.rs
+++ b/alvr/server_core/src/web_server.rs
@@ -223,11 +223,6 @@ async fn http_api(
 
                         session_manager.update_client_list(hostname, action);
                     }
-                    ServerRequest::GetAudioDevices => {
-                        if let Ok(list) = crate::SESSION_MANAGER.read().get_audio_devices_list() {
-                            alvr_events::send_event(EventType::AudioDevices(list));
-                        }
-                    }
                     ServerRequest::CaptureFrame => {
                         connection_context
                             .events_sender

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -12,7 +12,7 @@ use alvr_common::{
     error, info,
 };
 use alvr_events::EventType;
-use alvr_packets::{AudioDevicesList, ClientListAction, PathSegment, PathValuePair};
+use alvr_packets::{ClientListAction, PathSegment, PathValuePair};
 use alvr_session::{ClientConnectionConfig, SessionConfig, Settings};
 use serde_json as json;
 use std::{
@@ -302,33 +302,6 @@ impl ServerSessionManager {
 
         for hostname in self.client_hostnames() {
             self.update_client_list(hostname.clone(), ClientListAction::UpdateCurrentIp(None));
-        }
-    }
-
-    pub fn get_audio_devices_list(&self) -> Result<AudioDevicesList> {
-        #[cfg(not(target_os = "linux"))]
-        {
-            use cpal::traits::{DeviceTrait, HostTrait};
-
-            let host = cpal::default_host();
-
-            let output = host
-                .output_devices()?
-                .filter_map(|d| d.name().ok())
-                .collect::<Vec<_>>();
-            let input = host
-                .input_devices()?
-                .filter_map(|d| d.name().ok())
-                .collect::<Vec<_>>();
-
-            Ok(AudioDevicesList { output, input })
-        }
-        #[cfg(target_os = "linux")]
-        {
-            Ok(AudioDevicesList {
-                input: vec![],
-                output: vec![],
-            })
         }
     }
 }

--- a/wiki/Installation-guide.md
+++ b/wiki/Installation-guide.md
@@ -37,7 +37,7 @@ To use your microphone in ALVR on Windows you need to install **Virtual Audio Ca
 ### **3. Configure ALVR**
 1. **Open ALVR** and go to **Settings**.
 2. Set **Headset Speaker** → **System Default**.
-3. Set **Headset Microphone** → **VB Cable**.
+3. Set **Headset Microphone** → **Automatic** or **Virtual Audio Cable**.
 
 ## Advanced installation
 


### PR DESCRIPTION
* Removed output devices selection from preset on Windows
* Removed all the machinery for polling audio devices in the dashboard
* Added notice support for `HigherOrderSettings` and show notice for Headset speaker preset to instruct user how to change default device 

Initially I thought of adding a way to set the system default from the ALVR side. For now I decided for this solution with required user action in case of conflict with mic device, basically keeping it like before. In the future we should automatically change output audio device in case of conflict with microphone. Removing the machinery to poll audio device in the dashboard because it will not be needed even in the future.

This PR must be merged for the v20.14.1 release