### PR TITLE
Pin macOS CI check to macOS 26

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
       - run: cargo xtask clippy --ci
 
   check-macos:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- pin the macOS Rust check to the standard macos-26 runner instead of floating macos-latest

## Validation
- actionlint .github/workflows/rust.yml
- scanned workflow files for stale hosted macOS labels