### PR TITLE
fix: Normalize Windows header includes to lowercase for cross-compilation

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/Utils.h
+++ b/alvr/server_openvr/cpp/alvr_server/Utils.h
@@ -3,18 +3,18 @@
 #include <chrono>
 #ifdef _WIN32
 #pragma warning(disable : 4005)
-#include <WinSock2.h>
+#include <winsock2.h>
 #pragma warning(default : 4005)
-#include <WS2tcpip.h>
-#include <WinInet.h>
-#include <Windows.h>
 #include <d3d11.h>
 #include <delayimp.h>
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <windows.h>
+#include <wininet.h>
+#include <ws2tcpip.h>
 #define _USE_MATH_DEFINES
-#include <VersionHelpers.h>
+#include <versionhelpers.h>
 #else
 #include <arpa/inet.h>
 #include <netinet/in.h>

--- a/alvr/server_openvr/cpp/platform/win32/CrashHandler.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/CrashHandler.cpp
@@ -2,8 +2,8 @@
 
 #include "../../alvr_server/Logger.h"
 #include "../../shared/backward.hpp"
-#include <Windows.h>
 #include <ostream>
+#include <windows.h>
 
 static LONG WINAPI handler(PEXCEPTION_POINTERS ptrs) {
     backward::StackTrace stacktrace;

--- a/alvr/server_openvr/cpp/platform/win32/d3d-render-utils/RenderUtils.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/d3d-render-utils/RenderUtils.cpp
@@ -1,6 +1,6 @@
 #include "RenderUtils.h"
 
-#include <D3d11_4.h>
+#include <d3d11_4.h>
 
 using namespace std::string_literals;
 using Microsoft::WRL::ComPtr;

--- a/alvr/server_openvr/cpp/platform/win32/shared/d3drender.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/shared/d3drender.cpp
@@ -1,7 +1,7 @@
 //===================== Copyright (c) Valve Corporation. All Rights Reserved. ======================
 #include "d3drender.h"
-#include <D3d11_4.h>
-#include <Evntprov.h>
+#include <d3d11_4.h>
+#include <evntprov.h>
 
 #pragma comment( lib, "dxgi.lib" )
 #pragma comment( lib, "d3d11.lib" )


### PR DESCRIPTION
Standardize all Windows API header includes to use lowercase filenames. This ensures compatibility when cross-compiling on case-sensitive filesystems (Linux with MinGW).