### PR TITLE
chore(ci): add dev artifact workflow

### DIFF
--- a/.github/workflows/dev-artifacts.yml
+++ b/.github/workflows/dev-artifacts.yml
@@ -1,0 +1,94 @@
+name: Build dev artifacts
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: crazy-max/ghaction-chocolatey@v4
+        with:
+          args: install zip unzip pkgconfiglite
+
+      - name: Prepare dependencies
+        env:
+          RUST_BACKTRACE: 1
+        run: cargo xtask prepare-deps --platform windows
+
+      - name: Build Windows streamer and launcher
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          mkdir artifacts/
+          cargo xtask build-streamer --platform windows --ci
+          zip -r9X artifacts/alvr_streamer_windows.zip ./build/alvr_streamer*
+          cargo xtask build-launcher --platform windows --ci
+          zip -r9X artifacts/alvr_launcher_windows.zip ./build/alvr_launcher*
+
+      - name: Upload Windows launcher
+        uses: actions/upload-artifact@v7
+        with:
+          name: alvr-launcher-windows
+          path: artifacts/alvr_launcher_windows.zip
+
+      - name: Upload Windows streamer
+        uses: actions/upload-artifact@v7
+        with:
+          name: alvr-streamer-windows
+          path: artifacts/alvr_streamer_windows.zip
+
+  build-quest-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: android-actions/setup-android@v4
+        with:
+          packages: "platforms;android-32"
+
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r26b
+
+      - name: Prepare dependencies
+        env:
+          RUST_BACKTRACE: 1
+        run: cargo xtask prepare-deps --platform android
+
+      - name: Build Quest client APK
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          RUST_BACKTRACE: 1
+        run: cargo xtask build-client
+
+      - name: Upload Quest client APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: alvr-client-quest-apk
+          path: build/alvr_client_android/alvr_client_android.apk


### PR DESCRIPTION
Add an on-demand workflow so the fork can produce Windows launcher, Windows streamer, and Quest client APK artifacts for development installs.