### PR TITLE
fix: only count ALVR process names for early init

### DIFF
--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -484,19 +484,10 @@ pub unsafe extern "C" fn HmdDriverFactory(
         return ptr::null_mut();
     };
 
-    let dashboard_process_paths = sysinfo::System::new_all()
+    let system = sysinfo::System::new_all();
+    let dashboard_processes = system
         .processes_by_name(OsStr::new(&afs::dashboard_fname()))
-        .filter_map(|proc| Some(proc.exe()?.to_owned()))
         .collect::<Vec<_>>();
-
-    // Check that there is no active dashboard instance not part of this driver installation
-    // Note: if the iterator is empty, `all()` returns true
-    if !dashboard_process_paths
-        .iter()
-        .all(|path| *path == filesystem_layout.dashboard_exe())
-    {
-        return ptr::null_mut();
-    }
 
     static ONCE: Once = Once::new();
     ONCE.call_once(move || {
@@ -549,7 +540,7 @@ pub unsafe extern "C" fn HmdDriverFactory(
             // When there is already a ALVR dashboard running, initialize the HMD device early to
             // avoid buggy SteamVR behavior
             // NB: we already bail out before if the dashboards don't belong to this streamer
-            let early_hmd_initialization = !dashboard_process_paths.is_empty();
+            let early_hmd_initialization = !dashboard_processes.is_empty();
 
             CppInit(early_hmd_initialization);
         }


### PR DESCRIPTION
Previously the full executable path was counted as well, but for Linux distros such as NixOS, this causes issues as Steam runs inside bubblewrap, which means the openvr server does as well, which does not has access to the full exe path.

Instead we just count the number of processes with the `alvr_dashboard` name.

This fixes issue #3244 .