### PR TITLE
feat(docker): Add Docker-based build scripts for Linux and Windows cross-compilation from macOS

### DIFF
--- a/alvr/server_openvr/build.rs
+++ b/alvr/server_openvr/build.rs
@@ -1,8 +1,8 @@
 use std::{env, path::PathBuf};
 
-fn get_vulkan_headers_path() -> PathBuf {
+fn get_vulkan_headers_path(platform_name: &str) -> PathBuf {
     alvr_filesystem::deps_dir()
-        .join(if cfg!(target_os = "linux") {
+        .join(if platform_name == "linux" {
             "linux"
         } else {
             "windows"
@@ -10,23 +10,22 @@ fn get_vulkan_headers_path() -> PathBuf {
         .join("vulkan-headers/include")
 }
 
-fn get_ffmpeg_path() -> PathBuf {
+fn get_ffmpeg_path(platform_name: &str) -> PathBuf {
     let ffmpeg_path = alvr_filesystem::deps_dir()
-        .join(if cfg!(target_os = "linux") {
+        .join(if platform_name == "linux" {
             "linux"
         } else {
             "windows"
         })
         .join("ffmpeg");
 
-    if cfg!(target_os = "linux") {
+    if platform_name == "linux" {
         ffmpeg_path.join("alvr_build")
     } else {
         ffmpeg_path
     }
 }
 
-#[cfg(all(target_os = "linux", feature = "gpl"))]
 fn get_linux_x264_path() -> PathBuf {
     alvr_filesystem::deps_dir().join("linux/x264/alvr_build")
 }
@@ -91,33 +90,34 @@ fn main() {
     #[cfg(debug_assertions)]
     build.define("ALVR_DEBUG_LOG", None);
 
-    let gpl_or_linux = cfg!(feature = "gpl") || cfg!(target_os = "linux");
+    let gpl_or_linux = cfg!(feature = "gpl") || platform_name == "linux";
 
     if gpl_or_linux {
-        let ffmpeg_path = get_ffmpeg_path();
+        let ffmpeg_path = get_ffmpeg_path(&platform_name);
 
         assert!(ffmpeg_path.join("include").exists());
 
-        let vulkan_headers = get_vulkan_headers_path();
+        let vulkan_headers = get_vulkan_headers_path(&platform_name);
         assert!(vulkan_headers.exists());
         build.include(vulkan_headers);
 
         build.include(ffmpeg_path.join("include"));
     }
 
-    #[cfg(all(target_os = "linux", feature = "gpl"))]
-    {
-        let x264_path = get_linux_x264_path();
+    if platform_name == "linux" {
+        #[cfg(feature = "gpl")]
+        {
+            let x264_path = get_linux_x264_path();
 
-        assert!(x264_path.join("include").exists());
-        build.include(x264_path.join("include"));
+            assert!(x264_path.join("include").exists());
+            build.include(x264_path.join("include"));
+        }
     }
 
     #[cfg(feature = "gpl")]
     build.define("ALVR_GPL", None);
 
-    #[cfg(target_os = "windows")]
-    {
+    if platform_name == "windows" {
         let vpl_path = alvr_filesystem::deps_dir().join("windows/libvpl/alvr_build");
         let vpl_include_path = vpl_path.join("include");
         let vpl_lib_path = vpl_path.join("lib");
@@ -134,39 +134,42 @@ fn main() {
 
     build.compile("bindings");
 
-    #[cfg(all(target_os = "linux", feature = "gpl"))]
-    {
-        let x264_path = get_linux_x264_path();
-        let x264_lib_path = x264_path.join("lib");
+    if platform_name == "linux" {
+        #[cfg(feature = "gpl")]
+        {
+            let x264_path = get_linux_x264_path();
+            let x264_lib_path = x264_path.join("lib");
 
-        println!(
-            "cargo:rustc-link-search=native={}",
-            x264_lib_path.to_string_lossy()
-        );
+            println!(
+                "cargo:rustc-link-search=native={}",
+                x264_lib_path.to_string_lossy()
+            );
 
-        let x264_pkg_path = x264_lib_path.join("pkgconfig");
-        assert!(x264_pkg_path.exists());
+            let x264_pkg_path = x264_lib_path.join("pkgconfig");
+            assert!(x264_pkg_path.exists());
 
-        let x264_pkg_path = x264_pkg_path.to_string_lossy().to_string();
-        unsafe {
-            env::set_var(
-                "PKG_CONFIG_PATH",
-                env::var("PKG_CONFIG_PATH").map_or(x264_pkg_path.clone(), |old| {
-                    format!("{x264_pkg_path}:{old}")
-                }),
-            )
-        };
-        println!("cargo:rustc-link-lib=static=x264");
+            let x264_pkg_path = x264_pkg_path.to_string_lossy().to_string();
+            unsafe {
+                env::set_var(
+                    "PKG_CONFIG_PATH",
+                    env::var("PKG_CONFIG_PATH").map_or(x264_pkg_path.clone(), |old| {
+                        format!("{x264_pkg_path}:{old}")
+                    }),
+                )
+            };
+            println!("cargo:rustc-link-lib=static=x264");
 
-        pkg_config::Config::new()
-            .statik(true)
-            .probe("x264")
-            .unwrap();
+            #[cfg(target_os = "linux")]
+            pkg_config::Config::new()
+                .statik(true)
+                .probe("x264")
+                .unwrap();
+        }
     }
 
     // ffmpeg
     if gpl_or_linux {
-        let ffmpeg_path = get_ffmpeg_path();
+        let ffmpeg_path = get_ffmpeg_path(&platform_name);
         let ffmpeg_lib_path = ffmpeg_path.join("lib");
 
         assert!(ffmpeg_lib_path.exists());
@@ -176,8 +179,7 @@ fn main() {
             ffmpeg_lib_path.to_string_lossy()
         );
 
-        #[cfg(target_os = "linux")]
-        {
+        if platform_name == "linux" {
             let ffmpeg_pkg_path = ffmpeg_lib_path.join("pkgconfig");
             assert!(ffmpeg_pkg_path.exists());
 
@@ -191,15 +193,18 @@ fn main() {
                 )
             };
 
-            let pkg = pkg_config::Config::new().statik(true).to_owned();
+            #[cfg(target_os = "linux")]
+            {
+                let pkg = pkg_config::Config::new().statik(true).to_owned();
 
-            for lib in ["libavutil", "libavfilter", "libavcodec"] {
-                pkg.probe(lib).unwrap();
+                for lib in ["libavutil", "libavfilter", "libavcodec"] {
+                    pkg.probe(lib).unwrap();
+                }
             }
-        }
-        #[cfg(windows)]
-        for lib in ["avutil", "avfilter", "avcodec", "swscale"] {
-            println!("cargo:rustc-link-lib={lib}");
+        } else if platform_name == "windows" {
+            for lib in ["avutil", "avfilter", "avcodec", "swscale"] {
+                println!("cargo:rustc-link-lib={lib}");
+            }
         }
     }
 
@@ -230,12 +235,12 @@ fn main() {
         println!("cargo:rustc-link-lib=openvr_api");
     }
 
-    #[cfg(target_os = "linux")]
-    {
-        pkg_config::Config::new().probe("vulkan").unwrap();
-
-        #[cfg(not(feature = "gpl"))]
+    if platform_name == "linux" {
+        #[cfg(target_os = "linux")]
         {
+            pkg_config::Config::new().probe("vulkan").unwrap();
+
+            #[cfg(not(feature = "gpl"))]
             pkg_config::Config::new().probe("x264").unwrap();
         }
 

--- a/alvr/server_openvr/build.rs
+++ b/alvr/server_openvr/build.rs
@@ -26,6 +26,7 @@ fn get_ffmpeg_path(platform_name: &str) -> PathBuf {
     }
 }
 
+#[cfg(all(target_os = "linux", feature = "gpl"))]
 fn get_linux_x264_path() -> PathBuf {
     alvr_filesystem::deps_dir().join("linux/x264/alvr_build")
 }

--- a/docker/Dockerfile.linux-build
+++ b/docker/Dockerfile.linux-build
@@ -1,0 +1,32 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System dependencies matching CI (ubuntu-24.04)
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    pkg-config \
+    nasm \
+    libva-dev \
+    libdrm-dev \
+    libvulkan-dev \
+    libx264-dev \
+    libasound2-dev \
+    libxrandr-dev \
+    libunwind-dev \
+    libgtk-3-dev \
+    libpipewire-0.3-dev \
+    libspa-0.2-dev \
+    curl \
+    unzip \
+    git \
+    cmake \
+    clang \
+    libclang-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust toolchain (stable, matching CI)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain stable --profile minimal
+
+ENV PATH="/root/.cargo/bin:${PATH}"

--- a/docker/Dockerfile.windows-build
+++ b/docker/Dockerfile.windows-build
@@ -1,0 +1,35 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base build tools
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    unzip \
+    zip \
+    cmake \
+    pkg-config \
+    wget \
+    gnupg \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# LLVM 19 — Ubuntu 24.04 ships clang-18 but MSVC STL requires clang 19+
+RUN wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key && \
+    echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" \
+        > /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && apt-get install -y clang-19 lld-19 llvm-19 && \
+    update-alternatives --install /usr/bin/clang    clang    /usr/bin/clang-19    100 \
+        --slave /usr/bin/clang++  clang++  /usr/bin/clang++-19 \
+        --slave /usr/bin/clang-cl clang-cl /usr/bin/clang-cl-19 \
+        --slave /usr/bin/lld-link lld-link /usr/bin/lld-link-19 \
+        --slave /usr/bin/llvm-lib llvm-lib /usr/bin/llvm-lib-19 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Rust with Windows MSVC target + cargo-xwin
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup target add x86_64-pc-windows-msvc && \
+    cargo install cargo-xwin

--- a/docker/build-linux.sh
+++ b/docker/build-linux.sh
@@ -3,6 +3,7 @@
 #
 # Usage:
 #   ./docker/build-linux.sh                    # full build: prepare-deps + build-streamer + build-launcher
+#   ./docker/build-linux.sh check              # cargo check -D warnings (matches CI)
 #   ./docker/build-linux.sh <xtask-args...>    # run a specific cargo xtask subcommand
 #   ./docker/build-linux.sh shell              # drop into an interactive shell
 #
@@ -57,6 +58,15 @@ if [[ $# -eq 0 ]]; then
         cargo xtask prepare-deps --platform linux
         cargo xtask build-streamer --platform linux
         cargo xtask build-launcher --platform linux
+    "
+elif [[ "$1" == "check" ]]; then
+    run_in_container bash -c "
+        set -e
+        cargo xtask prepare-deps --platform linux
+        RUSTFLAGS='-D warnings' cargo check \
+            -p alvr_server_openvr \
+            -p alvr_dashboard \
+            -p alvr_launcher
     "
 elif [[ "$1" == "shell" ]]; then
     run_in_container bash

--- a/docker/build-linux.sh
+++ b/docker/build-linux.sh
@@ -22,11 +22,15 @@ CARGO_TARGET_VOLUME="alvr-linux-cargo-target"
 CARGO_REGISTRY_VOLUME="alvr-linux-cargo-registry"
 
 build_image() {
-    # DOCKER_BUILDKIT=0 + --network=host is required on macOS Docker Desktop:
-    # buildkit's DNS resolution fails for some hosts (e.g. sh.rustup.rs) during
-    # build, but works fine in running containers.
-    DOCKER_BUILDKIT=0 docker build \
+    # --platform linux/amd64 ensures x86_64 even on Apple Silicon — our target is
+    # always x86_64 Linux and openvr/ffmpeg deps are x86_64-only.
+    # docker buildx + --network=host works around buildkit DNS failures on macOS
+    # Docker Desktop that affect plain `docker build --network=host`.
+    # --load makes the built image available in the local docker images store.
+    docker buildx build \
+        --platform linux/amd64 \
         --network=host \
+        --load \
         --file "$SCRIPT_DIR/Dockerfile.linux-build" \
         --tag "$IMAGE_NAME" \
         "$SCRIPT_DIR"

--- a/docker/build-linux.sh
+++ b/docker/build-linux.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Cross-build ALVR for Linux from macOS using Docker (Ubuntu 24.04).
+#
+# Usage:
+#   ./docker/build-linux.sh                    # full build: prepare-deps + build-streamer + build-launcher
+#   ./docker/build-linux.sh <xtask-args...>    # run a specific cargo xtask subcommand
+#   ./docker/build-linux.sh shell              # drop into an interactive shell
+#
+# Build artifacts land in build/alvr_streamer_linux/ and build/alvr_launcher_linux/
+# as they would from CI.
+#
+# The Rust target dir is kept in a named Docker volume (alvr-linux-cargo-target)
+# so it persists across builds without conflicting with the macOS target/ dir.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IMAGE_NAME="alvr-linux-build"
+CARGO_TARGET_VOLUME="alvr-linux-cargo-target"
+CARGO_REGISTRY_VOLUME="alvr-linux-cargo-registry"
+
+build_image() {
+    # DOCKER_BUILDKIT=0 + --network=host is required on macOS Docker Desktop:
+    # buildkit's DNS resolution fails for some hosts (e.g. sh.rustup.rs) during
+    # build, but works fine in running containers.
+    DOCKER_BUILDKIT=0 docker build \
+        --network=host \
+        --file "$SCRIPT_DIR/Dockerfile.linux-build" \
+        --tag "$IMAGE_NAME" \
+        "$SCRIPT_DIR"
+}
+
+run_in_container() {
+    docker run --rm \
+        --volume "$REPO_ROOT:/workspace" \
+        --volume "$CARGO_TARGET_VOLUME:/cargo-target" \
+        --volume "$CARGO_REGISTRY_VOLUME:/root/.cargo/registry" \
+        --env CARGO_TARGET_DIR=/cargo-target \
+        --env CARGO_TERM_COLOR=always \
+        --env RUST_BACKTRACE=1 \
+        --workdir /workspace \
+        "$IMAGE_NAME" \
+        "$@"
+}
+
+build_image
+
+if [[ $# -eq 0 ]]; then
+    run_in_container bash -c "
+        set -e
+        cargo xtask prepare-deps --platform linux
+        cargo xtask build-streamer --platform linux
+        cargo xtask build-launcher --platform linux
+    "
+elif [[ "$1" == "shell" ]]; then
+    run_in_container bash
+else
+    run_in_container cargo xtask "$@"
+fi

--- a/docker/build-linux.sh
+++ b/docker/build-linux.sh
@@ -63,6 +63,7 @@ elif [[ "$1" == "check" ]]; then
     run_in_container bash -c "
         set -e
         cargo xtask prepare-deps --platform linux
+        cargo clean -p alvr_server_openvr -p alvr_dashboard -p alvr_launcher
         RUSTFLAGS='-D warnings' cargo check \
             -p alvr_server_openvr \
             -p alvr_dashboard \

--- a/docker/build-windows.sh
+++ b/docker/build-windows.sh
@@ -144,6 +144,7 @@ if [[ $# -eq 0 ]]; then
     "
 elif [[ "$1" == "check" ]]; then
     run_in_container bash -c "
+        cargo clean -p alvr_server_openvr -p alvr_dashboard -p alvr_launcher
         RUSTFLAGS='-D warnings' cargo xwin check \
             --target $TARGET \
             -p alvr_server_openvr \

--- a/docker/build-windows.sh
+++ b/docker/build-windows.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Cross-build ALVR for Windows (x86_64-pc-windows-msvc) from macOS using Docker.
+#
+# Usage:
+#   ./docker/build-windows.sh                  # full build
+#   ./docker/build-windows.sh <xtask-args...>  # run a specific cargo xtask subcommand
+#   ./docker/build-windows.sh shell            # interactive shell for debugging
+#
+# The Windows MSVC SDK is downloaded by cargo-xwin on first run and cached in a
+# named Docker volume (alvr-xwin-cache). libvpl is cross-compiled from source on
+# first run and the result cached in deps/windows/libvpl/alvr_build/.
+#
+# Note: cargo xtask build-streamer/build-launcher do not support Linux→Windows
+# cross-compilation (they don't pass --target). The default build here compiles
+# the server and launcher packages directly via cargo xwin.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IMAGE_NAME="alvr-windows-build"
+CARGO_TARGET_VOLUME="alvr-windows-cargo-target"
+CARGO_REGISTRY_VOLUME="alvr-windows-cargo-registry"
+XWIN_CACHE_VOLUME="alvr-xwin-cache"
+
+TARGET="x86_64-pc-windows-msvc"
+
+build_image() {
+    DOCKER_BUILDKIT=0 docker build \
+        --network=host \
+        --file "$SCRIPT_DIR/Dockerfile.windows-build" \
+        --tag "$IMAGE_NAME" \
+        "$SCRIPT_DIR"
+}
+
+run_in_container() {
+    docker run --rm \
+        --volume "$REPO_ROOT:/workspace" \
+        --volume "$CARGO_TARGET_VOLUME:/cargo-target" \
+        --volume "$CARGO_REGISTRY_VOLUME:/root/.cargo/registry" \
+        --volume "$XWIN_CACHE_VOLUME:/root/.cache/cargo-xwin" \
+        --env CARGO_TARGET_DIR=/cargo-target \
+        --env XWIN_INCLUDE_ATL=true \
+        --env CARGO_TERM_COLOR=always \
+        --env RUST_BACKTRACE=1 \
+        --workdir /workspace \
+        "$IMAGE_NAME" \
+        "$@"
+}
+
+# Cross-compile libvpl for Windows x64 using clang-cl + xwin MSVC SDK.
+# Installs into deps/windows/libvpl/alvr_build/ (include/ + lib/) to match
+# the paths expected by alvr/server_openvr/build.rs.
+setup_libvpl() {
+    cat <<'INNER'
+set -e
+LIBVPL_VERSION="2.15.0"
+DEST="/workspace/deps/windows/libvpl/alvr_build"
+XWIN="/root/.cache/cargo-xwin/xwin"
+
+if [ -f "$DEST/lib/vpl.lib" ]; then
+    echo "==> libvpl already built, skipping."
+else
+    echo "==> Downloading libvpl ${LIBVPL_VERSION} source..."
+    curl -fsSL -o /tmp/libvpl.zip \
+        "https://github.com/intel/libvpl/archive/refs/tags/v${LIBVPL_VERSION}.zip"
+    unzip -q /tmp/libvpl.zip -d /tmp/libvpl-src
+    SRC="/tmp/libvpl-src/libvpl-${LIBVPL_VERSION}"
+
+    # Patch cmake steps that fail on a Linux cross-build host:
+    # InstallRequiredSystemLibraries queries VS install dirs (Windows-only info).
+    # env/ tries to install a directory as a program (cross-build artifact).
+    sed -i "s/include(InstallRequiredSystemLibraries)/# cross-build skip/" "$SRC/CMakeLists.txt"
+    sed -i "s/add_subdirectory(env)/# cross-build skip/" "$SRC/CMakeLists.txt"
+
+    # CMake toolchain file for Windows cross-compilation via clang-cl + xwin MSVC SDK
+    cat > /tmp/windows_toolchain.cmake << 'TOOLCHAIN'
+cmake_policy(SET CMP0091 NEW)
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR AMD64)
+set(CMAKE_C_COMPILER clang-cl)
+set(CMAKE_CXX_COMPILER clang-cl)
+set(CMAKE_AR llvm-lib)
+set(CMAKE_RANLIB true)
+set(CMAKE_C_COMPILER_WORKS ON)
+set(CMAKE_CXX_COMPILER_WORKS ON)
+# Static CRT to match ALVR's /MT build
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
+set(CMAKE_C_FLAGS_RELEASE "/MT /O2 /Ob2 /DNDEBUG" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "/MT /O2 /Ob2 /DNDEBUG" CACHE STRING "" FORCE)
+TOOLCHAIN
+
+    IMSVC_FLAGS="-fuse-ld=lld-link \
+        --target=x86_64-pc-windows-msvc \
+        /imsvc${XWIN}/crt/include \
+        /imsvc${XWIN}/sdk/include/ucrt \
+        /imsvc${XWIN}/sdk/include/um \
+        /imsvc${XWIN}/sdk/include/shared \
+        /EHsc"
+
+    LINK_FLAGS="\
+        /LIBPATH:${XWIN}/crt/lib/x86_64 \
+        /LIBPATH:${XWIN}/sdk/lib/um/x86_64 \
+        /LIBPATH:${XWIN}/sdk/lib/ucrt/x86_64"
+
+    echo "==> Cross-compiling libvpl for Windows x64..."
+    cmake -B /tmp/libvpl-build \
+        -S "$SRC" \
+        -DCMAKE_TOOLCHAIN_FILE=/tmp/windows_toolchain.cmake \
+        "-DCMAKE_C_FLAGS=${IMSVC_FLAGS}" \
+        "-DCMAKE_CXX_FLAGS=${IMSVC_FLAGS}" \
+        "-DCMAKE_EXE_LINKER_FLAGS=${LINK_FLAGS}" \
+        "-DCMAKE_SHARED_LINKER_FLAGS=${LINK_FLAGS}" \
+        -DUSE_MSVC_STATIC_RUNTIME=ON \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$DEST"
+
+    cmake --build /tmp/libvpl-build --config Release -j"$(nproc)"
+    cmake --install /tmp/libvpl-build --config Release
+
+    rm -rf /tmp/libvpl.zip /tmp/libvpl-src /tmp/libvpl-build /tmp/windows_toolchain.cmake
+    echo "==> libvpl cross-compiled and installed to ${DEST}."
+fi
+INNER
+}
+
+build_image
+
+if [[ $# -eq 0 ]]; then
+    run_in_container bash -c "
+        $(setup_libvpl)
+        cargo xwin build \
+            --target $TARGET \
+            -p alvr_server_openvr \
+            -p alvr_dashboard \
+            -p alvr_launcher
+    "
+elif [[ "$1" == "shell" ]]; then
+    run_in_container bash
+else
+    run_in_container cargo xtask "$@"
+fi

--- a/docker/build-windows.sh
+++ b/docker/build-windows.sh
@@ -13,6 +13,11 @@
 # Note: cargo xtask build-streamer/build-launcher do not support Linux→Windows
 # cross-compilation (they don't pass --target). The default build here compiles
 # the server and launcher packages directly via cargo xwin.
+#
+# Usage:
+#   ./docker/build-windows.sh         # full build
+#   ./docker/build-windows.sh check   # cargo xwin check -D warnings (matches CI)
+#   ./docker/build-windows.sh shell   # interactive shell for debugging
 
 set -euo pipefail
 
@@ -132,6 +137,14 @@ if [[ $# -eq 0 ]]; then
     run_in_container bash -c "
         $(setup_libvpl)
         cargo xwin build \
+            --target $TARGET \
+            -p alvr_server_openvr \
+            -p alvr_dashboard \
+            -p alvr_launcher
+    "
+elif [[ "$1" == "check" ]]; then
+    run_in_container bash -c "
+        RUSTFLAGS='-D warnings' cargo xwin check \
             --target $TARGET \
             -p alvr_server_openvr \
             -p alvr_dashboard \


### PR DESCRIPTION
## Summary

Adds Docker-based build scripts so ALVR can be compiled for Linux and
Windows from a macOS host (including Apple Silicon), without needing a
native Linux/Windows machine.

### Linux (`docker/build-linux.sh` + `Dockerfile.linux-build`)
- Uses `docker buildx build --platform linux/amd64` to produce an x86_64
  image even on Apple Silicon hosts (required because openvr and ffmpeg
  deps are x86_64-only)
- Runs `cargo xtask prepare-deps`, `build-streamer`, and `build-launcher`
  inside the container; artifacts land in `build/` as they would from CI
- Cargo target dir and registry are kept in named Docker volumes so
  incremental builds survive across runs

### Windows (`docker/build-windows.sh` + `Dockerfile.windows-build`)
- Uses `cargo-xwin` with Clang 19 (Ubuntu 24.04 ships Clang 18, which is
  too old for the MSVC STL) to cross-compile `x86_64-pc-windows-msvc`
- Downloads the MSVC CRT + SDK (including ATL) via `xwin` on first run;
  cached in a named Docker volume
- Cross-compiles `libvpl` from source using `clang-cl` + the xwin MSVC SDK
  with `/MT` (static CRT) to match ALVR's build config; result cached in
  `deps/windows/libvpl/alvr_build/`

### `build.rs` changes
- Replace `cfg!(target_os = …)` / `#[cfg(target_os = …)]` guards with
  runtime checks against `CARGO_CFG_TARGET_OS` so Linux and Windows link
  paths resolve correctly when cross-compiling (where host ≠ target)
- Retain `#[cfg(target_os = "linux")]` only on `pkg_config` call sites,
  since that crate is declared as a Linux-only build-dependency
