### PR TITLE
Add SteamVR Quck Launch feature

### DIFF
--- a/alvr/dashboard/src/dashboard/components/devices.rs
+++ b/alvr/dashboard/src/dashboard/components/devices.rs
@@ -1,4 +1,5 @@
 use crate::dashboard::ServerRequest;
+use crate::data_sources;
 use alvr_common::ConnectionState;
 use alvr_gui_common::theme::{self, log_colors};
 use alvr_packets::ClientListAction;
@@ -76,7 +77,12 @@ impl DevicesTab {
                         #[cfg(not(target_arch = "wasm32"))]
                         ui.with_layout(Layout::right_to_left(eframe::emath::Align::Center), |ui| {
                             if ui.button("Launch SteamVR").clicked() {
-                                crate::steamvr_launcher::LAUNCHER.lock().launch_steamvr();
+
+                                let session = data_sources::get_read_only_local_session();
+                                let steamvr_settings = &session.settings().extra.steamvr_launcher;
+                                let quick_launch = steamvr_settings.quick_launch_steamvr;
+
+                                crate::steamvr_launcher::LAUNCHER.lock().launch_steamvr(quick_launch);
                             }
                         });
                     })

--- a/alvr/dashboard/src/dashboard/components/devices.rs
+++ b/alvr/dashboard/src/dashboard/components/devices.rs
@@ -1,5 +1,4 @@
 use crate::dashboard::ServerRequest;
-use crate::data_sources;
 use alvr_common::ConnectionState;
 use alvr_gui_common::theme::{self, log_colors};
 use alvr_packets::ClientListAction;
@@ -77,12 +76,7 @@ impl DevicesTab {
                         #[cfg(not(target_arch = "wasm32"))]
                         ui.with_layout(Layout::right_to_left(eframe::emath::Align::Center), |ui| {
                             if ui.button("Launch SteamVR").clicked() {
-
-                                let session = data_sources::get_read_only_local_session();
-                                let steamvr_settings = &session.settings().extra.steamvr_launcher;
-                                let quick_launch = steamvr_settings.quick_launch_steamvr;
-
-                                crate::steamvr_launcher::LAUNCHER.lock().launch_steamvr(quick_launch);
+                                crate::steamvr_launcher::LAUNCHER.lock().launch_steamvr();
                             }
                         });
                     })

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -85,6 +85,15 @@ impl Dashboard {
         }
     }
 
