### PR TITLE
fix(docker): cross-compile libvpl in build-windows.sh check mode

### DIFF
--- a/docker/build-windows.sh
+++ b/docker/build-windows.sh
@@ -144,6 +144,7 @@ if [[ $# -eq 0 ]]; then
     "
 elif [[ "$1" == "check" ]]; then
     run_in_container bash -c "
+        $(setup_libvpl)
         cargo clean -p alvr_server_openvr -p alvr_dashboard -p alvr_launcher
         RUSTFLAGS='-D warnings' cargo xwin check \
             --target $TARGET \


### PR DESCRIPTION
## Summary

- `./docker/build-windows.sh check` was skipping the `setup_libvpl` step, so `vpl/mfx.h` was always missing and the check always failed unless `deps/windows/libvpl/alvr_build/` had been pre-populated by a prior full build
- Added `$(setup_libvpl)` to the `check` branch, matching what the full build already does
- `setup_libvpl` has a skip-if-built guard (`if [ -f "$DEST/lib/vpl.lib" ]`), so repeated `check` runs add no overhead

## Notes

`setup_libvpl` requires the xwin MSVC SDK to be present in the `alvr-xwin-cache` Docker volume (populated by any prior `cargo xwin` invocation). This is the same requirement as the full build.

## Test plan

- [x] `./docker/build-windows.sh check` passes with no pre-built deps (libvpl cross-compiled from source)
- [x] `./docker/build-windows.sh check` passes when libvpl is already built (skip path taken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)