### PR TITLE
feat: update/modernize CI 

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,154 +13,100 @@ on:
 
 jobs:
   prepare_release:
-    runs-on: windows-2022
+    runs-on: ubuntu-latest
     outputs:
       release_ref: ${{ steps.output_ref.outputs.release_ref }}
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      release_id: ${{ steps.create_release.outputs.id }}
+      version_tag: ${{ steps.bump_version.outputs.version_tag }}
     steps:
-      - name: Configure git
-        run: git config --global core.autocrlf false
+      - uses: actions/checkout@v6
 
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Bump version
         id: bump_version
         env:
           RUST_BACKTRACE: 1
         run: |
-          $versionarg = "${{ github.event.inputs.version }}"
-          $versionarg = If ($versionarg.Length -gt 0) { "--version $versionarg" } else { "" }
-          $out = cargo xtask bump $versionarg.split()
-          echo $out
+          versionarg="${{ github.event.inputs.version }}"
+          [ -n "$versionarg" ] && versionarg="--version $versionarg" || versionarg=""
+          out=$(cargo xtask bump $versionarg)
+          echo "$out"
           cargo update -p alvr_common
-          echo "::set-output name=version_tag::$(echo $out | sls -CaseSensitive -Pattern '^v.*$')"
+          echo "version_tag=$(echo "$out" | grep -P '^v.*$')" >> $GITHUB_OUTPUT
 
       - name: Push changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "[Auto] Bump version"
 
       - name: Output ref for later checkouts
         id: output_ref
-        run: echo "::set-output name=release_ref::$(git rev-parse HEAD)"
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.bump_version.outputs.version_tag }}
-          release_name: ALVR ${{ steps.bump_version.outputs.version_tag }}
-          draft: true
-          prerelease: false
-          commitish: ${{ steps.output_ref.outputs.release_ref }}
+        run: echo "release_ref=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   build_windows_streamer:
-    runs-on: windows-2022
+    runs-on: windows-latest
     needs: [prepare_release]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare_release.outputs.release_ref }}
           submodules: true
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
 
-      - uses: crazy-max/ghaction-chocolatey@v1
+      - uses: crazy-max/ghaction-chocolatey@v4
         with:
           args: install zip unzip pkgconfiglite wixtoolset
 
       - name: Build and package ALVR
-        id: build
         env:
           RUST_BACKTRACE: 1
         run: |
           cargo xtask package-streamer --gpl --ci
           cargo xtask package-launcher --ci
 
-      - name: Upload streamer
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
         with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/alvr_streamer_windows.zip
-          asset_name: alvr_streamer_windows.zip
-          asset_content_type: application/zip
-      - name: Upload launcher
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/alvr_launcher_windows.zip
-          asset_name: alvr_launcher_windows.zip
-          asset_content_type: application/zip
+          name: windows-streamer
+          path: ./build/alvr_*.zip
 
   build_linux_streamer:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [prepare_release]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare_release.outputs.release_ref }}
           submodules: true
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Build and install dependencies
         env:
           RUST_BACKTRACE: 1
         run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 25088A0359807596
-          echo "deb http://ppa.launchpad.net/pipewire-debian/pipewire-upstream/ubuntu $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/pipewire-upstream.list
           sudo apt-get update
-          sudo apt-get install libfuse2 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+          sudo apt-get install libfuse2t64 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Build and package ALVR (.tar.gz)
-        id: build
         env:
           RUST_BACKTRACE: 1
         run: |
           cargo xtask package-streamer --gpl --ci
           cargo xtask package-launcher --ci
 
-      - name: Upload streamer (tar.gz)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
         with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/alvr_streamer_linux.tar.gz
-          asset_name: alvr_streamer_linux.tar.gz
-          asset_content_type: application/gzip
-      - name: Upload launcher
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/alvr_launcher_linux.tar.gz
-          asset_name: alvr_launcher_linux.tar.gz
-          asset_content_type: application/gzip
+          name: linux-streamer
+          path: ./build/alvr_*_linux.tar.gz
 
   build_flatpak_bundle:
     runs-on: ubuntu-latest
     needs: [prepare_release]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare_release.outputs.release_ref }}
           submodules: true
@@ -174,56 +120,49 @@ jobs:
           sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Build and package ALVR flatpak (.flatpak)
-        id: build_flatpak
         run: |
           sudo flatpak-builder --repo=.flatpak-repo --install-deps-from=flathub --force-clean --default-branch=stable --arch=x86_64 .flatpak-build-dir alvr/xtask/flatpak/com.valvesoftware.Steam.Utility.alvr.json
           flatpak build-bundle .flatpak-repo com.valvesoftware.Steam.Utility.alvr.flatpak com.valvesoftware.Steam.Utility.alvr stable --runtime
 
