### PR TITLE
Increased eye buffer resolution

### DIFF
--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -244,12 +244,10 @@ pub fn entry_point() {
             .unwrap();
         assert_eq!(views_config.len(), 2);
 
-        let system_properties = xr_instance.system_properties(xr_system).unwrap();
-
         let default_view_resolution = UVec2::new(
-            system_properties.graphics_properties.max_swapchain_image_width,
-            system_properties.graphics_properties.max_swapchain_image_height,
-        );
+            views_config[0].recommended_image_rect_width,
+            views_config[0].recommended_image_rect_height,
+        ) * 2;
 
         let refresh_rates = if exts.fb_display_refresh_rate {
             xr_session.enumerate_display_refresh_rates().unwrap()


### PR DESCRIPTION
Make ALVR render the lobby at native resolution. This has no significant performance impact but improves the clarity of the text.

This can be turned into an optional feature that can be toggled on or off in the dashboard, or it can be set to match the streaming resolution. That would require the resolution provided by the dashboard to be stored on the client side.

We can also just always have this enabled on supported devices on which the performance impact is negligible, which is what is implemented now.