### PR TITLE
Add Quest 1 emulation options

### DIFF
--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -82,6 +82,7 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
             ControllersEmulationMode::Quest2Touch => 1,
             ControllersEmulationMode::Quest3Plus => 2,
             ControllersEmulationMode::QuestPro => 3,
+            ControllersEmulationMode::Quest1Touch => 7,
             ControllersEmulationMode::Pico4 => 10,
             ControllersEmulationMode::ValveIndex => 20,
             ControllersEmulationMode::ViveWand => 40,

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -79,10 +79,10 @@ pub fn contruct_openvr_config(session: &SessionConfig) -> OpenvrConfig {
         // a bit easier though.
         controller_profile = match config.emulation_mode {
             ControllersEmulationMode::RiftSTouch => 0,
-            ControllersEmulationMode::Quest2Touch => 1,
-            ControllersEmulationMode::Quest3Plus => 2,
-            ControllersEmulationMode::QuestPro => 3,
-            ControllersEmulationMode::Quest1Touch => 7,
+            ControllersEmulationMode::Quest1Touch => 1,
+            ControllersEmulationMode::Quest2Touch => 2,
+            ControllersEmulationMode::Quest3Plus => 3,
+            ControllersEmulationMode::QuestPro => 4,
             ControllersEmulationMode::Pico4 => 10,
             ControllersEmulationMode::ValveIndex => 20,
             ControllersEmulationMode::ViveWand => 40,

--- a/alvr/server_core/src/input_mapping.rs
+++ b/alvr/server_core/src/input_mapping.rs
@@ -11,6 +11,7 @@ pub fn registered_button_set(
 ) -> HashSet<u64> {
     match &controllers_emulation_mode {
         ControllersEmulationMode::RiftSTouch
+        | ControllersEmulationMode::Quest1Touch
         | ControllersEmulationMode::Quest2Touch
         | ControllersEmulationMode::Quest3Plus
         | ControllersEmulationMode::QuestPro => CONTROLLER_PROFILE_INFO

--- a/alvr/server_openvr/src/props.rs
+++ b/alvr/server_openvr/src/props.rs
@@ -121,6 +121,7 @@ fn serial_number(device_id: u64) -> String {
     if device_id == *HEAD_ID {
         match &settings.headset.emulation_mode {
             HeadsetEmulationMode::RiftS => "1WMGH000XX0000".into(),
+            HeadsetEmulationMode::Quest1 => "1PASH0X0X00000".into(),
             HeadsetEmulationMode::Quest2 => "1WMHH000X00000".into(),
             HeadsetEmulationMode::QuestPro => "230YC0XXXX00XX".into(),
             HeadsetEmulationMode::Vive => "HTCVive-001".into(),
@@ -129,6 +130,7 @@ fn serial_number(device_id: u64) -> String {
     } else if device_id == *HAND_LEFT_ID || device_id == *HAND_RIGHT_ID {
         if let Switch::Enabled(controllers) = &settings.headset.controllers {
             let serial_number = match &controllers.emulation_mode {
+                ControllersEmulationMode::Quest1Touch => "1PALCXXXX00000_Controller", // 1PALCLC left, 1PALCRC right
                 ControllersEmulationMode::Quest2Touch => "1WMHH000X00000_Controller",
                 ControllersEmulationMode::Quest3Plus => "2G0YXX0X0000XX_Controller", // 2G0YY Left 2G0YZ Right
                 ControllersEmulationMode::QuestPro => "230YXXXXXXXXXX_Controller", // 230YT left, 230YV right
@@ -264,6 +266,14 @@ pub extern "C" fn set_device_openvr_props(instance_ptr: *mut c_void, device_id: 
                 set_prop(DriverVersionString, "1.42.0");
                 set_icons("{oculus}/icons/rifts_headset");
             }
+            HeadsetEmulationMode::Quest1 => {
+                set_prop(TrackingSystemNameString, "oculus");
+                set_prop(ModelNumberString, "Oculus Quest");
+                set_prop(ManufacturerNameString, "Oculus");
+                set_prop(RenderModelNameString, "generic_hmd");
+                set_prop(DriverVersionString, "1.111.0");
+                set_oculus_common_headset_props();
+            }
             HeadsetEmulationMode::Quest2 => {
                 set_prop(TrackingSystemNameString, "oculus");
                 set_prop(ModelNumberString, "Miramar");
@@ -353,6 +363,19 @@ pub extern "C" fn set_device_openvr_props(instance_ptr: *mut c_void, device_id: 
                     } else if right_hand {
                         set_prop(ModelNumberString, "Oculus Rift S (Right Controller)");
                         set_prop(RenderModelNameString, "oculus_rifts_controller_right");
+                    }
+                    set_prop(ControllerTypeString, "oculus_touch");
+                    set_prop(InputProfilePathString, "{oculus}/input/touch_profile.json");
+                    set_oculus_common_props();
+                }
+                ControllersEmulationMode::Quest1Touch => {
+                    set_prop(ManufacturerNameString, "Oculus");
+                    if left_hand {
+                        set_prop(ModelNumberString, "Oculus Quest (Left Controller)");
+                        set_prop(RenderModelNameString, "oculus_quest_controller_left");
+                    } else if right_hand {
+                        set_prop(ModelNumberString, "Oculus Quest (Right Controller)");
+                        set_prop(RenderModelNameString, "oculus_quest_controller_right");
                     }
                     set_prop(ControllerTypeString, "oculus_touch");
                     set_prop(InputProfilePathString, "{oculus}/input/touch_profile.json");

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -865,6 +865,8 @@ pub struct AudioConfig {
 pub enum HeadsetEmulationMode {
     #[schema(strings(display_name = "Rift S"))]
     RiftS,
+    #[schema(strings(display_name = "Quest 1"))]
+    Quest1,
     #[schema(strings(display_name = "Quest 2"))]
     Quest2,
     #[schema(strings(display_name = "Quest Pro"))]
@@ -962,6 +964,8 @@ pub struct VMCConfig {
 pub enum ControllersEmulationMode {
     #[schema(strings(display_name = "Rift S Touch"))]
     RiftSTouch,
+    #[schema(strings(display_name = "Quest 1 Touch"))]
+    Quest1Touch,
     #[schema(strings(display_name = "Quest 2 Touch"))]
     Quest2Touch,
     #[schema(strings(display_name = "Quest 3 Touch Plus"))]


### PR DESCRIPTION
Added options for Quest 1 headset emulation and Quest 1 Touch controller emulation, referencing a SteamVR report from the Windows Meta driver, and existing code in the project. I'm sure impact is minimal (especially with the controllers, but SteamVR does load different rendermodels for them), but it's a gap in options that has always bothered me.

Have never programmed with Rust, worked with SteamVR, or contributed to a public project before. Please tell me if I messed up with anything, or if this addition doesn't fit the goals of the project!