### PR TITLE
ci: fix merge-queue actions

### DIFF
--- a/.github/workflows/queue.yml
+++ b/.github/workflows/queue.yml
@@ -1,6 +1,8 @@
 name: Merge queue only checks
 
+// Merge queue checks need to be selected as required for prs to actually run, so simply skip them on prs
 on:
+  pull_request:
   merge_group:
 
 env:
@@ -8,6 +10,7 @@ env:
 
 jobs:
   check-linux-old:
+    if: github.event_name == 'merge_group'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +37,7 @@ jobs:
       - run: cargo clippy
 
   check-msrv-windows:
+    if: github.event_name == 'merge_group'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +57,7 @@ jobs:
       - run: cargo xtask check-msrv
 
   check-msrv-linux:
+    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This should actually fix the checks running on merge-queues. After this is merged I can finally set those jobs as required in the github ui so that they actually run on the merge-queue.