### PR TITLE
fix: :bug: Kill zombie ADB processes unconditionally

### DIFF
--- a/alvr/dashboard/src/steamvr_launcher/mod.rs
+++ b/alvr/dashboard/src/steamvr_launcher/mod.rs
@@ -114,13 +114,10 @@ pub struct Launcher {
 
 impl Launcher {
     pub fn launch_steamvr(&self) {
-        // The ADB server might be left running because of a unclean termination of SteamVR
-        // Note that this will also kill a system wide ADB server not started by ALVR
-        let wired_enabled = data_sources::get_read_only_local_session()
-            .session()
-            .client_connections
-            .contains_key(alvr_sockets::WIRED_CLIENT_HOSTNAME);
-        if wired_enabled && let Some(path) = adb::get_adb_path(&crate::get_filesystem_layout()) {
+        // The ADB server might be left running because of an unclean termination of SteamVR.
+        // Kill it unconditionally to ensure clean state, regardless of current connection mode.
+        // Note: this will also kill a system-wide ADB server not started by ALVR.
+        if let Some(path) = adb::get_adb_path(&crate::get_filesystem_layout()) {
             adb::kill_server(&path).ok();
         }
 


### PR DESCRIPTION
Fixes #2743 

## Problem
ADB cleanup only ran when wired mode was enabled. This caused zombie ADB processes to persist when switching between wired and wireless modes after a crash, blocking subsequent SteamVR launches.

## Solution
Remove the `wired_enabled` conditional check in `launch_steamvr()` and always kill zombie ADB processes on launch, regardless of connection mode. Since `adb kill-server` is idempotent, it's safe to run unconditionally.

## Testing
Verified the fix by:
1. Enabling wired mode and launching SteamVR
2. Force-killing vrserver.exe to simulate crash
3. Switching to wireless mode
4. Launching SteamVR - now works correctly (previously blocked by zombie ADB)

Also tested normal operation and the inverse scenario (wireless → wired).

## Changes
- Removed `wired_enabled` check in `alvr/dashboard/src/steamvr_launcher/mod.rs`
- Updated comments to explain unconditional cleanup behavior