### PR TITLE
Protocol cleanup (8): binary protocol refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_adb"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_audio"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_core"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_audio",
  "alvr_common",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_mock"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_client_openxr"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_client_core",
  "alvr_common",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_common"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_dashboard"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_adb",
  "alvr_audio",
@@ -290,7 +290,6 @@ dependencies = [
  "alvr_server_io",
  "alvr_session",
  "alvr_sockets",
- "bincode",
  "chrono",
  "cros-libva",
  "eframe",
@@ -311,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_events"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_packets",
@@ -322,14 +321,14 @@ dependencies = [
 
 [[package]]
 name = "alvr_filesystem"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "alvr_graphics"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -343,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_gui_common"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "egui",
@@ -351,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_launcher"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_adb",
  "alvr_common",
@@ -374,18 +373,17 @@ dependencies = [
 
 [[package]]
 name = "alvr_packets"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_session",
- "bincode",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alvr_server_core"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_adb",
  "alvr_audio",
@@ -397,7 +395,6 @@ dependencies = [
  "alvr_session",
  "alvr_sockets",
  "ash",
- "bincode",
  "bytes",
  "chrono",
  "fern",
@@ -419,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_io"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_events",
@@ -435,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_server_openvr"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -453,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_session"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -467,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_sockets"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_session",
@@ -480,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_system_info"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "jni",
@@ -494,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vrcompositor_wrapper"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -504,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_vulkan_layer"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_filesystem",
@@ -516,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "alvr_xtask"
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 dependencies = [
  "alvr_filesystem",
  "pico-args",
@@ -994,11 +991,22 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -5941,6 +5949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "ureq"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6038,6 +6052,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["alvr/*"]
 
 [workspace.package]
-version = "21.0.0-dev09"
+version = "21.0.0-dev10"
 edition = "2024"
 rust-version = "1.88"
 authors = ["alvr-org"]

--- a/alvr/dashboard/Cargo.toml
+++ b/alvr/dashboard/Cargo.toml
@@ -17,7 +17,6 @@ alvr_sockets.workspace = true
 alvr_gui_common.workspace = true
 alvr_audio.workspace = true
 
-bincode = "1"
 chrono = "0.4"
 eframe = "0.31"
 env_logger = "0.11"

--- a/alvr/packets/Cargo.toml
+++ b/alvr/packets/Cargo.toml
@@ -10,6 +10,5 @@ license.workspace = true
 alvr_common.workspace = true
 alvr_session.workspace = true
 
-bincode = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/alvr/server_core/Cargo.toml
+++ b/alvr/server_core/Cargo.toml
@@ -24,7 +24,6 @@ alvr_session.workspace = true
 alvr_sockets.workspace = true
 
 ash = "0.38"
-bincode = "1"
 bytes = "1"
 chrono = "0.4"
 fern = "0.7"

--- a/alvr/sockets/Cargo.toml
+++ b/alvr/sockets/Cargo.toml
@@ -13,9 +13,8 @@ trace-performance = ["profiling/profile-with-tracy"]
 alvr_common.workspace = true
 alvr_session.workspace = true
 
-bincode = "1"
+bincode = { version = "2", features = ["serde"] }
 profiling = { version = "1", optional = true }
 serde = "1"
 serde_json = "1"
 socket2 = "0.5"
-

--- a/alvr/sockets/src/control_socket.rs
+++ b/alvr/sockets/src/control_socket.rs
@@ -155,7 +155,7 @@ impl ProtoControlSocket {
     }
 
     pub fn send<S: Serialize>(&mut self, packet: &S) -> Result<()> {
-        framed_send(&mut self.inner, &mut vec![0; FRAMED_PREFIX_LENGTH], packet)
+        framed_send(&mut self.inner, &mut vec![], packet)
     }
 
     pub fn recv<R: DeserializeOwned>(&mut self, timeout: Duration) -> ConResult<R> {

--- a/alvr/sockets/src/control_socket.rs
+++ b/alvr/sockets/src/control_socket.rs
@@ -1,12 +1,9 @@
 use crate::backend::{SocketReader, SocketWriter, tcp};
 
 use super::CONTROL_PORT;
-use alvr_common::{
-    ConResult, HandleTryAgain, ToCon,
-    anyhow::{Result, bail},
-};
+use alvr_common::{ConResult, HandleTryAgain, ToCon, anyhow::Result};
 use alvr_session::SocketBufferSize;
-use bincode::{config, enc::write::SizeWriter, error::EncodeError};
+use bincode::config;
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
     marker::PhantomData,
@@ -18,45 +15,14 @@ use std::{
 // This corresponds to the length of the payload
 const FRAMED_PREFIX_LENGTH: usize = mem::size_of::<u32>();
 
-struct RecvState {
-    packet_length: usize, // contains length prefix
-    packet_cursor: usize, // counts also the length prefix bytes
-}
-
 fn framed_send<S: Serialize>(
     socket: &mut TcpStream,
     buffer: &mut Vec<u8>,
     packet: &S,
 ) -> Result<()> {
-    let maybe_size = bincode::serde::encode_into_slice(
-        packet,
-        &mut buffer[FRAMED_PREFIX_LENGTH..],
-        config::standard(),
-    );
+    buffer.resize(FRAMED_PREFIX_LENGTH, 0);
 
-    let encoded_size = match maybe_size {
-        Ok(size) => size,
-        Err(EncodeError::UnexpectedEnd) => {
-            // Obtaining the size of the encoded data is expensive, as the data would need to be
-            // encoded twice. If the buffer is not large enough, we will pay for 3 encoding times,
-            // but this should happen rarely at steady state.
-
-            let mut size_writer = SizeWriter::default();
-            bincode::serde::encode_into_writer(packet, &mut size_writer, config::standard())?;
-
-            let packet_size = FRAMED_PREFIX_LENGTH + size_writer.bytes_written;
-            if buffer.len() < packet_size {
-                buffer.resize(packet_size, 0);
-            }
-
-            bincode::serde::encode_into_slice(
-                packet,
-                &mut buffer[FRAMED_PREFIX_LENGTH..],
-                config::standard(),
-            )?
-        }
-        Err(e) => bail!("Failed to encode packet: {}", e),
-    };
+    let encoded_size = bincode::serde::encode_into_std_write(packet, buffer, config::standard())?;
 
     buffer[0..FRAMED_PREFIX_LENGTH].copy_from_slice(&(encoded_size as u32).to_le_bytes());
 
@@ -68,13 +34,13 @@ fn framed_send<S: Serialize>(
 fn framed_recv<R: DeserializeOwned>(
     socket: &mut TcpStream,
     buffer: &mut Vec<u8>,
-    maybe_recv_state: &mut Option<RecvState>,
+    recv_cursor: &mut Option<usize>,
     timeout: Duration,
 ) -> ConResult<R> {
     let deadline = Instant::now() + timeout;
 
-    let recv_state_mut = if let Some(state) = maybe_recv_state {
-        state
+    let recv_cursor_ref = if let Some(cursor) = recv_cursor {
+        cursor
     } else {
         let mut payload_length_bytes = [0; FRAMED_PREFIX_LENGTH];
 
@@ -90,34 +56,26 @@ fn framed_recv<R: DeserializeOwned>(
         let packet_length =
             FRAMED_PREFIX_LENGTH + u32::from_le_bytes(payload_length_bytes) as usize;
 
-        if buffer.len() < packet_length {
-            buffer.resize(packet_length, 0);
-        }
+        buffer.resize(packet_length, 0);
 
-        maybe_recv_state.insert(RecvState {
-            packet_length,
-            packet_cursor: 0,
-        })
+        recv_cursor.insert(0)
     };
 
     loop {
-        recv_state_mut.packet_cursor +=
-            socket.recv(&mut buffer[recv_state_mut.packet_cursor..recv_state_mut.packet_length])?;
+        *recv_cursor_ref += socket.recv(&mut buffer[*recv_cursor_ref..])?;
 
-        if recv_state_mut.packet_cursor == recv_state_mut.packet_length {
+        if *recv_cursor_ref == buffer.len() {
             break;
         } else if Instant::now() > deadline {
             return alvr_common::try_again();
         }
     }
 
-    let (packet, _) = bincode::serde::decode_from_slice(
-        &buffer[FRAMED_PREFIX_LENGTH..recv_state_mut.packet_length],
-        config::standard(),
-    )
-    .to_con()?;
+    let (packet, _) =
+        bincode::serde::decode_from_slice(&buffer[FRAMED_PREFIX_LENGTH..], config::standard())
+            .to_con()?;
 
-    *maybe_recv_state = None;
+    *recv_cursor = None;
 
     Ok(packet)
 }
@@ -137,7 +95,7 @@ impl<S: Serialize> ControlSocketSender<S> {
 pub struct ControlSocketReceiver<T> {
     inner: TcpStream,
     buffer: Vec<u8>,
-    recv_state: Option<RecvState>,
+    recv_cursor: Option<usize>,
     _phantom: PhantomData<T>,
 }
 
@@ -146,7 +104,7 @@ impl<R: DeserializeOwned> ControlSocketReceiver<R> {
         framed_recv(
             &mut self.inner,
             &mut self.buffer,
-            &mut self.recv_state,
+            &mut self.recv_cursor,
             timeout,
         )
     }
@@ -219,7 +177,7 @@ impl ProtoControlSocket {
             ControlSocketReceiver {
                 inner: self.inner,
                 buffer: vec![0; FRAMED_PREFIX_LENGTH],
-                recv_state: None,
+                recv_cursor: None,
                 _phantom: PhantomData,
             },
         ))

--- a/alvr/sockets/src/stream_socket.rs
+++ b/alvr/sockets/src/stream_socket.rs
@@ -132,10 +132,7 @@ impl<H> StreamSender<H> {
 
 impl<H: Serialize> StreamSender<H> {
     pub fn get_buffer(&mut self, header: &H) -> Result<Buffer<H>> {
-        let mut buffer = self
-            .used_buffers
-            .pop()
-            .unwrap_or(vec![0; SHARD_PREFIX_SIZE]);
+        let mut buffer = self.used_buffers.pop().unwrap_or_default();
 
         buffer.resize(SHARD_PREFIX_SIZE, 0);
 

--- a/alvr/sockets/src/stream_socket.rs
+++ b/alvr/sockets/src/stream_socket.rs
@@ -18,9 +18,13 @@
 
 use crate::backend::{SocketReader, SocketWriter, tcp, udp};
 use alvr_common::{
-    AnyhowToCon, ConResult, HandleTryAgain, ToCon, anyhow::Result, debug, parking_lot::Mutex,
+    AnyhowToCon, ConResult, HandleTryAgain, ToCon,
+    anyhow::{Result, bail},
+    debug,
+    parking_lot::Mutex,
 };
 use alvr_session::{DscpTos, SocketBufferSize, SocketProtocol};
+use bincode::{config, enc::write::SizeWriter, error::EncodeError};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
     cmp::Ordering,
@@ -116,14 +120,12 @@ impl<H> StreamSender<H> {
                 actual_buffer_size - packet_start_position,
             );
 
-            // todo: switch to little endian
             // todo: do not remove sizeof<u32> for packet length
-            sub_buffer[0..4]
-                .copy_from_slice(&((packet_length - mem::size_of::<u32>()) as u32).to_be_bytes());
-            sub_buffer[4..6].copy_from_slice(&self.stream_id.to_be_bytes());
-            sub_buffer[6..10].copy_from_slice(&self.next_packet_index.to_be_bytes());
-            sub_buffer[10..14].copy_from_slice(&(shards_count as u32).to_be_bytes());
-            sub_buffer[14..18].copy_from_slice(&(idx as u32).to_be_bytes());
+            sub_buffer[0..4].copy_from_slice(&(packet_length as u32).to_le_bytes());
+            sub_buffer[4..6].copy_from_slice(&self.stream_id.to_le_bytes());
+            sub_buffer[6..10].copy_from_slice(&self.next_packet_index.to_le_bytes());
+            sub_buffer[10..14].copy_from_slice(&(shards_count as u32).to_le_bytes());
+            sub_buffer[14..18].copy_from_slice(&(idx as u32).to_le_bytes());
 
             self.inner.lock().send(&sub_buffer[..packet_length])?;
         }
@@ -138,20 +140,44 @@ impl<H> StreamSender<H> {
 
 impl<H: Serialize> StreamSender<H> {
     pub fn get_buffer(&mut self, header: &H) -> Result<Buffer<H>> {
-        let mut buffer = self.used_buffers.pop().unwrap_or_default();
+        let mut buffer = self
+            .used_buffers
+            .pop()
+            .unwrap_or(vec![0; SHARD_PREFIX_SIZE]);
 
-        let header_size = bincode::serialized_size(header)? as usize;
-        let hidden_offset = SHARD_PREFIX_SIZE + header_size;
+        let maybe_size = bincode::serde::encode_into_slice(
+            header,
+            &mut buffer[SHARD_PREFIX_SIZE..],
+            config::standard(),
+        );
 
-        if buffer.len() < hidden_offset {
-            buffer.resize(hidden_offset, 0);
-        }
+        let encoded_size = match maybe_size {
+            Ok(size) => size,
+            Err(EncodeError::UnexpectedEnd) => {
+                // Obtaining the size of the encoded data is expensive, as the data would need to be
+                // encoded twice. If the buffer is not large enough, we will pay for 3 encoding
+                // times, but this should happen rarely at steady state.
 
-        bincode::serialize_into(&mut buffer[SHARD_PREFIX_SIZE..hidden_offset], header)?;
+                let mut size_writer = SizeWriter::default();
+                bincode::serde::encode_into_writer(header, &mut size_writer, config::standard())?;
+
+                let packet_size = SHARD_PREFIX_SIZE + size_writer.bytes_written;
+                if buffer.len() < packet_size {
+                    buffer.resize(packet_size, 0);
+                }
+
+                bincode::serde::encode_into_slice(
+                    header,
+                    &mut buffer[SHARD_PREFIX_SIZE..],
+                    config::standard(),
+                )?
+            }
+            Err(e) => bail!("Failed to encode header: {}", e),
+        };
 
         Ok(Buffer {
             inner: buffer,
-            hidden_offset,
+            hidden_offset: SHARD_PREFIX_SIZE + encoded_size,
             length: 0,
             _phantom: PhantomData,
         })
@@ -179,11 +205,11 @@ impl<H> ReceiverData<H> {
 
 impl<H: DeserializeOwned> ReceiverData<H> {
     pub fn get(&self) -> Result<(H, &[u8])> {
-        let mut data: &[u8] = &self.buffer.as_ref().unwrap()[SHARD_PREFIX_SIZE..self.size];
-        // This will partially consume the slice, leaving only the actual payload
-        let header = bincode::deserialize_from(&mut data)?;
+        let data = &self.buffer.as_ref().unwrap()[SHARD_PREFIX_SIZE..self.size];
 
-        Ok((header, data))
+        let (header, decoded_size) = bincode::serde::decode_from_slice(data, config::standard())?;
+
+        Ok((header, &data[decoded_size..]))
     }
     pub fn get_header(&self) -> Result<H> {
         Ok(self.get()?.0)
@@ -316,9 +342,7 @@ impl StreamSocketBuilder {
             };
 
         Ok(StreamSocket {
-            // +4 is a workaround to retain compatibilty with old protocol
-            // todo: remove +4
-            max_packet_size: max_packet_size + 4,
+            max_packet_size,
             send_socket: Arc::new(Mutex::new(send_socket)),
             receive_socket,
             shard_recv_state: None,
@@ -361,9 +385,7 @@ impl StreamSocketBuilder {
             };
 
         Ok(StreamSocket {
-            // +4 is a workaround to retain compatibilty with old protocol
-            // todo: remove +4
-            max_packet_size: max_packet_size + 4,
+            max_packet_size,
             send_socket: Arc::new(Mutex::new(send_socket)),
             receive_socket,
             shard_recv_state: None,
@@ -467,14 +489,11 @@ impl StreamSocket {
                 return alvr_common::try_again();
             }
 
-            // todo: switch to little endian
-            // todo: do not remove sizeof<u32> for packet length
-            let shard_length = mem::size_of::<u32>()
-                + u32::from_be_bytes(bytes[0..4].try_into().unwrap()) as usize;
-            let stream_id = u16::from_be_bytes(bytes[4..6].try_into().unwrap());
-            let packet_index = u32::from_be_bytes(bytes[6..10].try_into().unwrap());
-            let shards_count = u32::from_be_bytes(bytes[10..14].try_into().unwrap()) as usize;
-            let shard_index = u32::from_be_bytes(bytes[14..18].try_into().unwrap()) as usize;
+            let shard_length = u32::from_le_bytes(bytes[0..4].try_into().unwrap()) as usize;
+            let stream_id = u16::from_le_bytes(bytes[4..6].try_into().unwrap());
+            let packet_index = u32::from_le_bytes(bytes[6..10].try_into().unwrap());
+            let shards_count = u32::from_le_bytes(bytes[10..14].try_into().unwrap()) as usize;
+            let shard_index = u32::from_le_bytes(bytes[14..18].try_into().unwrap()) as usize;
 
             self.shard_recv_state.insert(RecvState {
                 shard_length,


### PR DESCRIPTION
* Upgrade to to Bincode 2
* Make prefix data little-endian
* Make packet length contain itself (add 4 bytes to the count)
* Remove extra 4 bytes from the max shard length
* Improve performance of send functions (control socket and stream socket) by avoiding double serialization at steady state
* Do not store separately the buffer size where applicable

Initially I wanted to use the new Bincode `Encode` and `Decode` traits in place of serde, given that they seem largely preferred by bincode. This is too cumbersome since we use glam in protocol packets which only implement serde `Serialize` and `Deserialize`. I know that `Decode` is more powerful than `Deserialize` because it allows for custom allocators, but apart from that I'm still unsure if there is any other change we could benefit from, like better performance.

Tested on Quest 3/Windows