### PR TITLE
fix(client_core): Set microphone input preset

### DIFF
--- a/alvr/client_core/Cargo.toml
+++ b/alvr/client_core/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.15"
-ndk = { version = "0.9", features = ["api-level-26", "audio", "media"] }
+ndk = { version = "0.9", features = ["api-level-28", "audio", "media"] }
 ndk-context = "0.1"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/alvr/client_core/src/audio.rs
+++ b/alvr/client_core/src/audio.rs
@@ -6,8 +6,8 @@ use alvr_common::{
 use alvr_session::AudioBufferingConfig;
 use alvr_sockets::{StreamReceiver, StreamSender};
 use ndk::audio::{
-    AudioCallbackResult, AudioDirection, AudioError, AudioFormat, AudioPerformanceMode,
-    AudioSharingMode, AudioStreamBuilder,
+    AudioCallbackResult, AudioDirection, AudioError, AudioFormat, AudioInputPreset,
+    AudioPerformanceMode, AudioSharingMode, AudioStreamBuilder,
 };
 use std::{
     collections::VecDeque,
@@ -44,6 +44,7 @@ pub fn record_audio_blocking(
         .channel_count(1)
         .sample_rate(sample_rate as _)
         .format(AudioFormat::PCM_I16)
+        .input_preset(AudioInputPreset::VoiceCommunication)
         .performance_mode(AudioPerformanceMode::LowLatency)
         .sharing_mode(AudioSharingMode::Shared)
         .data_callback(Box::new(move |_, data_ptr, frames_count| {

--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -41,7 +41,7 @@ path = "../../build/alvr_client_android/debug.keystore"
 keystore_password = "alvrclient"
 
 [package.metadata.android.sdk]
-min_sdk_version = 26
+min_sdk_version = 28
 target_sdk_version = 32
 
 [[package.metadata.android.uses_feature]]

--- a/alvr/system_info/Cargo.toml
+++ b/alvr/system_info/Cargo.toml
@@ -15,6 +15,6 @@ serde = { version = "1", features = ["derive"] }
 settings-schema = { git = "https://github.com/alvr-org/settings-schema-rs", rev = "676185f" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk = { version = "0.9", features = ["api-level-26", "media"] }
+ndk = { version = "0.9", features = ["api-level-28", "media"] }
 ndk-context = "0.1"
 ndk-sys = "0.6"

--- a/alvr/xtask/src/build.rs
+++ b/alvr/xtask/src/build.rs
@@ -308,7 +308,7 @@ pub fn build_launcher(profile: Profile, reproducible: bool) {
 fn build_android_lib_impl(dir_name: &str, profile: Profile, link_stdcpp: bool, all_targets: bool) {
     let sh = Shell::new().unwrap();
 
-    let mut ndk_flags = vec!["--no-strip", "-p", "26", "-t", "arm64-v8a"];
+    let mut ndk_flags = vec!["--no-strip", "-p", "28", "-t", "arm64-v8a"];
 
     if all_targets {
         ndk_flags.extend(["-t", "armeabi-v7a", "-t", "x86_64", "-t", "x86"]);


### PR DESCRIPTION
Fixes microphone audio quality regression since https://github.com/alvr-org/ALVR/pull/2860 due to missing input preset setting.
Requires bumping minimum Android API level from 26 to 28.

Tests with default `VoiceRecognition` (1) and `VoiceCommunication` (2) presets on Pico 4 Pro:

<img width="1625" height="336" alt="image" src="https://github.com/user-attachments/assets/e22eed6e-3915-4829-89d9-f97e3f8e17cb" />
