### PR TITLE
[bugfix] Fix Galaxy XR controller offsets

### DIFF
--- a/alvr/client_openxr/src/interaction.rs
+++ b/alvr/client_openxr/src/interaction.rs
@@ -60,7 +60,6 @@ fn get_controller_offset(platform: Platform, is_right_hand: bool) -> Pose {
             position: Vec3::new(0.0, 0.0, 0.055),
             orientation: Quat::IDENTITY,
         },
-
         _ => Pose::IDENTITY,
     };
 


### PR DESCRIPTION
Measured by touching the controllers together and making the Quest 3 models not overlap, offsets are suspiciously 1/2 the default -0.110 for whatever reason. Also checked the size of the controllers against my actual Quest 3 controllers and everything seems to check out.