### PR TITLE
fix: windows packaging write cargo-about to file

### DIFF
--- a/alvr/xtask/src/main.rs
+++ b/alvr/xtask/src/main.rs
@@ -271,7 +271,7 @@ fn main() {
                 }
                 "check-msrv" => version::check_msrv(),
                 "check-licenses" => {
-                    packaging::generate_licenses();
+                    packaging::check_licenses();
                 }
                 "kill-oculus" => kill_oculus_processes(),
                 _ => print_help_and_exit("Unrecognized subcommand."),

--- a/alvr/xtask/src/packaging.rs
+++ b/alvr/xtask/src/packaging.rs
@@ -14,18 +14,22 @@ pub enum ReleaseFlavor {
     PicoStore,
 }
 
-pub fn generate_licenses() -> String {
+pub fn generate_licenses(licenses_output: &Path) {
     let sh = Shell::new().unwrap();
-
     cmd!(sh, "cargo install cargo-about --version 0.8.4 --locked")
         .run()
         .unwrap();
-
     let licenses_template = afs::crate_dir("xtask").join("licenses_template.hbs");
+    cmd!(
+        sh,
+        "cargo about generate {licenses_template} -o {licenses_output}"
+    )
+    .run()
+    .unwrap();
+}
 
-    cmd!(sh, "cargo about generate {licenses_template}")
-        .read()
-        .unwrap()
+pub fn check_licenses() {
+    generate_licenses(&std::env::temp_dir().join("dependencies.html"));
 }
 
 pub fn include_licenses(root_path: &Path, gpl: bool) {
@@ -59,9 +63,7 @@ pub fn include_licenses(root_path: &Path, gpl: bool) {
         .unwrap();
     }
 
-    let licenses_content = generate_licenses();
-    sh.write_file(licenses_dir.join("dependencies.html"), licenses_content)
-        .unwrap();
+    generate_licenses(&licenses_dir.join("dependencies.html"));
 }
 
 pub fn package_streamer(


### PR DESCRIPTION
Fixes this issue next time a release is prepared https://github.com/eyJhb/ALVR/actions/runs/23938819603/job/69820607800

```
 cargo install cargo-about --version 0.8.4 --locked
     Ignored package `cargo-about v0.8.4` is already installed, use --force to override
2026-04-03 8:17:39.9671943 +00:00:00 [ERROR] cargo-about should not redirect its output in powershell, please use the -o, --output-file option to redirect to a file to avoid powershell encoding issues

thread 'main' (952) panicked at alvr\xtask\src\packaging.rs:28:10:
called `Result::unwrap()` on an `Err` value: command exited with non-zero code `cargo about generate D:\a\ALVR\ALVR\alvr\xtask\licenses_template.hbs`: 1
stack backtrace:
   0: std::panicking::panic_handler
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library\std\src\panicking.rs:689
   1: core::panicking::panic_fmt
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library\core\src\panicking.rs:80
   2: core::result::unwrap_failed
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library\core\src\result.rs:1867
   3: enum2$<core::result::Result<alloc::string::String,xshell::error::Error> >::unwrap
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library\core\src\result.rs:1233
   4: alvr_xtask::packaging::generate_licenses
             at .\alvr\xtask\src\packaging.rs:28
   5: alvr_xtask::packaging::include_licenses
             at .\alvr\xtask\src\packaging.rs:62
   6: alvr_xtask::packaging::package_launcher
             at .\alvr\xtask\src\packaging.rs:96
   7: alvr_xtask::main
             at .\alvr\xtask\src\main.rs:258
   8: core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library\core\src\ops\function.rs:250
   9: core::hint::black_box
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library\core\src\hint.rs:482
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
error: process didn't exit successfully: `target\debug\alvr_xtask.exe package-launcher --ci` (exit code: 101)
Error: Process completed with exit code 1.
```