### PR TITLE
fix nightly build issues

### DIFF
--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -271,7 +271,7 @@ fn main() {
                 }
                 "check-msrv" => version::check_msrv(),
                 "check-licenses" => {
-                    packaging::generate_licenses();
+                    packaging::generate_licenses(&afs::build_dir().join("dependencies.html"));
                 }
                 "kill-oculus" => kill_oculus_processes(),
                 _ => print_help_and_exit("Unrecognized subcommand."),

--- a/alvr/xtask/src/packaging.rs
+++ b/alvr/xtask/src/packaging.rs
@@ -14,7 +14,7 @@ pub enum ReleaseFlavor {
     PicoStore,
 }
 
-pub fn generate_licenses() -> String {
+pub fn generate_licenses(output_path: &Path) {
     let sh = Shell::new().unwrap();
 
     cmd!(sh, "cargo install cargo-about --version 0.8.4 --locked")
@@ -23,9 +23,12 @@ pub fn generate_licenses() -> String {
 
     let licenses_template = afs::crate_dir("xtask").join("licenses_template.hbs");
 
-    cmd!(sh, "cargo about generate {licenses_template}")
-        .read()
-        .unwrap()
+    cmd!(
+        sh,
+        "cargo about generate {licenses_template} -o {output_path}"
+    )
+    .run()
+    .unwrap();
 }
 
 pub fn include_licenses(root_path: &Path, gpl: bool) {
@@ -59,9 +62,7 @@ pub fn include_licenses(root_path: &Path, gpl: bool) {
         .ok();
     }
 
-    let licenses_content = generate_licenses();
-    sh.write_file(licenses_dir.join("dependencies.html"), licenses_content)
-        .unwrap();
+    generate_licenses(&licenses_dir.join("dependencies.html"));
 }
 
 pub fn package_streamer(

--- a/alvr/xtask/src/packaging.rs
+++ b/alvr/xtask/src/packaging.rs
@@ -56,7 +56,7 @@ pub fn include_licenses(root_path: &Path, gpl: bool) {
             afs::deps_dir().join("windows/libvpl/alvr_build/share/vpl/licensing/license.txt"),
             licenses_dir.join("libvpl.txt"),
         )
-        .unwrap();
+        .ok();
     }
 
     let licenses_content = generate_licenses();


### PR DESCRIPTION
The ALVR-Nightly build pipeline for windows currently fails due to what seems like these two issues:

1. The launcher cannot be built because the required libvpl license is missing. The launcher does not prepare the dependencies like the streamer, thus not downloading libvpl and its license.
2. The streamer cannot be built because `cargo-about` denies outputting to stdout in PowerShell.
```
[ERROR] cargo-about should not redirect its output in powershell, please use the -o, --output-file option to redirect to a file to avoid powershell encoding issues
```

This PR should address both by
- making copying the libvpl license optional (like for example the ffmpeg license) and
- using the suggested `-o` parameter.

I assume that the launcher does not need the libvpl license as it is included with the streamer (where the library is actually used).