### PR TITLE
fix: temporarily remove lynx (unable to download loader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,23 @@ This is a fork of [ALVR](https://github.com/polygraphene/ALVR).
 |     Pico Neo 3/4/4 Ultra     |                                   :heavy_check_mark:                                   |
 |    Play For Dream YVR 1/2/MR |                                   :heavy_check_mark:                                   |
 | Vive Focus 3/Vision/XR Elite |                                   :heavy_check_mark:                                   |
-|           Lynx R1            |                                   :heavy_check_mark:                                   |
 |     PhoneVR (smartphone)     |     :heavy_check_mark: ** ([repo](https://github.com/PhoneVR-Developers/PhoneVR))      |
-|        Android/Monado        |                                      :warning: **                                      |
+|        Android/Monado        |                                   :warning: **                                         |
+|           Lynx R1            |                                   :warning: ***                                        |
 |          Oculus Go           |                 :x: ([old repo](https://github.com/polygraphene/ALVR))                 |
 
 \* ALVR for Quest 1 is not available through the Meta store.  
-\** Works on some smartphones, but has not been extensively tested.  
+\** Works on some smartphones, but has not been extensively tested.
+\*** Temporarily removed, last supported on version [20.14.1](https://github.com/alvr-org/ALVR/releases/tag/v20.14.1).
 
 |     PC OS      |                                    Support                                    |
 | :------------: | :---------------------------------------------------------------------------: |
 | Windows 10/11  | :heavy_check_mark: ([store link](https://store.steampowered.com/app/3312710)) |
 | Windows XP/7/8 |                                      :x:                                      |
-|     Linux      |                             :heavy_check_mark:***                             |
+|     Linux      |                             :heavy_check_mark:****                            |
 |     macOS      |                                      :x:                                      |
 
-\*** Please check the wiki for detailed compatibility information.
+\**** Please check the wiki for detailed compatibility information.
 
 ### Requirements
 

--- a/alvr/client_openxr/Cargo.toml
+++ b/alvr/client_openxr/Cargo.toml
@@ -202,12 +202,6 @@ value = "5900"
 name = "com.yvr.intent.category.VR"
 value = "vr_only"
 
-# Lynx entries
-[[package.metadata.android.queries.package]]
-name = "com.ultraleap.tracking.service"
-[[package.metadata.android.queries.package]]
-name = "com.ultraleap.openxr.api_layer"
-
 # Android XR
 [[package.metadata.android.uses_feature]]
 name = "android.software.xr.api.spatial"

--- a/alvr/client_openxr/src/lib.rs
+++ b/alvr/client_openxr/src/lib.rs
@@ -175,7 +175,6 @@ pub fn entry_point() {
         | Platform::Pico4Enterprise => ("_pico_old", LEGACY_OPENXR_VERSION),
         p if p.is_vive() => ("", LEGACY_OPENXR_VERSION),
         p if p.is_yvr() => ("_yvr", LEGACY_OPENXR_VERSION),
-        Platform::Lynx => ("_lynx", LEGACY_OPENXR_VERSION),
         _ => ("", CURRENT_OPENXR_VERSION),
     };
     let xr_entry = unsafe {

--- a/alvr/client_openxr/src/stream.rs
+++ b/alvr/client_openxr/src/stream.rs
@@ -193,10 +193,9 @@ impl StreamContext {
             ],
             format,
             config.foveated_encoding_config.clone(),
-            core_ctx.platform() != Platform::Lynx
-                && !((core_ctx.platform().is_pico()
-                    || (core_ctx.platform() == Platform::SamsungGalaxyXR))
-                    && config.enable_hdr),
+            !((core_ctx.platform().is_pico()
+                || (core_ctx.platform() == Platform::SamsungGalaxyXR))
+                && config.enable_hdr),
             // TODO: Find a driver heuristic for the limited range bug instead?
             core_ctx.platform() != Platform::SamsungGalaxyXR && !config.enable_hdr,
             config.encoding_gamma,

--- a/alvr/system_info/src/lib.rs
+++ b/alvr/system_info/src/lib.rs
@@ -34,7 +34,6 @@ pub enum Platform {
     ViveUnknown,
     Yvr,
     PlayForDreamMR,
-    Lynx,
     SamsungGalaxyXR,
     AndroidUnknown,
     VisionOSHeadset,
@@ -104,7 +103,6 @@ impl Display for Platform {
             Self::ViveUnknown => "HTC VIVE (unknown)",
             Self::Yvr => "YVR",
             Self::PlayForDreamMR => "Play For Dream MR",
-            Self::Lynx => "Lynx Headset",
             Self::SamsungGalaxyXR => "Samsung Galaxy XR",
             Self::AndroidUnknown => "Android (unknown)",
             Self::VisionOSHeadset => "visionOS Headset",
@@ -159,7 +157,6 @@ pub fn platform(runtime_name: Option<String>, runtime_version: Option<u64>) -> P
             ("HTC", _, _, _) => Platform::ViveUnknown,
             ("YVR", _, _, _) => Platform::Yvr,
             ("Play For Dream", _, _, _) => Platform::PlayForDreamMR,
-            ("Lynx Mixed Reality", _, _, _) => Platform::Lynx,
             ("samsung", _, "xrvst2", _) => Platform::SamsungGalaxyXR,
             _ => Platform::AndroidUnknown,
         }

--- a/alvr/xtask/src/dependencies.rs
+++ b/alvr/xtask/src/dependencies.rs
@@ -364,12 +364,6 @@ fn get_android_openxr_loaders(selection: OpenXRLoadersSelection) {
         "https://developer.yvrdream.com/yvrdoc/sdk/openxr/yvr_openxr_mobile_sdk_2.0.0.zip",
         "yvr_openxr_mobile_sdk_2.0.0/OpenXR/Libs/Android/arm64-v8a",
     );
-
-    get_openxr_loader(
-        "_lynx",
-        "https://portal.lynx-r.com/downloads/download/16", // version 1.0.0
-        "jni/arm64-v8a",
-    );
 }
 
 pub fn build_android_deps(


### PR DESCRIPTION
It is currently not possible to download OpenXR loaders, for the lynx headset because of errors on their developer portal.