### PR TITLE
fix(dashboard): :bug: Fix unexpected version popup

### DIFF
--- a/alvr/dashboard/src/data_sources.rs
+++ b/alvr/dashboard/src/data_sources.rs
@@ -64,6 +64,12 @@ pub fn clean_session() {
         session_ref.server_version = ALVR_VERSION.clone();
         session_ref.client_connections.clear();
         session_ref.session_settings.extra.open_setup_wizard = true;
+        session_ref
+            .session_settings
+            .extra
+            .new_version_popup
+            .content
+            .hide_while_version = ALVR_VERSION.to_string();
     }
 }
 


### PR DESCRIPTION
On Linux, or when transferring over the session from an older ALVR version, the version popup appears after upgrading even when already on the latest version. In this PR i make sure to reset the checked version to the current version if it's the first time opening the dashboard.