### PR TITLE
fix (dashboard): Fix incorrect AV1 gpu in note #2331, add more information about headsets

### DIFF
--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
@@ -114,7 +114,8 @@ pub fn codec_preset_schema() -> PresetSchemaNode {
         name: "codec_preset".into(),
         strings: [(
             "help".into(),
-            "AV1 is only supported on newer gpus (AMD RX 7xxx+ , NVIDIA RTX 30xx+, Intel ARC)!"
+            "AV1 encoding is only supported on RDNA3, Ada Lovelace, Intel ARC or newer GPUs (AMD RX 7xxx+ , NVIDIA RTX 40xx+, Intel ARC)
+and on headsets that have XR2 Gen 2 on board (Quest 3, Pico 4 Ultra)"
                 .into(),
         )]
         .into_iter()

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/builtin_schema.rs
@@ -115,7 +115,7 @@ pub fn codec_preset_schema() -> PresetSchemaNode {
         strings: [(
             "help".into(),
             "AV1 encoding is only supported on RDNA3, Ada Lovelace, Intel ARC or newer GPUs (AMD RX 7xxx+ , NVIDIA RTX 40xx+, Intel ARC)
-and on headsets that have XR2 Gen 2 on board (Quest 3, Pico 4 Ultra)"
+and on headsets that have XR2 Gen 2 onboard (Quest 3, Pico 4 Ultra)"
                 .into(),
         )]
         .into_iter()


### PR DESCRIPTION
Self-explanatory, just wanted to adjust it so users won't be confused