+    fn use_quick_launch(&self) -> bool {
+        return self.session.as_ref().is_some_and(|s| {
+            s.to_settings()
+                .extra
+                .steamvr_launcher
+                .quick_launch_steamvr
+        })
+    }
+
     // This call may block
     fn restart_steamvr(&self, requests: &mut Vec<ServerRequest>) {
         requests.push(ServerRequest::RestartSteamvr);
@@ -98,12 +107,14 @@ impl Dashboard {
 
         *server_restarting_lock = true;
 
+        let quick_launch = self.use_quick_launch();
+        
         #[cfg(not(target_arch = "wasm32"))]
         std::thread::spawn({
             let server_restarting = Arc::clone(&self.server_restarting);
             let condvar = Arc::clone(&self.server_restarting_condvar);
             move || {
-                crate::steamvr_launcher::LAUNCHER.lock().restart_steamvr();
+                crate::steamvr_launcher::LAUNCHER.lock().restart_steamvr(quick_launch);
 
                 *server_restarting.lock() = false;
                 condvar.notify_one();
@@ -235,7 +246,9 @@ impl eframe::App for Dashboard {
                                     self.restart_steamvr(&mut requests);
                                 }
                             } else if ui.button("Launch SteamVR").clicked() {
-                                crate::steamvr_launcher::LAUNCHER.lock().launch_steamvr();
+                                let quick_launch = self.use_quick_launch();
+
+                                crate::steamvr_launcher::LAUNCHER.lock().launch_steamvr(quick_launch);
                             }
 
                             ui.horizontal(|ui| {

--- a/alvr/dashboard/src/main.rs
+++ b/alvr/dashboard/src/main.rs
@@ -64,11 +64,10 @@ fn main() {
 
     let session = data_sources::get_read_only_local_session();
     let steamvr_settings = &session.settings().extra.steamvr_launcher;
-    let quick_launch = steamvr_settings.quick_launch_steamvr;
 
     if steamvr_settings.open_close_steamvr_with_dashboard
     {
-        steamvr_launcher::LAUNCHER.lock().launch_steamvr(quick_launch);
+        steamvr_launcher::LAUNCHER.lock().launch_steamvr();
     }
 
     let ico = IconDir::read(Cursor::new(include_bytes!("../resources/dashboard.ico"))).unwrap();

--- a/alvr/dashboard/src/main.rs
+++ b/alvr/dashboard/src/main.rs
@@ -62,13 +62,13 @@ fn main() {
 
     data_sources::clean_session();
 
-    if data_sources::get_read_only_local_session()
-        .settings()
-        .extra
-        .steamvr_launcher
-        .open_close_steamvr_with_dashboard
+    let session = data_sources::get_read_only_local_session();
+    let steamvr_settings = &session.settings().extra.steamvr_launcher;
+    let quick_launch = steamvr_settings.quick_launch_steamvr;
+
+    if steamvr_settings.open_close_steamvr_with_dashboard
     {
-        steamvr_launcher::LAUNCHER.lock().launch_steamvr()
+        steamvr_launcher::LAUNCHER.lock().launch_steamvr(quick_launch);
     }
 
     let ico = IconDir::read(Cursor::new(include_bytes!("../resources/dashboard.ico"))).unwrap();

--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -6,11 +6,18 @@ use alvr_common::anyhow::bail;
 use alvr_common::{debug, error, info, warn};
 use sysinfo::Process;
 
-pub fn start_steamvr() {
-    Command::new("steam")
-        .args(["steam://rungameid/250820"])
-        .spawn()
-        .ok();
+pub fn start_steamvr(quick_launch: bool) {
+
+    if quick_launch {
+        Command::new("~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh") // Change if necessary
+            .spawn()
+            .ok();
+    } else {
+        Command::new("steam")
+            .args(["steam://rungameid/250820"])
+            .spawn()
+            .ok();
+    }
 }
 
 pub fn terminate_process(process: &Process) {

--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -8,7 +8,7 @@ use sysinfo::Process;
 
 pub fn launch_steam_app(app_id: &str) {
     Command::new("steam")
-        .args(["steam://rungameid/", app_id])
+        .args([format!("steam://rungameid/{}", app_id).as_str()])
         .spawn()
         .ok();
 }

--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -6,30 +6,9 @@ use alvr_common::anyhow::bail;
 use alvr_common::{debug, error, info, warn};
 use sysinfo::Process;
 
-use crate::data_sources;
-
-pub fn start_steamvr() {
-
-    let session = data_sources::get_read_only_local_session();
-    let steamvr_settings = &session.settings().extra.steamvr_launcher;
-    let quick_launch = steamvr_settings.quick_launch_steamvr;
-    let steamvr_path = steamvr_settings.quick_launch_steamvr;
-
-    if quick_launch {
-        Command::new("~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh") // Change if necessary
-            .spawn()
-            .ok();
-    } else {
-        Command::new("steam")
-            .args(["steam://rungameid/250820"])
-            .spawn()
-            .ok();
-    }
-}
-
-pub fn launch_steam_app(app_id: u32) {
+pub fn launch_steam_app(app_id: &str) {
     Command::new("steam")
-        .args(["steam://rungameid/", &app_id.to_string()])
+        .args(["steam://rungameid/", app_id])
         .spawn()
         .ok();
 }

--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -93,6 +93,8 @@ pub fn linux_hardware_checks() {
     linux_encoder_checks(&device_infos);
 }
 
+
+
 fn linux_gpu_checks(device_infos: &[(&wgpu::Adapter, DeviceInfo)]) {
     let have_intel_igpu = device_infos.iter().any(|gpu| {
         gpu.1
@@ -149,17 +151,7 @@ fn linux_gpu_checks(device_infos: &[(&wgpu::Adapter, DeviceInfo)]) {
     });
     debug!("have_intel_dgpu: {}", have_intel_dgpu);
 
-    let steamvr_root_dir = match alvr_server_io::steamvr_root_dir() {
-        Ok(dir) => dir,
-        Err(e) => {
-            error!(
-                "Couldn't detect openvr or steamvr files. \
-            Please make sure you have installed and ran SteamVR at least once. \
-            Or if you're using Flatpak Steam, make sure to use ALVR Dashboard from Flatpak ALVR. {e}"
-            );
-            return;
-        }
-    };
+    let steamvr_root_dir = get_steamvr_root_dir();
 
     let vrmonitor_path_string = steamvr_root_dir
         .join("bin")
@@ -341,4 +333,13 @@ fn probe_libva_encoder_profile(
             );
         }
     }
+}
+
+pub fn get_default_steamvr_executable_path() -> String {
+    return get_steamvr_root_dir()
+        .join("bin")
+        .join("vrstartup.sh") // Adjust this to match actual entry point for Linux
+        .into_os_string()
+        .into_string()
+        .unwrap();
 }

--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -6,7 +6,14 @@ use alvr_common::anyhow::bail;
 use alvr_common::{debug, error, info, warn};
 use sysinfo::Process;
 
-pub fn start_steamvr(quick_launch: bool) {
+use crate::data_sources;
+
+pub fn start_steamvr() {
+
+    let session = data_sources::get_read_only_local_session();
+    let steamvr_settings = &session.settings().extra.steamvr_launcher;
+    let quick_launch = steamvr_settings.quick_launch_steamvr;
+    let steamvr_path = steamvr_settings.quick_launch_steamvr;
 
     if quick_launch {
         Command::new("~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh") // Change if necessary
@@ -18,6 +25,13 @@ pub fn start_steamvr(quick_launch: bool) {
             .spawn()
             .ok();
     }
+}
+
+pub fn launch_steam_app(app_id: u32) {
+    Command::new("steam")
+        .args(["steam://rungameid/", &app_id.to_string()])
+        .spawn()
+        .ok();
 }
 
 pub fn terminate_process(process: &Process) {

--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -334,12 +334,3 @@ fn probe_libva_encoder_profile(
         }
     }
 }
-
-pub fn get_default_steamvr_executable_path() -> String {
-    return get_steamvr_root_dir()
-        .join("bin")
-        .join("vrstartup.sh") // Adjust this to match actual entry point for Linux
-        .into_os_string()
-        .into_string()
-        .unwrap();
-}

--- a/alvr/dashboard/src/steamvr_launcher/mod.rs
+++ b/alvr/dashboard/src/steamvr_launcher/mod.rs
@@ -176,9 +176,9 @@ impl Launcher {
         maybe_kill_steamvr();
     }
 
-    pub fn restart_steamvr(&self, quick_launch: bool) {
+    pub fn restart_steamvr(&self, ) {
         self.ensure_steamvr_shutdown();
-        self.launch_steamvr(quick_launch);
+        self.launch_steamvr();
     }
 }
 

--- a/alvr/dashboard/src/steamvr_launcher/mod.rs
+++ b/alvr/dashboard/src/steamvr_launcher/mod.rs
@@ -3,7 +3,7 @@ mod linux_steamvr;
 #[cfg(windows)]
 mod windows_steamvr;
 
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
 
 use crate::data_sources;
 use alvr_adb::commands as adb;
@@ -13,6 +13,7 @@ use alvr_common::{
     glam::bool,
     parking_lot::Mutex,
     warn,
+    error,
 };
 use alvr_filesystem as afs;
 use serde_json::{self, json};
@@ -107,6 +108,22 @@ fn unblock_alvr_driver_within_vrsettings(text: &str) -> Result<String> {
     }
 
     Ok(serde_json::to_string_pretty(&settings)?)
+}
+
+fn get_steamvr_root_dir() -> PathBuf {
+    let steamvr_root_dir = match alvr_server_io::steamvr_root_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            error!(
+                "Couldn't detect openvr or steamvr files. \
+            Please make sure you have installed and ran SteamVR at least once. \
+            Or if you're using Flatpak Steam, make sure to use ALVR Dashboard from Flatpak ALVR. {e}"
+            );
+            return "".into();
+        }
+    };
+
+    return  steamvr_root_dir;
 }
 
 pub struct Launcher {

--- a/alvr/dashboard/src/steamvr_launcher/mod.rs
+++ b/alvr/dashboard/src/steamvr_launcher/mod.rs
@@ -112,7 +112,7 @@ pub struct Launcher {
 }
 
 impl Launcher {
-    pub fn launch_steamvr(&self) {
+    pub fn launch_steamvr(&self, quick_launch: bool) {
         // The ADB server might be left running because of a unclean termination of SteamVR
         // Note that this will also kill a system wide ADB server not started by ALVR
         let wired_enabled = data_sources::get_read_only_local_session()
@@ -156,11 +156,13 @@ impl Launcher {
         if !is_steamvr_running() {
             debug!("SteamVR is dead. Launching...");
 
+            
+
             #[cfg(windows)]
-            windows_steamvr::start_steamvr();
+            windows_steamvr::start_steamvr(quick_launch);
 
             #[cfg(target_os = "linux")]
-            linux_steamvr::start_steamvr();
+            linux_steamvr::start_steamvr(quick_launch);
         }
     }
 
@@ -174,9 +176,9 @@ impl Launcher {
         maybe_kill_steamvr();
     }
 
-    pub fn restart_steamvr(&self) {
+    pub fn restart_steamvr(&self, quick_launch: bool) {
         self.ensure_steamvr_shutdown();
-        self.launch_steamvr();
+        self.launch_steamvr(quick_launch);
     }
 }
 

--- a/alvr/dashboard/src/steamvr_launcher/mod.rs
+++ b/alvr/dashboard/src/steamvr_launcher/mod.rs
@@ -4,7 +4,6 @@ mod linux_steamvr;
 mod windows_steamvr;
 
 #[cfg(windows)]
-use std::default;
 use std::{path::PathBuf, process::Command};
 
 use crate::data_sources;

--- a/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
@@ -1,33 +1,13 @@
 use std::os::windows::process::CommandExt;
 use std::process::Command;
 
-use crate::data_sources;
+use std::default;
 
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-pub fn start_steamvr() {
-
-    let session = data_sources::get_read_only_local_session();
-    let steamvr_settings = &session.settings().extra.steamvr_launcher;
-    let quick_launch = steamvr_settings.quick_launch_steamvr;
-    let steamvr_path = steamvr_settings.quick_launch_steamvr;
-
-    if quick_launch {
-        Command::new("C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe")
-            .spawn()
-            .ok();
-    } else {
-        Command::new("cmd")
-            .args(["/C", "start", "steam://rungameid/250820"])
-            .creation_flags(CREATE_NO_WINDOW)
-            .spawn()
-            .ok();
-    }
-}
-
-pub fn launch_steam_app(app_id: u32) {
+pub fn launch_steam_app(app_id: &str) {
     Command::new("cmd")
-            .args(["/C", "start", "steam://rungameid/", &app_id.to_string()])
+            .args(["/C", "start", "steam://rungameid/", app_id])
             .creation_flags(CREATE_NO_WINDOW)
             .spawn()
             .ok();
@@ -39,4 +19,23 @@ pub fn kill_process(pid: u32) {
         .creation_flags(CREATE_NO_WINDOW)
         .output()
         .ok();
+}
+
+pub fn get_default_steamvr_executable_path() -> String {
+    let default_steamvr_executable = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe".to_string();
+
+    let steamvr_root_dir = alvr_server_io::steamvr_root_dir();
+
+    if !steamvr_root_dir.exists() {
+        return default_steamvr_executable;
+    }
+
+    let steamvr_bin_dir = steamvr_root_dir.join("bin").join("win64"); // Set to win32 for 32-bit systems
+    let steamvr_bin;
+
+    if !steamvr_bin_dir.exists() {
+        steamvr_bin = steamvr_bin_dir.join("vrstartup.exe").to_string_lossy().into_owned()
+    }
+
+    return steamvr_bin;
 }

--- a/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
@@ -5,7 +5,7 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 pub fn launch_steam_app(app_id: &str) {
     Command::new("cmd")
-            .args(["/C", "start", "steam://rungameid/", app_id])
+            .args(["/C", "start", format!("steam://rungameid/{}", app_id).as_str()])
             .creation_flags(CREATE_NO_WINDOW)
             .spawn()
             .ok();

--- a/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
@@ -1,7 +1,8 @@
 use std::os::windows::process::CommandExt;
+use std::path::PathBuf;
 use std::process::Command;
 
-use std::default;
+use crate::steamvr_launcher::get_steamvr_root_dir;
 
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
@@ -22,20 +23,11 @@ pub fn kill_process(pid: u32) {
 }
 
 pub fn get_default_steamvr_executable_path() -> String {
-    let default_steamvr_executable = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe".to_string();
-
-    let steamvr_root_dir = alvr_server_io::steamvr_root_dir();
-
-    if !steamvr_root_dir.exists() {
-        return default_steamvr_executable;
-    }
-
-    let steamvr_bin_dir = steamvr_root_dir.join("bin").join("win64"); // Set to win32 for 32-bit systems
-    let steamvr_bin;
-
-    if !steamvr_bin_dir.exists() {
-        steamvr_bin = steamvr_bin_dir.join("vrstartup.exe").to_string_lossy().into_owned()
-    }
-
-    return steamvr_bin;
+    return get_steamvr_root_dir()
+        .join("bin")
+        .join("win64")
+        .join("vrstartup.exe")
+        .into_os_string()
+        .into_string()
+        .unwrap();
 }

--- a/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
@@ -1,8 +1,5 @@
 use std::os::windows::process::CommandExt;
-use std::path::PathBuf;
 use std::process::Command;
-
-use crate::steamvr_launcher::get_steamvr_root_dir;
 
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
@@ -20,14 +17,4 @@ pub fn kill_process(pid: u32) {
         .creation_flags(CREATE_NO_WINDOW)
         .output()
         .ok();
-}
-
-pub fn get_default_steamvr_executable_path() -> String {
-    return get_steamvr_root_dir()
-        .join("bin")
-        .join("win64")
-        .join("vrstartup.exe")
-        .into_os_string()
-        .into_string()
-        .unwrap();
 }

--- a/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
@@ -4,11 +4,17 @@ use std::process::Command;
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 pub fn start_steamvr() {
-    Command::new("cmd")
-        .args(["/C", "start", "steam://rungameid/250820"])
-        .creation_flags(CREATE_NO_WINDOW)
-        .spawn()
-        .ok();
+    if true {
+        Command::new("C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe")
+            .spawn()
+            .ok();
+    } else {
+        Command::new("cmd")
+            .args(["/C", "start", "steam://rungameid/250820"])
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn()
+            .ok();
+    }
 }
 
 pub fn kill_process(pid: u32) {

--- a/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
@@ -1,9 +1,17 @@
 use std::os::windows::process::CommandExt;
 use std::process::Command;
 
+use crate::data_sources;
+
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-pub fn start_steamvr(quick_launch: bool) {
+pub fn start_steamvr() {
+
+    let session = data_sources::get_read_only_local_session();
+    let steamvr_settings = &session.settings().extra.steamvr_launcher;
+    let quick_launch = steamvr_settings.quick_launch_steamvr;
+    let steamvr_path = steamvr_settings.quick_launch_steamvr;
+
     if quick_launch {
         Command::new("C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe")
             .spawn()
@@ -15,6 +23,14 @@ pub fn start_steamvr(quick_launch: bool) {
             .spawn()
             .ok();
     }
+}
+
+pub fn launch_steam_app(app_id: u32) {
+    Command::new("cmd")
+            .args(["/C", "start", "steam://rungameid/", &app_id.to_string()])
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn()
+            .ok();
 }
 
 pub fn kill_process(pid: u32) {

--- a/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/windows_steamvr.rs
@@ -3,8 +3,8 @@ use std::process::Command;
 
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-pub fn start_steamvr() {
-    if true {
+pub fn start_steamvr(quick_launch: bool) {
+    if quick_launch {
         Command::new("C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe")
             .spawn()
             .ok();

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -2145,7 +2145,7 @@ pub fn session_settings_default() -> SettingsDefault {
                 steamvr_executable_path: if !cfg!(target_os = "windows") {
                     "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe".into()
                 } else {
-                    "~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh".into()
+                    "~/.local/share/Steam/steamapps/common/SteamVR/bin/vrstartup.sh".into()
                 },
             },
             capture: CaptureConfigDefault {

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1472,7 +1472,7 @@ pub struct LoggingConfig {
 pub struct SteamvrLauncher {
     #[schema(strings(display_name = "Open and close SteamVR with dashboard"))]
     pub open_close_steamvr_with_dashboard: bool,
-    #[schema(strings(display_name = "Launch SteamVR standalone (quick launch)"))]
+    #[schema(strings(display_name = "SteamVR Quick Launch"))]
     pub quick_launch_steamvr: bool,
 }
 

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1478,7 +1478,7 @@ pub struct SteamvrLauncher {
     ))]
     pub quick_launch_steamvr: bool,
     #[schema(strings(display_name = "SteamVR executable path"))]
-    pub steamvr_executable: String,
+    pub steamvr_executable_path: String,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -2142,7 +2142,7 @@ pub fn session_settings_default() -> SettingsDefault {
             steamvr_launcher: SteamvrLauncherDefault {
                 open_close_steamvr_with_dashboard: false,
                 quick_launch_steamvr: false,
-                steamvr_executable: if !cfg!(target_os = "windows") {
+                steamvr_executable_path: if !cfg!(target_os = "windows") {
                     "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe".into()
                 } else {
                     "~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh".into()

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1515,6 +1515,7 @@ pub struct NewVersionPopupConfig {
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
 pub struct ExtraConfig {
+    #[schema(strings(display_name = "SteamVR Launcher"))]
     pub steamvr_launcher: SteamvrLauncher,
     pub capture: CaptureConfig,
     pub logging: LoggingConfig,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1472,7 +1472,10 @@ pub struct LoggingConfig {
 pub struct SteamvrLauncher {
     #[schema(strings(display_name = "Open and close SteamVR with dashboard"))]
     pub open_close_steamvr_with_dashboard: bool,
-    #[schema(strings(display_name = "SteamVR Quick Launch"))]
+    #[schema(strings(
+        display_name = "SteamVR Quick Launch",
+        help = "Launches SteamVR directly without Steam. This makes launching SteamVR significantly faster, allows SteamVR to be launched offline and avoids the \"app already running\" pop-up."
+    ))]
     pub quick_launch_steamvr: bool,
 }
 

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -2142,7 +2142,7 @@ pub fn session_settings_default() -> SettingsDefault {
             steamvr_launcher: SteamvrLauncherDefault {
                 open_close_steamvr_with_dashboard: false,
                 quick_launch_steamvr: false,
-                steamvr_executable_path: if !cfg!(target_os = "windows") {
+                steamvr_executable_path: if cfg!(target_os = "windows") {
                     "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe".into()
                 } else {
                     "~/.local/share/Steam/steamapps/common/SteamVR/bin/vrstartup.sh".into()

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1477,6 +1477,8 @@ pub struct SteamvrLauncher {
         help = "Launches SteamVR directly without Steam. This makes launching SteamVR significantly faster, allows SteamVR to be launched offline and avoids the \"app already running\" pop-up."
     ))]
     pub quick_launch_steamvr: bool,
+    #[schema(strings(display_name = "SteamVR executable path"))]
+    pub steamvr_executable: String,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -2140,6 +2142,11 @@ pub fn session_settings_default() -> SettingsDefault {
             steamvr_launcher: SteamvrLauncherDefault {
                 open_close_steamvr_with_dashboard: false,
                 quick_launch_steamvr: false,
+                steamvr_executable: if !cfg!(target_os = "windows") {
+                    "C:\\Program Files (x86)\\Steam\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe".into()
+                } else {
+                    "~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh".into()
+                },
             },
             capture: CaptureConfigDefault {
                 startup_video_recording: false,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1472,6 +1472,8 @@ pub struct LoggingConfig {
 pub struct SteamvrLauncher {
     #[schema(strings(display_name = "Open and close SteamVR with dashboard"))]
     pub open_close_steamvr_with_dashboard: bool,
+    #[schema(strings(display_name = "Launch SteamVR standalone (quick launch)"))]
+    pub quick_launch_steamvr: bool,
 }
 
 #[derive(SettingsSchema, Serialize, Deserialize, Clone)]
@@ -2133,6 +2135,7 @@ pub fn session_settings_default() -> SettingsDefault {
             },
             steamvr_launcher: SteamvrLauncherDefault {
                 open_close_steamvr_with_dashboard: false,
+                quick_launch_steamvr: false,
             },
             capture: CaptureConfigDefault {
                 startup_video_recording: false,


### PR DESCRIPTION
Added a toggle to choose to directly start SteamVR instead of using the steam protocol.

Benefits:
- Much faster startup and restart times
- Works offline
- No memory wasted by Steam
- Enables launching SteamVR with proxy server and https decryption active.
- Should allow using ALVR with Vive's offline Enterprise SteamVR packages.
- No more worrying about Steam throwing the "app already running" error when it's not running.

Drawbacks:
- If SteamVR isn't the default OpenXR runtime and the given path in settings is wrong it can't find SteamVR. (Could add protocol as a fallback or show a pop-up to let the user know to change their settings).
- No cloud syncing (doesn't really make a difference).


I really wanted an easier way to launch SteamVR this way, it's annoying to have to use a shortcut to the executable and having the automatic restart in ALVR launch Steam. Enabling this greatly improves the experience by removing the wait for SteamVR to launch. If there's stuff you'd like changed just let me know. I'll provide support and updates for the feature must there be bugs or issues with it.

Thank you very much!