### PR TITLE
fix(ci): :green_heart: Fix CI release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare_release:
-    runs-on: windows-2019
+    runs-on: windows-2022
     outputs:
       release_ref: ${{ steps.output_ref.outputs.release_ref }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -62,12 +62,8 @@ jobs:
           commitish: ${{ steps.output_ref.outputs.release_ref }}
 
   build_windows_streamer:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [prepare_release]
-    env:
-      # For bindgen to find libclang.dll, we need to give it the path to the Visual Studio package.
-      # This is specific to the GitHub windows-2019 runner.
-      LIBCLANG_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,8 +12,6 @@ env:
 jobs:
   check-windows:
     runs-on: windows-latest
-    env:
-      LIBCLANG_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -153,8 +151,6 @@ jobs:
 
   check-msrv-windows:
     runs-on: windows-latest
-    env:
-      LIBCLANG_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The runner windows-2019 was removed some time ago.

This also removes the LIBCLANG env var, the workaround has proven to be fixed from at least the runner windows-2022