### PR TITLE
fix: missing libvpl.dll causes driver_alvr_server to crash

### DIFF
--- a/alvr/server_openvr/build.rs
+++ b/alvr/server_openvr/build.rs
@@ -114,7 +114,7 @@ fn main() {
 
         build.define("ONEVPL_EXPERIMENTAL", None);
         build.include(vpl_include_path);
-        println!("cargo:rustc-link-lib=static=vpl");
+        println!("cargo:rustc-link-lib=vpl");
     }
 
     build.compile("bindings");

--- a/alvr/xtask/src/build.rs
+++ b/alvr/xtask/src/build.rs
@@ -199,6 +199,13 @@ pub fn build_streamer(
                 sh.copy_file(lib_path.clone(), bin_dir).unwrap();
             }
         }
+
+        // copy libvpl.dll
+        sh.copy_file(
+            afs::deps_dir().join("windows/libvpl/alvr_build/bin/libvpl.dll"),
+            build_layout.openvr_driver_lib_dir(),
+        )
+        .unwrap();
     } else if cfg!(target_os = "linux") {
         // build compositor wrapper
         let _push_guard = sh.push_dir(afs::crate_dir("vrcompositor_wrapper"));

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -92,9 +92,12 @@ fn prepare_libvpl_windows(deps_path: &Path) {
     let install_prefix = final_path.join("alvr_build");
     let _push_guard = sh.push_dir(final_path);
 
-    cmd!(sh, "cmake -B build -DCMAKE_INSTALL_PREFIX={install_prefix}")
-        .run()
-        .unwrap();
+    cmd!(
+        sh,
+        "cmake -B build -DUSE_MSVC_STATIC_RUNTIME=ON -DCMAKE_INSTALL_PREFIX={install_prefix}"
+    )
+    .run()
+    .unwrap();
     cmd!(sh, "cmake --build build --config Release")
         .run()
         .unwrap();

--- a/alvr/xtask/src/packaging.rs
+++ b/alvr/xtask/src/packaging.rs
@@ -51,6 +51,13 @@ pub fn include_licenses(root_path: &Path, gpl: bool) {
         )
         .ok();
     }
+    if cfg!(windows) {
+        sh.copy_file(
+            afs::deps_dir().join("windows/libvpl/alvr_build/share/vpl/licensing/license.txt"),
+            licenses_dir.join("libvpl.txt"),
+        )
+        .unwrap();
+    }
 
     let licenses_content = generate_licenses();
     sh.write_file(licenses_dir.join("dependencies.html"), licenses_content)


### PR DESCRIPTION
Bundles `libvpl.dll` with ALVR Dashboard just like the x264 libraries.
This should fix #3131. See that issue for further details.