### PR TITLE
Fix: frame freezing on Windows (#2931)

### DIFF
--- a/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
@@ -228,8 +228,7 @@ void OvrDirectModeComponent::Present(vr::SharedTextureHandle_t syncTexture) {
         // This enforces scheduling of work on the gpu between processes.
         if (SUCCEEDED(pSyncTexture->QueryInterface(__uuidof(IDXGIKeyedMutex), (void**)&pKeyedMutex)
             )) {
-            // TODO: Reasonable timeout and timeout handling
-            HRESULT hr = pKeyedMutex->AcquireSync(0, 10);
+            HRESULT hr = pKeyedMutex->AcquireSync(0, 500);
             if (hr != S_OK) {
                 Debug(
                     "[VDispDvr] ACQUIRESYNC FAILED!!! hr=%d %p %ls", hr, hr, GetErrorStr(hr).c_str()


### PR DESCRIPTION
Fixes issue #2931 for Windows users.

This also fixes the issue for v20.14.1 (see [this](https://github.com/awa-vr/ALVR/tree/v20.14.1-framerate-fix) branch), so maybe a v20.14.2 to fix this issue before v21 comes out could be nice.