### PR TITLE
fix(xtask): :pushpin: Pin cargo-ndk to previous version

### DIFF
--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -385,7 +385,10 @@ pub fn build_android_deps(
             .run()
             .unwrap();
     }
-    cmd!(sh, "cargo install cargo-ndk cbindgen").run().unwrap();
+    cmd!(sh, "cargo install cbindgen").run().unwrap();
+    cmd!(sh, "cargo install cargo-ndk --version 3.5.4")
+        .run()
+        .unwrap();
     cmd!(
         sh,
         "cargo install --git https://github.com/zarik5/cargo-apk cargo-apk"


### PR DESCRIPTION
cargo-ndk updated to 4.0.0, plus they yanked a bunch of versions, this downgrades it to the latest working version. This should fix the broken nightlies. To be honest I haven't checked exactly what was causing the crash, but it just said "cargo-ndk panicked" which is definitely a bugged behavior.