### PR TITLE
docs(linux): Improve accuracy, grammar, spelling

### DIFF
--- a/wiki/Linux-Troubleshooting.md
+++ b/wiki/Linux-Troubleshooting.md
@@ -4,14 +4,14 @@ The Steam runtimes SteamVR runs in break the ALVR driver loaded by SteamVR. This
 
 ### Fix
 
-Add `~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` to the command-line options of SteamVR (SteamVR -> Manage/Right Click -> Properties -> General -> Launch Options).
+Add `~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` to the launch options of SteamVR (SteamVR -> Manage/Right Click -> Properties -> General -> Launch Options).
 
 This path might differ based on your Steam installation; in that case, SteamVR will not start at all. If this is the case, you can figure out the actual path by going to Steam Settings -> Storage.
-Then pick the storage location with the star emoji (⭐) and take the path directly above the usage statistics. Prepend this path to `steamapps/common/SteamVR/bin/vrmonitor.sh`. Finally, put the resulting path into the SteamVR command-line options instead of the original one.
+Then pick the storage location with the star emoji (⭐) and take the path directly above the usage statistics. Prepend this path to `steamapps/common/SteamVR/bin/vrmonitor.sh`. Finally, put the resulting path into the SteamVR launch options instead of the original one.
 
 ### Hyprland/Sway/wlroots Qt fix
 
