### PR TITLE
fix/chore/refactor(server_core, server_openvr): misc Rust fixes and cleanups

### DIFF
--- a/alvr/server_core/src/c_api.rs
+++ b/alvr/server_core/src/c_api.rs
@@ -179,13 +179,13 @@ pub unsafe extern "C" fn alvr_dbg_encoder(string_ptr: *const c_char) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn alvr_log_periodically(tag_ptr: *const c_char, message_ptr: *const c_char) {
     const INTERVAL: Duration = Duration::from_secs(1);
-    static LASTEST_TAG_TIMESTAMPS: LazyLock<Mutex<HashMap<String, Instant>>> =
+    static LATEST_TAG_TIMESTAMPS: LazyLock<Mutex<HashMap<String, Instant>>> =
         LazyLock::new(|| Mutex::new(HashMap::new()));
 
     let tag = unsafe { CStr::from_ptr(tag_ptr) }.to_string_lossy();
     let message = unsafe { CStr::from_ptr(message_ptr) }.to_string_lossy();
 
-    let mut timestamps_ref = LASTEST_TAG_TIMESTAMPS.lock();
+    let mut timestamps_ref = LATEST_TAG_TIMESTAMPS.lock();
     let old_timestamp = timestamps_ref
         .entry(tag.to_string())
         .or_insert_with(Instant::now);
@@ -548,7 +548,7 @@ pub extern "C" fn alvr_report_present(timestamp_ns: u64, offset_ns: u64) {
     }
 }
 
-/// Retr  un true if a valid value is provided
+/// Return true if a valid value is provided
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn alvr_duration_until_next_vsync(out_ns: *mut u64) -> bool {
     if let Some(context) = &*SERVER_CORE_CONTEXT.read()

--- a/alvr/server_core/src/c_api.rs
+++ b/alvr/server_core/src/c_api.rs
@@ -120,11 +120,13 @@ fn string_to_c_str(buffer: *mut c_char, value: &str) -> u64 {
     cstring.as_bytes_with_nul().len() as u64
 }
 
+static SERVER_START_INSTANT: LazyLock<Instant> = LazyLock::new(Instant::now);
+
 // Get ALVR server time. The libalvr user should provide timestamps in the provided time frame of
 // reference in the following functions
 #[unsafe(no_mangle)]
 pub extern "C" fn alvr_get_time_ns() -> u64 {
-    Instant::now().elapsed().as_nanos() as u64
+    SERVER_START_INSTANT.elapsed().as_nanos() as u64
 }
 
 // The libalvr user is responsible of interpreting values and calling functions using

--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -580,7 +580,7 @@ impl Drop for ServerCoreContext {
         }
 
         // apply openvr config for the next launch
-        dbg_server_core!("Setting restart settings chache");
+        dbg_server_core!("Setting restart settings cache");
         {
             let mut session_manager_lock = SESSION_MANAGER.write();
             let new_steamvr_hmd_init_config = session_manager_lock

--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -485,15 +485,12 @@ impl ServerCoreContext {
                 .get_encoder_params(&session_manager_lock.settings().video.bitrate)
         };
 
-        if let Some((params, stats)) = pair {
+        pair.map(|(params, stats)| {
             if let Some(stats_manager) = &mut *self.connection_context.statistics_manager.write() {
                 stats_manager.report_throughput_stats(stats);
             }
-
-            Some(params)
-        } else {
-            None
-        }
+            params
+        })
     }
 
     pub fn report_composed(&self, target_timestamp: Duration, offset: Duration) {

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -238,7 +238,7 @@ fn make_settings(negotiated: Option<&ServerNegotiatedStreamingConfig>) -> Settin
     }
 }
 
-fn event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
+fn spawn_event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
     thread::spawn(move || {
         if let Some(context) = &*SERVER_CORE_CONTEXT.read() {
             context.start_connection();
@@ -749,7 +749,7 @@ pub unsafe extern "C" fn HmdDriverFactory(
 
         *SERVER_CORE_CONTEXT.write() = Some(context);
 
-        event_loop(events_receiver);
+        spawn_event_loop(events_receiver);
     });
 
     unsafe { CppOpenvrEntryPoint(interface_name, return_code) }


### PR DESCRIPTION
## Summary

- **fix**: `alvr_get_time_ns` always returned ~0 because it called `Instant::now().elapsed()` on a freshly created instant — replaced with a `LazyLock` start instant so it returns time since server start
- **chore**: fix typos in identifiers (`LASTEST_TAG_TIMESTAMPS` → `LATEST_TAG_TIMESTAMPS`, `chache` → `cache`, doc comment `Retr  un` → `Return`) and in a debug string
- **refactor**: rename `event_loop` → `spawn_event_loop` to better reflect that it spawns a thread rather than blocking
- **refactor**: simplify `get_dynamic_encoder_params` by replacing an `if let … Some(x) { Some(…) } else { None }` pattern with `.map()`

## Test plan

- [x] `./docker/build-linux.sh check` — clean (no new warnings)
- [x] `./docker/build-windows.sh check` — clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)