### PR TITLE
fix(server_openvr): gate x264 build steps on Linux host to match function cfg

### DIFF
--- a/alvr/server_openvr/build.rs
+++ b/alvr/server_openvr/build.rs
@@ -106,7 +106,7 @@ fn main() {
     }
 
     if platform_name == "linux" {
-        #[cfg(feature = "gpl")]
+        #[cfg(all(target_os = "linux", feature = "gpl"))]
         {
             let x264_path = get_linux_x264_path();
 
@@ -136,7 +136,7 @@ fn main() {
     build.compile("bindings");
 
     if platform_name == "linux" {
-        #[cfg(feature = "gpl")]
+        #[cfg(all(target_os = "linux", feature = "gpl"))]
         {
             let x264_path = get_linux_x264_path();
             let x264_lib_path = x264_path.join("lib");


### PR DESCRIPTION
## Summary

- `get_linux_x264_path()` is defined with `#[cfg(all(target_os = "linux", feature = "gpl"))]` but was called from two blocks guarded only by `#[cfg(feature = "gpl")]`
- On a Windows host with the `gpl` feature enabled, the function is not compiled in but the call sites are, causing a build failure
- Fixed by adding `target_os = "linux"` to the cfg predicate on both call sites, matching the function definition

## Test plan

- [ ] Build on Windows with `gpl` feature enabled — should no longer fail with `get_linux_x264_path not found`
- [ ] Build on Linux with `gpl` feature enabled — x264 include/link steps still active

🤖 Generated with [Claude Code](https://claude.com/claude-code)