### PR TITLE
feat(dashboard): ✨ Refactor handling of session paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,7 @@ version = "21.0.0-dev10"
 dependencies = [
  "alvr_common",
  "alvr_session",
+ "nom 8.0.0",
  "serde",
  "serde_json",
 ]
@@ -1274,7 +1275,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -3133,7 +3134,7 @@ dependencies = [
  "libc",
  "libspa-sys",
  "nix 0.27.1",
- "nom",
+ "nom 7.1.3",
  "system-deps",
 ]
 
@@ -3512,6 +3513,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4698,7 +4708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd37602e1513794e952274082d074e8d31aa7f64d047e3acb746c91db40600a5"
 dependencies = [
  "byteorder",
- "nom",
+ "nom 7.1.3",
  "time",
 ]
 

--- a/alvr/dashboard/src/dashboard/components/new_version_popup.rs
+++ b/alvr/dashboard/src/dashboard/components/new_version_popup.rs
@@ -1,6 +1,5 @@
 use crate::dashboard::ServerRequest;
 use alvr_gui_common::ModalButton;
-use alvr_packets::PathValuePair;
 use eframe::egui::{self, Context, OpenUrl, Ui};
 use std::{path::PathBuf, process::Command};
 
@@ -91,12 +90,12 @@ impl NewVersionPopup {
         if let Some(button) = result {
             if button == no_remind_button {
                 Some(CloseAction::CloseWithRequest(
-                    ServerRequest::SetSessionValues(vec![PathValuePair {
-                        path: alvr_packets::parse_path(
-                            "session_settings.extra.new_version_popup.content.hide_while_version",
+                    ServerRequest::SetSessionValues(vec![alvr_packets::parse_path_value_pair(
+                        &format!(
+                            "session_settings.extra.new_version_popup.content.hide_while_version = {}",
+                            self.version
                         ),
-                        value: serde_json::Value::String(self.version.clone()),
-                    }]),
+                    )]),
                 ))
             } else {
                 Some(CloseAction::Close)

--- a/alvr/dashboard/src/dashboard/components/new_version_popup.rs
+++ b/alvr/dashboard/src/dashboard/components/new_version_popup.rs
@@ -90,12 +90,12 @@ impl NewVersionPopup {
         if let Some(button) = result {
             if button == no_remind_button {
                 Some(CloseAction::CloseWithRequest(
-                    ServerRequest::SetSessionValues(vec![alvr_packets::parse_path_value_pair(
+                    ServerRequest::SetSessionValues(alvr_packets::parse_path_value_pairs(
                         &format!(
                             "session_settings.extra.new_version_popup.content.hide_while_version = {}",
                             self.version
                         ),
-                    )]),
+                    ).unwrap()),
                 ))
             } else {
                 Some(CloseAction::Close)

--- a/alvr/dashboard/src/dashboard/components/settings.rs
+++ b/alvr/dashboard/src/dashboard/components/settings.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::dashboard::ServerRequest;
 use alvr_gui_common::{DisplayString, theme};
-use alvr_packets::PathSegment;
+use alvr_packets::{Path, PathSegment};
 use alvr_session::{SessionSettings, Settings};
 use eframe::egui::{self, Align, Frame, Grid, Layout, RichText, ScrollArea, Ui};
 #[cfg(target_arch = "wasm32")]
@@ -42,7 +42,7 @@ pub struct SettingsTab {
 impl SettingsTab {
     pub fn new() -> Self {
         let nesting_info = NestingInfo {
-            path: alvr_packets::parse_path("session_settings"),
+            path: Path(vec![PathSegment::Name("session_settings".to_owned())]),
             indentation_level: 0,
         };
         let schema = Settings::schema(alvr_session::session_settings_default());
@@ -220,7 +220,9 @@ impl SettingsTab {
         }
 
         if !path_value_pairs.is_empty() {
-            requests.push(ServerRequest::SetSessionValues(path_value_pairs));
+            requests.push(ServerRequest::SetSessionValues(
+                alvr_packets::PathValuePairList(path_value_pairs),
+            ));
         }
 
         requests

--- a/alvr/dashboard/src/dashboard/components/settings.rs
+++ b/alvr/dashboard/src/dashboard/components/settings.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::dashboard::ServerRequest;
 use alvr_gui_common::{DisplayString, theme};
+use alvr_packets::PathSegment;
 use alvr_session::{SessionSettings, Settings};
 use eframe::egui::{self, Align, Frame, Grid, Layout, RichText, ScrollArea, Ui};
 #[cfg(target_arch = "wasm32")]
@@ -41,7 +42,7 @@ pub struct SettingsTab {
 impl SettingsTab {
     pub fn new() -> Self {
         let nesting_info = NestingInfo {
-            path: vec!["session_settings".into()],
+            path: alvr_packets::parse_path("session_settings"),
             indentation_level: 0,
         };
         let schema = Settings::schema(alvr_session::session_settings_default());
@@ -58,7 +59,7 @@ impl SettingsTab {
                 let display = super::get_display_name(&id, &entry.strings);
 
                 let mut nesting_info = nesting_info.clone();
-                nesting_info.path.push(id.clone().into());
+                nesting_info.path.push(PathSegment::Name(id.clone()));
 
                 TopLevelEntry {
                     id: DisplayString { id, display },

--- a/alvr/dashboard/src/dashboard/components/settings_controls/array.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/array.rs
@@ -1,5 +1,5 @@
 use super::{NestingInfo, SettingControl, collapsible};
-use alvr_packets::PathValuePair;
+use alvr_packets::{PathSegment, PathValuePair};
 use alvr_session::settings_schema::SchemaNode;
 use eframe::egui::Ui;
 use serde_json as json;
@@ -16,8 +16,10 @@ impl Control {
             .enumerate()
             .map(|(idx, schema)| {
                 let mut nesting_info = nesting_info.clone();
-                nesting_info.path.push("content".into());
-                nesting_info.path.push(idx.into());
+                nesting_info
+                    .path
+                    .push(PathSegment::Name("content".to_string()));
+                nesting_info.path.push(PathSegment::Index(idx));
 
                 SettingControl::new(nesting_info, schema)
             })

--- a/alvr/dashboard/src/dashboard/components/settings_controls/choice.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/choice.rs
@@ -1,6 +1,6 @@
 use super::{NestingInfo, SettingControl, reset};
 use alvr_gui_common::DisplayString;
-use alvr_packets::PathValuePair;
+use alvr_packets::{PathSegment, PathValuePair};
 use alvr_session::settings_schema::{ChoiceControlType, SchemaEntry, SchemaNode};
 use eframe::{
     egui::{ComboBox, Layout, Ui},
@@ -74,7 +74,9 @@ impl Control {
             .into_iter()
             .map(|entry| {
                 let mut nesting_info = nesting_info.clone();
-                nesting_info.path.push(entry.name.clone().into());
+                nesting_info
+                    .path
+                    .push(PathSegment::Name(entry.name.clone()));
 
                 let control = if let Some(schema) = entry.content {
                     SettingControl::new(nesting_info, schema)
@@ -114,7 +116,7 @@ impl Control {
         fn get_request(nesting_info: &NestingInfo, variant: &str) -> Option<PathValuePair> {
             super::get_single_value(
                 nesting_info,
-                "variant".into(),
+                PathSegment::Name("variant".into()),
                 json::Value::String(variant.to_owned()),
             )
         }

--- a/alvr/dashboard/src/dashboard/components/settings_controls/collapsible.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/collapsible.rs
@@ -1,5 +1,5 @@
 use super::NestingInfo;
-use alvr_packets::PathValuePair;
+use alvr_packets::{PathSegment, PathValuePair};
 use eframe::egui::Ui;
 use serde_json as json;
 
@@ -19,7 +19,7 @@ pub fn collapsible_button(
         *state_mut = !*state_mut;
         *request = super::get_single_value(
             nesting_info,
-            "gui_collapsed".into(),
+            PathSegment::Name("gui_collapsed".into()),
             json::Value::Bool(*state_mut),
         );
     }

--- a/alvr/dashboard/src/dashboard/components/settings_controls/dictionary.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/dictionary.rs
@@ -3,7 +3,7 @@ use crate::dashboard::components::{
     collapsible,
     up_down::{self, UpDownResult},
 };
-use alvr_packets::PathValuePair;
+use alvr_packets::{PathSegment, PathValuePair};
 use alvr_session::settings_schema::SchemaNode;
 use eframe::{
     egui::{Layout, TextEdit, Ui},
@@ -57,7 +57,7 @@ impl Control {
         ) -> Option<PathValuePair> {
             super::get_single_value(
                 nesting_info,
-                "content".into(),
+                PathSegment::Name("content".into()),
                 json::to_value(entries).unwrap(),
             )
         }
@@ -85,9 +85,9 @@ impl Control {
         while session_content.len() > self.controls.len() {
             let mut nesting_info = self.nesting_info.clone();
             nesting_info.path.extend_from_slice(&[
-                "content".into(),
-                self.controls.len().into(),
-                1.into(),
+                PathSegment::Name("content".into()),
+                PathSegment::Index(self.controls.len()),
+                PathSegment::Index(1),
             ]);
 
             self.controls.push(Entry {
@@ -139,13 +139,14 @@ impl Control {
                         if response.lost_focus() {
                             if let Some(editing_key_mut) = editing_key_mut {
                                 let mut nesting_info = self.nesting_info.clone();
-                                nesting_info
-                                    .path
-                                    .extend_from_slice(&["content".into(), idx.into()]);
+                                nesting_info.path.extend_from_slice(&[
+                                    PathSegment::Name("content".into()),
+                                    PathSegment::Index(idx),
+                                ]);
 
                                 request = super::get_single_value(
                                     &nesting_info,
-                                    0.into(),
+                                    PathSegment::Index(0),
                                     json::Value::String(editing_key_mut.clone()),
                                 );
 

--- a/alvr/dashboard/src/dashboard/components/settings_controls/mod.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/mod.rs
@@ -14,7 +14,7 @@ pub mod text;
 pub mod up_down;
 pub mod vector;
 
-use alvr_packets::{PathSegment, PathValuePair};
+use alvr_packets::{Path, PathSegment, PathValuePair};
 use alvr_session::settings_schema::SchemaNode;
 use eframe::egui::Ui;
 use serde_json as json;
@@ -73,7 +73,7 @@ pub fn json_values_eq(a: &serde_json::Value, b: &serde_json::Value) -> bool {
 
 #[derive(Clone)]
 pub struct NestingInfo {
-    pub path: Vec<PathSegment>,
+    pub path: Path,
     pub indentation_level: usize,
 }
 

--- a/alvr/dashboard/src/dashboard/components/settings_controls/optional.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/optional.rs
@@ -1,5 +1,5 @@
 use super::{NestingInfo, SettingControl, reset};
-use alvr_packets::PathValuePair;
+use alvr_packets::{PathSegment, PathValuePair};
 use alvr_session::settings_schema::SchemaNode;
 use eframe::{
     egui::{Layout, Ui},
@@ -24,7 +24,7 @@ impl Control {
 
         let control = {
             let mut nesting_info = nesting_info.clone();
-            nesting_info.path.push("content".into());
+            nesting_info.path.push(PathSegment::Name("content".into()));
 
             SettingControl::new(nesting_info, schema_content)
         };
@@ -54,7 +54,11 @@ impl Control {
         let mut request = None;
 
         fn get_request(nesting_info: &NestingInfo, enabled: bool) -> Option<PathValuePair> {
-            super::get_single_value(nesting_info, "set".into(), json::Value::Bool(enabled))
+            super::get_single_value(
+                nesting_info,
+                PathSegment::Name("set".into()),
+                json::Value::Bool(enabled),
+            )
         }
 
         ui.with_layout(Layout::left_to_right(Align::Center), |ui| {

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
 
-use super::schema::{HigherOrderChoiceSchema, PresetModifierOperation};
+use super::schema::HigherOrderChoiceSchema;
 use crate::dashboard::components::{self, INDENTATION_STEP, NestingInfo, SettingControl, notice};
 use alvr_gui_common::theme::{
     OK_GREEN,
     log_colors::{INFO_LIGHT, WARNING_LIGHT},
 };
-use alvr_packets::{PathSegment, PathValuePair};
+use alvr_packets::{Path, PathSegment, PathValuePair};
 use eframe::egui::Ui;
 use serde_json as json;
 use settings_schema::{SchemaEntry, SchemaNode};
@@ -33,38 +33,22 @@ impl Control {
         let modifiers = schema
             .options
             .iter()
-            .map(|option| {
-                (
-                    option.display_name.clone(),
-                    option
-                        .modifiers
-                        .iter()
-                        .map(|modifier| match &modifier.operation {
-                            PresetModifierOperation::Assign(value) => PathValuePair {
-                                path: alvr_packets::parse_path(&modifier.target_path),
-                                value: value.clone(),
-                            },
-                        })
-                        .collect(),
-                )
-            })
+            .map(|option| (option.name.clone(), option.modifiers.clone()))
             .collect();
         let control_schema = SchemaNode::Choice {
             default: schema
                 .options
                 .iter()
-                .find(|option| option.display_name == schema.default_option_display_name)
+                .find(|option| option.name == schema.default_option_name)
                 .unwrap()
-                .display_name
+                .name
                 .clone(),
             variants: schema
                 .options
                 .into_iter()
                 .map(|option| SchemaEntry {
-                    name: option.display_name.clone(),
-                    strings: [("display_name".into(), option.display_name)]
-                        .into_iter()
-                        .collect(),
+                    name: option.name.clone(),
+                    strings: [("display_name".into(), option.name)].into_iter().collect(),
                     flags: HashSet::new(),
                     content: None,
                 })
@@ -74,7 +58,7 @@ impl Control {
 
         let control = SettingControl::new(
             NestingInfo {
-                path: vec![],
+                path: Path(vec![]),
                 indentation_level: 0,
             },
             control_schema,
@@ -99,12 +83,12 @@ impl Control {
     pub fn update_session_settings(&mut self, session_setting_json: &json::Value) {
         let mut selected_option = String::new();
 
-        'outer: for (key, descs) in &self.modifiers {
-            for desc in descs {
+        'outer: for (key, modifiers) in &self.modifiers {
+            for modifier in modifiers {
                 let mut session_ref = session_setting_json;
 
                 // Note: the first path segment is always "settings_schema". Skip that.
-                for segment in &desc.path[1..] {
+                for segment in &modifier.path[1..] {
                     session_ref = match segment {
                         PathSegment::Name(name) => {
                             if let Some(name) = session_ref.get(name) {
@@ -123,7 +107,7 @@ impl Control {
                     };
                 }
 
-                if !components::json_values_eq(session_ref, &desc.value) {
+                if !components::json_values_eq(session_ref, &modifier.value) {
                     continue 'outer;
                 }
             }

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
@@ -33,7 +33,7 @@ impl Control {
         let modifiers = schema
             .options
             .iter()
-            .map(|option| (option.name.clone(), option.modifiers.clone()))
+            .map(|option| (option.name.clone(), option.modifiers.0.clone()))
             .collect();
         let control_schema = SchemaNode::Choice {
             default: schema

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/schema.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/schema.rs
@@ -1,24 +1,12 @@
+use alvr_packets::PathValuePair;
 use serde::{Deserialize, Serialize};
-use serde_json as json;
 use settings_schema::ChoiceControlType;
 use std::collections::{HashMap, HashSet};
 
-#[derive(Serialize, Deserialize, Clone)]
-pub enum PresetModifierOperation {
-    Assign(json::Value),
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct PresetModifier {
-    // session-style path
-    pub target_path: String,
-    pub operation: PresetModifierOperation,
-}
-
 #[derive(Serialize, Deserialize)]
 pub struct HigherOrderChoiceOption {
-    pub display_name: String,
-    pub modifiers: Vec<PresetModifier>,
+    pub name: String,
+    pub modifiers: Vec<PathValuePair>,
     pub content: Option<PresetSchemaNode>,
 }
 
@@ -28,7 +16,7 @@ pub struct HigherOrderChoiceSchema {
     pub strings: HashMap<String, String>,
     pub flags: HashSet<String>,
     pub options: Vec<HigherOrderChoiceOption>,
-    pub default_option_display_name: String,
+    pub default_option_name: String,
     pub gui: ChoiceControlType,
 }
 

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/schema.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/schema.rs
@@ -1,4 +1,4 @@
-use alvr_packets::PathValuePair;
+use alvr_packets::PathValuePairList;
 use serde::{Deserialize, Serialize};
 use settings_schema::ChoiceControlType;
 use std::collections::{HashMap, HashSet};
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 #[derive(Serialize, Deserialize)]
 pub struct HigherOrderChoiceOption {
     pub name: String,
-    pub modifiers: Vec<PathValuePair>,
+    pub modifiers: PathValuePairList,
     pub content: Option<PresetSchemaNode>,
 }
 

--- a/alvr/dashboard/src/dashboard/components/settings_controls/section.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/section.rs
@@ -6,7 +6,7 @@ use alvr_gui_common::{
         log_colors::{INFO_LIGHT, WARNING_LIGHT},
     },
 };
-use alvr_packets::PathValuePair;
+use alvr_packets::{PathSegment, PathValuePair};
 use alvr_session::settings_schema::{SchemaEntry, SchemaNode};
 use eframe::egui::Ui;
 use serde_json as json;
@@ -47,7 +47,7 @@ impl Control {
                 let real_time_flag = entry.flags.contains("real-time");
 
                 let mut nesting_info = nesting_info.clone();
-                nesting_info.path.push(id.clone().into());
+                nesting_info.path.push(PathSegment::Name(id.clone()));
 
                 Entry {
                     id: DisplayString { id, display },

--- a/alvr/dashboard/src/dashboard/components/settings_controls/switch.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/switch.rs
@@ -1,5 +1,5 @@
 use super::{NestingInfo, SettingControl, reset};
-use alvr_packets::PathValuePair;
+use alvr_packets::{PathSegment, PathValuePair};
 use alvr_session::settings_schema::SchemaNode;
 use eframe::{
     egui::{Layout, Ui},
@@ -28,7 +28,7 @@ impl Control {
 
         let control = {
             let mut nesting_info = nesting_info.clone();
-            nesting_info.path.push("content".into());
+            nesting_info.path.push(PathSegment::Name("content".into()));
 
             SettingControl::new(nesting_info, schema_content)
         };
@@ -58,7 +58,11 @@ impl Control {
         let mut request = None;
 
         fn get_request(nesting_info: &NestingInfo, enabled: bool) -> Option<PathValuePair> {
-            super::get_single_value(nesting_info, "enabled".into(), json::Value::Bool(enabled))
+            super::get_single_value(
+                nesting_info,
+                PathSegment::Name("enabled".into()),
+                json::Value::Bool(enabled),
+            )
         }
 
         ui.with_layout(Layout::left_to_right(Align::Center), |ui| {

--- a/alvr/dashboard/src/dashboard/components/settings_controls/vector.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/vector.rs
@@ -3,7 +3,7 @@ use crate::dashboard::components::{
     collapsible,
     up_down::{self, UpDownResult},
 };
-use alvr_packets::PathValuePair;
+use alvr_packets::{PathSegment, PathValuePair};
 use alvr_session::settings_schema::SchemaNode;
 use eframe::{
     egui::{Layout, Ui},
@@ -44,7 +44,11 @@ impl Control {
             nesting_info: &NestingInfo,
             elements: Vec<json::Value>,
         ) -> Option<PathValuePair> {
-            super::get_single_value(nesting_info, "content".into(), json::Value::Array(elements))
+            super::get_single_value(
+                nesting_info,
+                PathSegment::Name("content".into()),
+                json::Value::Array(elements),
+            )
         }
 
         let mut request = None;
@@ -69,8 +73,10 @@ impl Control {
 
         while session_content.len() > self.controls.len() {
             let mut nesting_info = self.nesting_info.clone();
-            nesting_info.path.push("content".into());
-            nesting_info.path.push(self.controls.len().into());
+            nesting_info.path.push(PathSegment::Name("content".into()));
+            nesting_info
+                .path
+                .push(PathSegment::Index(self.controls.len()));
 
             self.controls.push(SettingControl::new(
                 nesting_info,

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -216,12 +216,9 @@ impl eframe::App for Dashboard {
                         SetupWizardRequest::Close { finished } => {
                             if finished {
                                 requests.push(ServerRequest::SetSessionValues(vec![
-                                    PathValuePair {
-                                        path: alvr_packets::parse_path(
-                                            "session_settings.extra.open_setup_wizard",
-                                        ),
-                                        value: serde_json::Value::Bool(false),
-                                    },
+                                    alvr_packets::parse_path_value_pair(
+                                        "session_settings.extra.open_setup_wizard = false",
+                                    ),
                                 ]))
                             }
 

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -13,7 +13,7 @@ use alvr_common::{
 };
 use alvr_events::EventType;
 use alvr_gui_common::theme;
-use alvr_packets::{ClientConnectionsAction, PathValuePair};
+use alvr_packets::{ClientConnectionsAction, PathValuePairList};
 use alvr_session::SessionConfig;
 use eframe::egui::{self, Align, CentralPanel, Frame, Layout, Margin, RichText, SidePanel, Stroke};
 use serde::{Deserialize, Serialize};
@@ -24,7 +24,7 @@ pub enum ServerRequest {
     Log(LogEntry),
     GetSession,
     UpdateSession(Box<SessionConfig>),
-    SetSessionValues(Vec<PathValuePair>),
+    SetSessionValues(PathValuePairList),
     UpdateClientList {
         hostname: String,
         action: ClientConnectionsAction,
@@ -215,11 +215,12 @@ impl eframe::App for Dashboard {
                         }
                         SetupWizardRequest::Close { finished } => {
                             if finished {
-                                requests.push(ServerRequest::SetSessionValues(vec![
-                                    alvr_packets::parse_path_value_pair(
+                                requests.push(ServerRequest::SetSessionValues(
+                                    alvr_packets::parse_path_value_pairs(
                                         "session_settings.extra.open_setup_wizard = false",
-                                    ),
-                                ]))
+                                    )
+                                    .unwrap(),
+                                ))
                             }
 
                             self.setup_wizard_open = false;

--- a/alvr/dashboard/src/data_sources.rs
+++ b/alvr/dashboard/src/data_sources.rs
@@ -219,10 +219,7 @@ impl DataSources {
 
                 while running.value() {
                     while let Ok(request) = requests_receiver.try_recv() {
-                        debug!(
-                            "Dashboard request: {}",
-                            serde_json::to_string(&request).unwrap()
-                        );
+                        debug!("Dashboard request: {request:?}");
 
                         if let SessionSource::Local(session_manager) = &mut *session_source.lock() {
                             match request {

--- a/alvr/packets/Cargo.toml
+++ b/alvr/packets/Cargo.toml
@@ -12,3 +12,4 @@ alvr_session.workspace = true
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+nom = "8"

--- a/alvr/server_core/src/web_server.rs
+++ b/alvr/server_core/src/web_server.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use alvr_common::{ConnectionState, LogEntry, anyhow::Result, error, info, log};
 use alvr_events::{ButtonEvent, EventType};
-use alvr_packets::{ButtonEntry, ClientConnectionsAction, FirewallRulesAction, PathValuePair};
+use alvr_packets::{ButtonEntry, ClientConnectionsAction, FirewallRulesAction, PathValuePairList};
 use alvr_session::SessionConfig;
 use axum::{
     Json, Router,
@@ -167,7 +167,7 @@ async fn update_session(Json(config): Json<SessionConfig>) {
     *SESSION_MANAGER.write().session_mut() = config;
 }
 
-async fn set_session_values(Json(descs): Json<Vec<PathValuePair>>) {
+async fn set_session_values(Json(descs): Json<PathValuePairList>) {
     SESSION_MANAGER.write().set_session_values(descs).ok();
 }
 

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -12,7 +12,7 @@ use alvr_common::{
     error, info,
 };
 use alvr_events::EventType;
-use alvr_packets::{ClientConnectionsAction, PathSegment, PathValuePair};
+use alvr_packets::{ClientConnectionsAction, PathSegment, PathValuePairList};
 use alvr_session::{ClientConnectionConfig, SessionConfig, Settings};
 use serde_json as json;
 use std::{
@@ -153,10 +153,10 @@ impl ServerSessionManager {
     }
 
     // Note: "value" can be any session subtree, in json format.
-    pub fn set_session_values(&mut self, modifiers: Vec<PathValuePair>) -> Result<()> {
+    pub fn set_session_values(&mut self, modifiers: PathValuePairList) -> Result<()> {
         let mut session_json = serde_json::to_value(self.session_config.clone()).unwrap();
 
-        for modifier in modifiers {
+        for modifier in &*modifiers {
             let mut session_ref = &mut session_json;
             for segment in &*modifier.path {
                 session_ref = match segment {

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -153,30 +153,30 @@ impl ServerSessionManager {
     }
 
     // Note: "value" can be any session subtree, in json format.
-    pub fn set_session_values(&mut self, descs: Vec<PathValuePair>) -> Result<()> {
+    pub fn set_session_values(&mut self, modifiers: Vec<PathValuePair>) -> Result<()> {
         let mut session_json = serde_json::to_value(self.session_config.clone()).unwrap();
 
-        for desc in descs {
+        for modifier in modifiers {
             let mut session_ref = &mut session_json;
-            for segment in &desc.path {
+            for segment in &*modifier.path {
                 session_ref = match segment {
                     PathSegment::Name(name) => {
                         if let Some(name) = session_ref.get_mut(name) {
                             name
                         } else {
-                            bail!("From path {:?}: segment \"{name}\" not found", desc.path);
+                            bail!("From path {}: segment \"{name}\" not found", modifier.path);
                         }
                     }
                     PathSegment::Index(index) => {
                         if let Some(index) = session_ref.get_mut(index) {
                             index
                         } else {
-                            bail!("From path {:?}: segment [{index}] not found", desc.path);
+                            bail!("From path {}: segment [{index}] not found", modifier.path);
                         }
                     }
                 };
             }
-            *session_ref = desc.value.clone();
+            *session_ref = modifier.value.clone();
         }
 
         // session_json has been updated


### PR DESCRIPTION
The main benefit of this PR is more readable json text for session paths and modifiers. Also this should prepare for custom presets support (probably I will not work on this before all the tasks for v21 re done).
This is not urgent but I'd like to merge this in the short term. together with previous PRs it should clean up the webserver API and I'd expect no more changes except additions for a while