-If you're on Hyprland, Sway, or another wlroots-based Wayland compositor, you might have to prepend `QT_QPA_PLATFORM=xcb` to your command-line.
+If you're on Hyprland, Sway, or another wlroots-based Wayland compositor, you might have to prepend `QT_QPA_PLATFORM=xcb` to your launch options.
 
 Related issue:
 [[BUG] No SteamVR UI on wlroots-based wayland compositors (sway, hyprland, ...) with workaround](https://github.com/ValveSoftware/SteamVR-for-Linux/issues/637).
@@ -72,13 +72,13 @@ If you're using a PC and can disable your integrated GPU from the BIOS/UEFI, it'
 
 ### AMD/Intel integrated GPU + AMD/Intel discrete GPU
 
-Prepend `DRI_PRIME=1` to the command-line options of SteamVR and of all VR games you intend to play with ALVR.
+Prepend `DRI_PRIME=1` to the launch options of SteamVR and of all VR games you intend to play with ALVR.
 
 ### AMD/Intel integrated GPU + Nvidia discrete GPU
 
-Prepend `__NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia` to the command-line options of SteamVR and of all VR games you intend to play with ALVR.
+Prepend `__NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia` to the launch options of SteamVR and of all VR games you intend to play with ALVR.
 
-If this results in errors such as `error in encoder thread: Failed to initialize vulkan frame context: Invalid argument`, then try adding `VK_DRIVER_FILES=/usr/share/vulkan/icd.d/nvidia_icd.json` to the above command-line options.
+If this results in errors such as `error in encoder thread: Failed to initialize vulkan frame context: Invalid argument`, then try adding `VK_DRIVER_FILES=/usr/share/vulkan/icd.d/nvidia_icd.json` to the above launch options.
 
 - Go to `/usr/share/vulkan/icd.d` and ensure `nvidia_icd.json` exists. It may also be under the name `nvidia_icd.x86_64.json`, in which case you should adjust `VK_DRIVER_FILES` accordingly.
 - On older distributions, `VK_DRIVER_FILES` may not be available, in which case you should use the deprecated but equivalent `VK_ICD_FILENAMES`.
@@ -92,7 +92,7 @@ When using older Gnome versions (<47) under Wayland, issues may be caused by DRM
 
 ### Fix
 
-Prepend `WAYLAND_DISPLAY=''` to the SteamVR command-line options to force XWayland on SteamVR.
+Prepend `WAYLAND_DISPLAY=''` to the SteamVR launch options to force XWayland on SteamVR.
 
 ## The view shakes when using SlimeVR
 

--- a/wiki/Linux-Troubleshooting.md
+++ b/wiki/Linux-Troubleshooting.md
@@ -18,7 +18,7 @@ Related issue:
 
 ## The ALVR driver doesn't get detected by SteamVR (even after vrmonitor fix)
 
-This can be related to use of an AUR package on Arch.
+This can be related to the use of an AUR package on Arch.
 
 ### Fix
 
@@ -52,7 +52,7 @@ For other distros (e.g. Manjaro):
 
 ## Nvidia driver version requirements
 
-ALVR requires the Nvidia driver version >=535 and CUDA version >=12.1. If your configuration doesn't meet these requirements, SteamVR or the encoder might not work.
+ALVR requires the Nvidia driver version 535 or newer and CUDA version 12.1 or newer. If your configuration doesn't meet these requirements, SteamVR or the encoder might not work.
 
 ### Fix
 
@@ -88,7 +88,7 @@ You may need to run the entire Steam client itself via PRIME render offload. Fir
 
 ## Wayland
 
-When using older Gnome versions (<47) under Wayland, issues may be caused by DRM leasing not being available.
+When using older Gnome versions (older than 47) under Wayland, issues may be caused by DRM leasing not being available.
 
 ### Fix
 
@@ -116,7 +116,7 @@ Audio and/or microphone are enabled in presets, but you still can't hear audio o
 
 ### Fix
 
-Make sure you select `ALVR Audio` and/or `ALVR Microphone` in your device list as default **after** connecting the headset. As soon as the headset is disconnected, the devices will be removed. If you set them as default, they will be automatically selected whenever they show up, and you won't need to do it manually ever again. If you don't appear to have the audio devices, or have PipeWire errors in your logs, ensure you have `pipewire` version >=0.3.49 installed by using the command `pipewire --version`. For older Debian (<=11) or Ubuntu-based (<=22.04) distributions, you can check the [pipewire-upstream](https://github.com/pipewire-debian/pipewire-debian) page for instructions on installing newer PipeWire versions.
+Make sure you select `ALVR Audio` and/or `ALVR Microphone` in your device list as default **after** connecting the headset. As soon as the headset is disconnected, the devices will be removed. If you set them as default, they will be automatically selected whenever they show up, and you won't need to do it manually ever again. If you don't appear to have the audio devices, or have PipeWire errors in your logs, ensure you have `pipewire` version 0.3.49 or newer installed by using the command `pipewire --version`. For older Debian (version 11 or older) or Ubuntu-based (version 22.04 or older) distributions, you can check the [pipewire-upstream](https://github.com/pipewire-debian/pipewire-debian) page for instructions on installing newer PipeWire versions.
 
 ## Low AMDGPU performance and shutters
 

--- a/wiki/Linux-Troubleshooting.md
+++ b/wiki/Linux-Troubleshooting.md
@@ -1,131 +1,122 @@
 ## (! Mandatory, apply fix if not applied yet !) Black screen even when SteamVR shows movement, Dashboard not detecting launched ALVR/SteamVR
 
-The steam runtimes SteamVR runs in break the alvr driver loaded by SteamVR.
-This causes the screen to stay black on the headset or an error to be reported that the pipewire device is missing or can even result in SteamVR crashing.
+The Steam runtimes SteamVR runs in break the ALVR driver loaded by SteamVR. This causes the screen to stay black on the headset, an error to be reported that the PipeWire device is missing, or can even result in SteamVR crashing.
 
 ### Fix
 
-Add `~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` to the commandline options of SteamVR (SteamVR -> Manage/Right Click -> Properties -> General -> Launch Options).
+Add `~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` to the command-line options of SteamVR (SteamVR -> Manage/Right Click -> Properties -> General -> Launch Options).
 
-This path might differ based on your Steam installation, in that case SteamVR will not start at all. If this is the case you can figure out the actual path by going to Steam Settings -> Storage.
-Then pick the storage location with the star emoji (⭐) and take the path directly above the usage statistics. Prepend this path to `steamapps/common/SteamVR/bin/vrmonitor.sh`.
-Finally put this entire path into the SteamVR commandline options instead of the other one.
+This path might differ based on your Steam installation; in that case, SteamVR will not start at all. If this is the case, you can figure out the actual path by going to Steam Settings -> Storage.
+Then pick the storage location with the star emoji (⭐) and take the path directly above the usage statistics. Prepend this path to `steamapps/common/SteamVR/bin/vrmonitor.sh`. Finally, put the resulting path into the SteamVR command-line options instead of the original one.
 
-### Hyprland/Sway/Wlroots Qt fix
+### Hyprland/Sway/wlroots Qt fix
 
-If you're on hyprland, sway, or other wlroots-based wayland compositor, you might have to prepend `QT_QPA_PLATFORM=xcb` before commandline, which results in full commandline for steamvr being something like this:
-`QT_QPA_PLATFORM=xcb ~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%`.
+If you're on Hyprland, Sway, or another wlroots-based Wayland compositor, you might have to prepend `QT_QPA_PLATFORM=xcb` to your command-line.
 
 Related issue:
 [[BUG] No SteamVR UI on wlroots-based wayland compositors (sway, hyprland, ...) with workaround](https://github.com/ValveSoftware/SteamVR-for-Linux/issues/637).
 
+## The ALVR driver doesn't get detected by SteamVR (even after vrmonitor fix)
 
-## The alvr driver doesn't get detected by SteamVR (even after vrmonitor fix)
-
-Could be related to Arch AUR package (either installed not for nvidia on nvidia based system (`alvr-nvidia`), or just in general).
+This can be related to use of an AUR package on Arch.
 
 ### Fix
 
-Try using a launcher or portable .tar.gz release from the Releases page.
+If you're using an Nvidia-based system, ensure you are using a package which supports this (e.g. `alvr-nvidia`). Also try using a launcher (e.g. `alvr-launcher-bin`) or portable .tar.gz release from the Releases page.
 
 ## Artifacting, no SteamVR Overlay or graphical glitches in streaming view
 
-Could be related to AMD amdvlk or amdgpu-pro driver being present on your system.
-
-If you have Amdvlk installed on your system, it overrides other vulkan drivers and causes SteamVR to break. Use the `vulkan-radeon` driver (aka radv) instead.
+This could be related to the AMD AMDVLK or AMDGPU-PRO drivers being present on your system. AMDVLK overrides other Vulkan drivers and can cause SteamVR to break. Also to note is that AMD has discontinued the AMDVLK driver, so limited support should be expected if using it.
 
 ### Fix
 
-Check if amdvlk or amdgpu-pro are installed by seeing if `ls /usr/share/vulkan/icd.d/ | grep -e amd_icd -e amd_pro` shows anything.
-If so, uninstall amdvlk and/or the amdgpu-pro drivers from your system. (This method may not catch all installations due to distro variations)
+First check if AMDVLK or AMDGPU-PRO are installed by seeing if `ls /usr/share/vulkan/icd.d/ | grep -e amd_icd -e amd_pro` shows anything. If so, uninstall AMDVLK and/or the AMDGPU-PRO drivers from your system to use the RADV driver instead. (This method may not catch all installations due to distro variations.)
 
-On arch, first install `vulkan-radeon` and uninstall other drivers.
+On Arch, first install `vulkan-radeon`, then uninstall other drivers.
 
-## Failed to create VAAPI encoder
+## "Failed to create VAAPI encoder" error
 
-Blocky or crashing streams of gameplay and then an error window on your desktop saying:
+Gameplay stream appears blocky or crashes, then an error window appears on your desktop saying:
 > Failed to create VAAPI encoder: Cannot open video encoder codec: Function not implemented. Please make sure you have installed VAAPI runtime.
 
 ### Fix
 
-For fedora:
- * Switch from `mesa-va-drivers` to `mesa-va-drivers-freeworld`. [Guide on how to do so](https://fostips.com/hardware-acceleration-video-fedora/) or [the RPM docs](https://rpmfusion.org/Howto/Multimedia)
-For arch (don't use vaapi for nvidia):
- * Follow through [this](https://wiki.archlinux.org/title/Hardware_video_acceleration#Installation) page
-Then reboot your machine.
+For Fedora:
+ * Switch from `mesa-va-drivers` to `mesa-va-drivers-freeworld`. [Guide on how to do so](https://fostips.com/hardware-acceleration-video-fedora/) or [the RPM docs](https://rpmfusion.org/Howto/Multimedia).
+
+For Arch (don't use VAAPI for Nvidia):
+ * Follow the steps on [this](https://wiki.archlinux.org/title/Hardware_video_acceleration#Installation) page, then reboot your machine.
 
 For other distros (e.g. Manjaro):
- * Install the nonfree version of the mesa/vaapi drivers that include the proprietary codecs needed for h264/hevc encoding
+ * Install the nonfree version of the Mesa/VAAPI drivers that include the proprietary codecs needed for H264/HEVC encoding.
 
 ## Nvidia driver version requirements
 
-Alvr requires at least driver version 535 and CUDA version 12.1. If this is not the case SteamVR or the encoder might not work.
+ALVR requires the Nvidia driver version >=535 and CUDA version >=12.1. If your configuration doesn't meet these requirements, SteamVR or the encoder might not work.
 
 ### Fix
 
-Install at least the required versions of the driver and ensure you have CUDA installed with at least version 12.1.
+Install the minimum or newer versions of the Nvidia and CUDA drivers.
 
-If an error saying CUDA was not detected persists, try using the latest alvr nightly release.
+If errors saying CUDA was not detected persist, try using the latest ALVR nightly release.
 
 ## Using ALVR with only integrated graphics
 
-Beware that using **only** integrated graphics for running ALVR is highly inadvisable as in most cases it will lead to very poor performance (even on more powerful devices like Steam Deck, it's still very slow).
-Don't expect things to work perfectly in this case too, as some older integrated graphics simply might not have the best vulkan support and might fail to work at all. 
+Beware that using **only** integrated graphics for running ALVR is highly inadvisable, as in most cases it will lead to very poor performance (even on more powerful devices like the Steam Deck, it's still very slow). Don't expect things to work perfectly in this case either, as some older integrated graphics may simply not have the best Vulkan support and might fail to work at all. 
 
-## Hybrid graphics advices
+## Hybrid graphics advice
 
-### General advise
+### General advice
 
-If you have PC and can disable your integrated gpu from BIOS/UEFI, it's highly advised to do so to avoid multiple problems of handling hybrid graphics.
-If you're on laptop and it doesn't allow disabling integrated graphics (in most cases) you have to resort to methods bellow.
+If you're using a PC and can disable your integrated GPU from the BIOS/UEFI, it's highly advised to do so to avoid multiple problems with handling hybrid graphics. If you're using a laptop and it doesn't allow disabling integrated graphics (in most cases), you'll have to resort to the methods below.
 
-### Amd/Intel integrated gpu + Amd/Intel discrete gpu
+### AMD/Intel integrated GPU + AMD/Intel discrete GPU
 
-Put `DRI_PRIME=1 ~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` (adjust vrmonitor path to your distro) into SteamVR's commandline options and in those of all VR games you intend to play with ALVR.
+Prepend `DRI_PRIME=1` to the command-line options of SteamVR and of all VR games you intend to play with ALVR.
 
-### Amd/Intel integrated gpu + Nvidia discrete gpu
+### AMD/Intel integrated GPU + Nvidia discrete GPU
 
-Put `__NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia ~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` (adjust vrmonitor path to your distro) into SteamVR's commandline options and in those of all VR games you intend to play with ALVR.
+Prepend `__NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia` to the command-line options of SteamVR and of all VR games you intend to play with ALVR.
 
-If this results in errors such as `error in encoder thread: Failed to initialize vulkan frame context: Invalid argument`, then try this instead:
+If this results in errors such as `error in encoder thread: Failed to initialize vulkan frame context: Invalid argument`, then try adding `VK_DRIVER_FILES=/usr/share/vulkan/icd.d/nvidia_icd.json` to the above command-line options.
 
-`__NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only __GLX_VENDOR_LIBRARY_NAME=nvidia VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json  ~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%`
-
-- Again, adjust vrmonitor path to your distro
-- Go to `/usr/share/vulkan/icd.d` and make sure `nvidia_icd.json` exists. It may also be under the name `nvidia_icd.x86_64.json`, in which case you should adjust `VK_ICD_FILENAMES` accordingly.
+- Go to `/usr/share/vulkan/icd.d` and ensure `nvidia_icd.json` exists. It may also be under the name `nvidia_icd.x86_64.json`, in which case you should adjust `VK_DRIVER_FILES` accordingly.
+- On older distributions, `VK_DRIVER_FILES` may not be available, in which case you should use the deprecated but equivalent `VK_ICD_FILENAMES`.
 
 ### SteamVR Dashboard not rendering in VR on Nvidia discrete GPU
-If you encounter issues with the SteamVR dashboard not rendering in VR you may need to run the entire steam client itself via PRIME render offload. First close the steam client completey if you have it open already, you can do so by clicking the Steam dropdown in the top left and choosing exit. Then from a terminal run: `__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia steam-runtime`
+You may need to run the entire Steam client itself via PRIME render offload. First, ensure the Steam client is completely closed. If Steam is already open, you can do so by clicking the Steam dropdown in the top left and choosing "Exit". Then from a terminal run: `__NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia steam-runtime`.
 
 ## Wayland
 
-When using old Gnome (< 47 version) under Wayland you might need to put `WAYLAND_DISPLAY='' ~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` (adjust vrmonitor path to your distro) into the SteamVR commandline options to force XWayland on SteamVR. This fixes issue with drm leasing not being available.
-
-## The view shakes
-
-SlimeVR related, might be fixed in future updates of ALVR
+When using older Gnome versions (<47) under Wayland, issues may be caused by DRM leasing not being available.
 
 ### Fix
 
-Start the SlimeVR Server only after you connected and got an image to alvr at least once.
+Prepend `WAYLAND_DISPLAY=''` to the SteamVR command-line options to force XWayland on SteamVR.
 
-## 109 Error
+## The view shakes when using SlimeVR
 
-The 109 error or others appear.
+This might be fixed in future updates of ALVR.
 
 ### Fix
 
-Start Steam first before starting SteamVR through alvr. If SteamVR is already started, restart it.
+Start the SlimeVR Server only after you have connected and gotten an image to ALVR at least once.
+
+## Error 109
+
+SteamVR displays 109 or other errors.
+
+### Fix
+
+Start Steam first before starting SteamVR through ALVR. If SteamVR is already started, restart it.
 
 ## No audio or microphone
 
-Even though audio or microphone are enabled in presets, still can't hear audio or no one can hear me
+Audio and/or microphone are enabled in presets, but you still can't hear audio or no one can hear you.
 
 ### Fix
 
-Make sure you select `ALVR Audio` and `ALVR Microphone` in device list as default **after** connecting headset. As soon as headset disconnected, devices will be removed. If you set it as default, they will be automatically chosen whenever they show up and you don't need to do it manually ever again.
-If you don't appear to have audio devices, or have pipewire errors in logs, check if you have `pipewire` installed and it's at least version `0.3.49` by using command `pipewire --version`
-For older (<=22.04 or debian <=11) ubuntu or debian based distributions you can check [pipewire-upstream](https://github.com/pipewire-debian/pipewire-debian) page for installing newer pipewire version
+Make sure you select `ALVR Audio` and/or `ALVR Microphone` in your device list as default **after** connecting the headset. As soon as the headset is disconnected, the devices will be removed. If you set them as default, they will be automatically selected whenever they show up, and you won't need to do it manually ever again. If you don't appear to have the audio devices, or have PipeWire errors in your logs, ensure you have `pipewire` version >=0.3.49 installed by using the command `pipewire --version`. For older Debian (<=11) or Ubuntu-based (<=22.04) distributions, you can check the [pipewire-upstream](https://github.com/pipewire-debian/pipewire-debian) page for instructions on installing newer PipeWire versions.
 
 ## Low AMDGPU performance and shutters
 
@@ -133,21 +124,21 @@ This might be caused by [[PERF] Subpar GPU performance due to wrong power profil
 
 ### Fix
 
-Using CoreCtrl is highly advised (install it using your distribution package management) and in settings set your GPU to VR profile, as well as cpu to performance profile (if it's old Ryzen cpu).
+Using CoreCtrl is highly advised (install it using your distribution's package management system). In its settings, set your GPU to the VR profile, as well as CPU to the performance profile (if it's an old Ryzen CPU).
 
 ## OVR Advanced Settings
 
-Disable the OVR Advanced Settings driver and don't use it with ALVR.
-It's incompatible and will produce ladder-like latency graph with very bad shifting vision.
+OVR Advanced Settings is incompatible with ALVR, and will produce a ladder-like latency graph with very bad shifting vision. Disable the OVR Advanced Settings driver, and don't use it with ALVR.
 
+## Bindings not working/high CPU usage due to bindings UI
 
-## Bindings not working/high cpu usage due to bindings ui
+SteamVR can't properly update bindings, open menus, and/or eats too much CPU.
 
-Steamvr can't properly update bindings, open menus, and possibly eats too much cpu.
-
-This issue is caused by SteamVR's webserver spamming requests that stall the chromium ui and causes it to use a lot of cpu.
+This issue is caused by SteamVR's webserver spamming requests that stall the Chromium UI and cause it to use a lot of CPU.
 
 ### Fix
 
-Apply the following patch: `https://github.com/alvr-org/ALVR-Distrobox-Linux-Guide/blob/main/patch_bindings_spam.sh`
-Assuming default path for Arch, Fedora - one-liner: `curl -s https://raw.githubusercontent.com/alvr-org/ALVR-Distrobox-Linux-Guide/main/patch_bindings_spam.sh | sh -s ~/.steam/steam/steamapps/common/SteamVR`
+Apply the following patch: `https://github.com/alvr-org/ALVR-Distrobox-Linux-Guide/blob/main/patch_bindings_spam.sh`.
+
+
+One-liner assuming the default Steam path for Arch, Fedora: `curl -s https://raw.githubusercontent.com/alvr-org/ALVR-Distrobox-Linux-Guide/main/patch_bindings_spam.sh | sh -s ~/.steam/steam/steamapps/common/SteamVR`.


### PR DESCRIPTION
The Linux Troubleshooting page in the Wiki has glaring issues with grammar, spelling, and consistency, which in my opinion harm its usefulness. Capitalization changes were made for consistency throughout the page and with external branding. A few formatting errors/inconsistencies were "corrected" for polish and readability. Spelling changes were made for correctness. Grammar and readability changes were made with my admittedly limited knowledge of proper conventions.

There are also a couple troublesome pieces of information. One is the suggestion for users to insert `~/.local/share/Steam/steamapps/common/SteamVR/bin/vrmonitor.sh %command%` in the launch options for every VR game (they will not launch this way). The other is the suggestion of using `VK_ICD_FILENAMES`, which was deprecated in favor of `VK_DRIVER_FILES` over 3 years ago, and as far as I know is not even relevant in many LTS distros. I tried to make both of these clearer, with a note on the latter for those using older systems.

I use Arch on an Intel+Nvidia laptop with Wayland, if anyone uses a different configuration, please tell me if applicable information should be updated. I tried to confirm most of the details with the current state of things through online searching, but experience knows best!

Hope everything looks good, but tell me if there are issues or objections! Also hoping to look over the rest of the Wiki after this, but I have my priorities as a selfish Linux user...