-      - name: Upload flatpak streamer for Linux
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
         with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: com.valvesoftware.Steam.Utility.alvr.flatpak
-          asset_name: com.valvesoftware.Steam.Utility.alvr.flatpak
-          asset_content_type: application/octet-stream
+          name: flatpak-bundle
+          path: com.valvesoftware.Steam.Utility.alvr.flatpak
 
   build_android_client:
     runs-on: ubuntu-latest
     needs: [prepare_release]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare_release.outputs.release_ref }}
           submodules: true
-        
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: aarch64-linux-android
-          override: true
-      - uses: actions/setup-java@v2
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"
-      - uses: android-actions/setup-android@v3
+
+      - uses: android-actions/setup-android@v4
         with:
           packages: "platforms;android-32"
+
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
           ndk-version: r26b
 
       - name: Build and package ALVR
-        id: build
         env:
           RUST_BACKTRACE: 1
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: cargo xtask package-client --ci
 
       - name: Sign APK
-        uses: ilharp/sign-android-release@v1
+        uses: ilharp/sign-android-release@v2
         id: sign_apk
         with:
           releaseDir: build/alvr_client_android
@@ -233,12 +172,34 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
           buildToolsVersion: 34.0.0
 
-      - name: Upload APK
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
         with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ${{ steps.sign_apk.outputs.signedFile }}
