### PR TITLE
fix(tracking): 🐛 Correct quaternion multiplication order in motion prediction

### DIFF
--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -799,7 +799,10 @@ pub fn get_hand_data(
             last_controller_pose.position = crate::from_xr_vec3(location.pose.position);
         }
 
-        let pose = *last_controller_pose * hand_source.pose_offset;
+        let pose = Pose {
+            orientation: last_controller_pose.orientation * hand_source.pose_offset.orientation,
+            position: last_controller_pose.position + hand_source.pose_offset.position,
+        };
 
         let mut linear_velocity = crate::from_xr_vec3(velocity.linear_velocity);
         let mut angular_velocity = crate::from_xr_vec3(velocity.angular_velocity);

--- a/alvr/common/src/primitives.rs
+++ b/alvr/common/src/primitives.rs
@@ -91,11 +91,19 @@ impl DeviceMotion {
 
         DeviceMotion {
             pose: Pose {
-                orientation: self.pose.orientation * delta_orientation,
+                orientation: delta_orientation * self.pose.orientation,
                 position: self.pose.position + delta_position,
             },
             linear_velocity: self.linear_velocity,
             angular_velocity: self.angular_velocity,
+        }
+    }
+
+    pub fn to_local(&self) -> Self {
+        Self {
+            pose: self.pose,
+            linear_velocity: self.pose.orientation.conjugate() * self.linear_velocity,
+            angular_velocity: self.pose.orientation.conjugate() * self.angular_velocity,
         }
     }
 }

