### PR TITLE
ci: make rarely triggering checks run on merge queue only

### DIFF
--- a/.github/workflows/queue.yml
+++ b/.github/workflows/queue.yml
@@ -1,0 +1,74 @@
+name: Merge queue only checks
+
+on:
+  merge_group:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-linux-old:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 25088A0359807596
+          echo "deb http://ppa.launchpad.net/pipewire-debian/pipewire-upstream/ubuntu $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/pipewire-upstream.list
+          sudo add-apt-repository universe
+          sudo apt-get update
+          sudo apt-get install libfuse2 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+
+      - name: Prepare deps
+        env:
+          RUST_BACKTRACE: 1
+        run:  cargo xtask prepare-deps --platform linux --no-nvidia
+
+      - run: cargo clippy
+
+  check-msrv-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      # Fix actions rust install and msrv both being stupid
+      - run: rustup update
+
+      - name: Prepare deps
+        env:
+          RUST_BACKTRACE: 1
+        run: cargo xtask prepare-deps --platform windows
+
+      - run: cargo xtask check-msrv
+
+  check-msrv-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+
+      - name: Prepare deps
+        env:
+          RUST_BACKTRACE: 1
+        run:  cargo xtask prepare-deps --platform linux --no-nvidia
+
+      - run: cargo xtask check-msrv

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always
@@ -28,7 +29,7 @@ jobs:
 
       - run: cargo xtask clippy --ci
 
-  check-linux-latest:
+  check-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,32 +51,6 @@ jobs:
         run:  cargo xtask prepare-deps --platform linux --no-nvidia
 
       - run: cargo xtask clippy --ci
-
-  check-linux-old:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install dependencies
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 25088A0359807596
-          echo "deb http://ppa.launchpad.net/pipewire-debian/pipewire-upstream/ubuntu $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/pipewire-upstream.list
-          sudo add-apt-repository universe
-          sudo apt-get update
-          sudo apt-get install libfuse2 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
-
-      - name: Prepare deps
-        env:
-          RUST_BACKTRACE: 1
-        run:  cargo xtask prepare-deps --platform linux --no-nvidia
-
-      - run: cargo clippy
 
   check-macos:
     runs-on: macos-latest
@@ -148,43 +123,3 @@ jobs:
           components: rustfmt
 
       - run: cargo xtask check-format
-
-  check-msrv-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      # Fix actions rust install and msrv both being stupid
-      - run: rustup update
-
-      - name: Prepare deps
-        env:
-          RUST_BACKTRACE: 1
-        run: cargo xtask prepare-deps --platform windows
-
-      - run: cargo xtask check-msrv
-
-  check-msrv-linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
-
-      - name: Prepare deps
-        env:
-          RUST_BACKTRACE: 1
-        run:  cargo xtask prepare-deps --platform linux --no-nvidia
-
-      - run: cargo xtask check-msrv


### PR DESCRIPTION
Afaik this will need to be merged first before the checks will ever run in the merge queue and after that I'll force the merge queue to be enabled on master so they're actually ran