-          asset_name: alvr_client_android.apk
-          asset_content_type: application/vnd.android.package-archive
+          name: android-client
+          path: ${{ steps.sign_apk.outputs.signedFile }}
+
+  publish_release:
+    runs-on: ubuntu-latest
+    needs:
+      [
+        prepare_release,
+        build_windows_streamer,
+        build_linux_streamer,
+        build_flatpak_bundle,
+        build_android_client,
+      ]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          merge-multiple: true
+          path: artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare_release.outputs.version_tag }}
+          draft: true
+          prerelease: false
+          target_commitish: ${{ needs.prepare_release.outputs.release_ref }}
+          files: artifacts/**

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       release_ref: ${{ steps.output_ref.outputs.release_ref }}
       version_tag: ${{ steps.bump_version.outputs.version_tag }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -86,8 +86,8 @@ jobs:
         env:
           RUST_BACKTRACE: 1
         run: |
-          sudo apt-get update
-          sudo apt-get install libfuse2t64 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+          sudo apt update
+          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Build and package ALVR (.tar.gz)
         env:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: crazy-max/ghaction-chocolatey@v4
         with:
-          args: install zip unzip pkgconfiglite wixtoolset
+          args: install zip unzip pkgconfiglite
 
       - name: Build and package ALVR
         env:
@@ -72,7 +72,7 @@ jobs:
           path: ./build/alvr_*.zip
 
   build_linux_streamer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [prepare_release]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/queue.yml
+++ b/.github/workflows/queue.yml
@@ -13,12 +13,14 @@ jobs:
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
@@ -32,7 +34,7 @@ jobs:
       - name: Prepare deps
         env:
           RUST_BACKTRACE: 1
-        run:  cargo xtask prepare-deps --platform linux --no-nvidia
+        run: cargo xtask prepare-deps --platform linux --no-nvidia
 
       - run: cargo clippy
 
@@ -43,11 +45,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
 
-      # Fix actions rust install and msrv both being stupid
-      - run: rustup update
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Prepare deps
         env:
@@ -60,10 +61,12 @@ jobs:
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+
       - uses: dtolnay/rust-toolchain@stable
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
@@ -74,7 +77,7 @@ jobs:
       - name: Prepare deps
         env:
           RUST_BACKTRACE: 1
-        run:  cargo xtask prepare-deps --platform linux --no-nvidia
+        run: cargo xtask prepare-deps --platform linux --no-nvidia
 
       - run: cargo xtask check-msrv
 
@@ -82,10 +85,12 @@ jobs:
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+
       - uses: dtolnay/rust-toolchain@stable
+
       - uses: Swatinem/rust-cache@v2
 
       - run: cargo xtask check-licenses

--- a/.github/workflows/queue.yml
+++ b/.github/workflows/queue.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Install dependencies
         run: |
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 25088A0359807596
@@ -48,8 +46,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Prepare deps
         env:
           RUST_BACKTRACE: 1
@@ -66,8 +62,6 @@ jobs:
           submodules: true
 
       - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
         run: |
@@ -90,7 +84,5 @@ jobs:
           submodules: true
 
       - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
 
       - run: cargo xtask check-licenses

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,12 +12,14 @@ jobs:
   check-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Prepare deps
@@ -30,9 +32,10 @@ jobs:
   check-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -46,19 +49,21 @@ jobs:
       - name: Prepare deps
         env:
           RUST_BACKTRACE: 1
-        run:  cargo xtask prepare-deps --platform linux --no-nvidia
+        run: cargo xtask prepare-deps --platform linux --no-nvidia
 
       - run: cargo xtask clippy --ci
 
   check-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+
       - uses: Swatinem/rust-cache@v2
 
       # This step currently does nothing on macos, but might in the future
@@ -69,20 +74,25 @@ jobs:
   build-android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android
+
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-java@v2
+
+      - uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '17'
-      - uses: android-actions/setup-android@v3
+          distribution: "temurin"
+          java-version: "17"
+
+      - uses: android-actions/setup-android@v4
         with:
-          packages: 'platforms;android-32'
+          packages: "platforms;android-32"
+
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
@@ -103,10 +113,11 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: dtolnay/rust-toolchain@stable
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Run tests
@@ -115,7 +126,8 @@ jobs:
   check-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,44 @@ jobs:
 
       - run: cargo xtask clippy --ci
 
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: crazy-max/ghaction-chocolatey@v4
+        with:
+          args: install zip unzip pkgconfiglite wixtoolset
+
+      - name: Prepare deps
+        env:
+          RUST_BACKTRACE: 1
+        run: cargo xtask prepare-deps --platform windows
+
+      - name: Build and package ALVR (.zip)
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          mkdir artifacts/
+          cargo xtask build-streamer --platform windows --ci
+          zip -r9X artifacts/alvr_streamer_windows.zip ./build/alvr_streamer*
+          cargo xtask build-launcher --platform windows --ci
+          zip -r9X artifacts/alvr_launcher_windows.zip ./build/alvr_launcher*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: check-windows
+          path: ./artifacts/*
+
   check-linux:
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+          sudo apt-get install libfuse2t64 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Prepare deps
         env:
@@ -52,6 +90,45 @@ jobs:
         run: cargo xtask prepare-deps --platform linux --no-nvidia
 
       - run: cargo xtask clippy --ci
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install libfuse2t64 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+
+      - name: Prepare deps
+        env:
+          RUST_BACKTRACE: 1
+        run: cargo xtask prepare-deps --platform linux
+
+      - name: Build and package ALVR (.tar.gz)
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          set -e
+          mkdir artifacts/
+          cargo xtask build-streamer --platform linux --ci
+          tar -cJf artifacts/alvr_streamer_linux.tar.xz ./build/alvr_streamer*
+          cargo xtask build-launcher --platform linux --ci
+          tar -cJf artifacts/alvr_launcher_linux.tar.xz ./build/alvr_launcher*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: check-linux
+          path: ./artifacts/*
 
   check-macos:
     runs-on: macos-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [master]
   merge_group:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -30,21 +31,16 @@ jobs:
       - run: cargo xtask clippy --ci
 
   build-windows:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - uses: Swatinem/rust-cache@v2
-
       - uses: crazy-max/ghaction-chocolatey@v4
         with:
-          args: install zip unzip pkgconfiglite wixtoolset
+          args: install zip unzip pkgconfiglite
 
       - name: Prepare deps
         env:
@@ -82,7 +78,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt-get install libfuse2t64 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Prepare deps
         env:
@@ -92,21 +88,17 @@ jobs:
       - run: cargo xtask clippy --ci
 
   build-linux:
-    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt-get install libfuse2t64 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Prepare deps
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Prepare deps
         env:
@@ -98,7 +98,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
+          sudo apt install build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libasound2-dev libxrandr-dev libunwind-dev libgtk-3-dev libpipewire-0.3-dev libspa-0.2-dev
 
       - name: Prepare deps
         env:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           exempt-issue-labels: 'bug,documentation,enhancement,good-first-issue,hep-wanted,needs-testing,release'

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -9,7 +9,8 @@ jobs:
   wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+
       - name: Publish to wiki
         uses: cmbrose/github-docs-to-wiki@v0.24
         with:


### PR DESCRIPTION
Updates the CI actions to the latest version of all actions + replaces prepare-release runner with Linux instead of Windows.
It also replaces a bunch of deprecated actions, with the newer replacements.

Github CI will deprecate Node 20 ~June this year. These changes should resolve this, as it was heavily used in some actions.

I've run the CI on my own fork to validate it works.

- Release CI: https://github.com/eyJhb/ALVR/actions/runs/23997973402
- Merge Queue CI: https://github.com/eyJhb/ALVR/actions/runs/23999470028
- Release Example: https://github.com/eyJhb/ALVR/releases/tag/v21.0.0-dev-update-ci5

I changed to use artifacts for releases, which has the nice benefit of the artifacts being added to the release CI run.