--- a/alvr/common/src/primitives.rs
+++ b/alvr/common/src/primitives.rs
@@ -91,7 +91,7 @@ impl DeviceMotion {
 
         DeviceMotion {
             pose: Pose {
-                orientation: delta_orientation * self.pose.orientation,
+                orientation: self.pose.orientation * delta_orientation,
                 position: self.pose.position + delta_position,
             },
             linear_velocity: self.linear_velocity,

--- a/alvr/common/src/primitives.rs
+++ b/alvr/common/src/primitives.rs
@@ -99,7 +99,7 @@ impl DeviceMotion {
         }
     }
 
-    pub fn to_local(&self) -> Self {
+    pub fn to_local_velocity(&self) -> Self {
         Self {
             pose: self.pose,
             linear_velocity: self.pose.orientation.conjugate() * self.linear_velocity,

--- a/alvr/dashboard/src/data_sources.rs
+++ b/alvr/dashboard/src/data_sources.rs
@@ -64,6 +64,12 @@ pub fn clean_session() {
         session_ref.server_version = ALVR_VERSION.clone();
         session_ref.client_connections.clear();
         session_ref.session_settings.extra.open_setup_wizard = true;
+        session_ref
+            .session_settings
+            .extra
+            .new_version_popup
+            .content
+            .hide_while_version = ALVR_VERSION.to_string();
     }
 }
 

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -192,8 +192,6 @@ impl TrackingManager {
                 motion.linear_velocity += motion
                     .angular_velocity
                     .cross(motion.pose.orientation * config.pose_offset.position);
-                motion.angular_velocity =
-                    motion.pose.orientation.conjugate() * motion.angular_velocity;
 
                 fn cutoff(v: Vec3, threshold: f32) -> Vec3 {
                     if v.length_squared() > threshold * threshold {

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -101,7 +101,8 @@ fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                         let ffi_head_motion = if let Some(motion) =
                             context.get_device_motion(*HEAD_ID, poll_timestamp)
                         {
-                            let motion = motion.predict(poll_timestamp, target_timestamp).to_local();
+                            let motion =
+                                motion.predict(poll_timestamp, target_timestamp).to_local();
                             let predicted_motion = motion.predict(poll_timestamp, target_timestamp);
                             let local_motion = predicted_motion.to_local();
 

--- a/alvr/server_openvr/src/tracking.rs
+++ b/alvr/server_openvr/src/tracking.rs
@@ -137,6 +137,15 @@ pub fn to_openvr_ffi_hand_skeleton(
     // global joints
     let gj = hand_skeleton;
 
+    // Get the default hand tracking position offset
+    let default_offset_arr = alvr_session::session_settings_default()
+        .headset
+        .controllers
+        .content
+        .left_hand_tracking_position_offset
+        .content;
+    let default_hand_tracking_offset = Vec3::from_array(default_offset_arr);
+
     // Correct the orientation for auxiliary bones.
     pub fn aux_orientation(id: u64, pose: Pose) -> Pose {
         let o = pose.orientation;
@@ -219,7 +228,9 @@ pub fn to_openvr_ffi_hand_skeleton(
         Pose {
             orientation: gj[0].orientation * pose_offset.orientation,
             position: gj[0].position
-                + gj[0].orientation * pose_offset.orientation * pose_offset.position,
+                + gj[0].orientation * pose_offset.orientation * default_hand_tracking_offset
+                + pose_offset.position
+                - default_hand_tracking_offset,
         },
         // Wrist
         root_parented_pose(gj[1]),

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1203,6 +1203,11 @@ Currently this cannot be reliably estimated automatically. The correct value sho
     #[schema(flag = "real-time")]
     #[schema(strings(help = "Right controller offset is mirrored horizontally"))]
     // note: logarithmic scale seems to be glitchy for this control
+    #[schema(gui(slider(min = -0.2, max = 0.2, step = 0.001)), suffix = "m")]
+    pub left_controller_pivot_offset: [f32; 3],
+
+    #[schema(flag = "real-time")]
+    #[schema(strings(help = "Right controller offset is mirrored horizontally"))]
     #[schema(gui(slider(min = -0.5, max = 0.5, step = 0.001)), suffix = "m")]
     pub left_hand_tracking_position_offset: [f32; 3],
 
@@ -1210,6 +1215,11 @@ Currently this cannot be reliably estimated automatically. The correct value sho
     #[schema(strings(help = "Right controller offset is mirrored horizontally"))]
     #[schema(gui(slider(min = -180.0, max = 180.0, step = 1.0)), suffix = "°")]
     pub left_hand_tracking_rotation_offset: [f32; 3],
+
+    #[schema(flag = "real-time")]
+    #[schema(strings(help = "Right controller offset is mirrored horizontally"))]
+    #[schema(gui(slider(min = -0.2, max = 0.2, step = 0.001)), suffix = "m")]
+    pub left_hand_tracking_pivot_offset: [f32; 3],
 
     #[schema(strings(help = "List of OpenXR-syle paths"))]
     pub button_mappings: Option<Vec<(String, Vec<ButtonBindingTarget>)>>,
@@ -2015,6 +2025,10 @@ pub fn session_settings_default() -> SettingsDefault {
                         gui_collapsed: true,
                         content: [0.0; 3],
                     },
+                    left_controller_pivot_offset: ArrayDefault {
+                        gui_collapsed: true,
+                        content: [0.0, 0.0, 0.11],
+                    },
                     left_hand_tracking_position_offset: ArrayDefault {
                         gui_collapsed: true,
                         content: [0.04, -0.02, -0.13],
@@ -2022,6 +2036,10 @@ pub fn session_settings_default() -> SettingsDefault {
                     left_hand_tracking_rotation_offset: ArrayDefault {
                         gui_collapsed: true,
                         content: [0.0, -45.0, -90.0],
+                    },
+                    left_hand_tracking_pivot_offset: ArrayDefault {
+                        gui_collapsed: true,
+                        content: [-0.04, 0.02, 0.13],
                     },
                     haptics: SwitchDefault {
                         enabled: true,


### PR DESCRIPTION
This PR corrects the multiplication order to `old * delta`, ensuring that the rotational delta from angular velocity is correctly applied in the local coordinate system rather than world coordinate system of the tracked device.

The wrong multiplication was made apparent after the motion prediction logic was moved from the client to the server in #2904 , which make the movement of the controller become strange under high-speed movement.