### PR TITLE
feat(server_openvr): upgrade openvr SDK from v1.16.8 to v2.15.6

### DIFF
--- a/alvr/server_openvr/build.rs
+++ b/alvr/server_openvr/build.rs
@@ -252,4 +252,12 @@ fn main() {
     for path in cpp_paths {
         println!("cargo:rerun-if-changed={}", path.to_string_lossy());
     }
+
+    for path in walkdir::WalkDir::new(alvr_filesystem::workspace_dir().join("openvr/headers"))
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .map(|e| e.into_path())
+    {
+        println!("cargo:rerun-if-changed={}", path.to_string_lossy());
+    }
 }

--- a/alvr/server_openvr/cpp/alvr_server/HMD.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/HMD.cpp
@@ -357,3 +357,11 @@ void Hmd::GetProjectionRaw(vr::EVREye eye, float* left, float* right, float* top
 vr::DistortionCoordinates_t Hmd::ComputeDistortion(vr::EVREye, float u, float v) {
     return { { u, v }, { u, v }, { u, v } };
 }
+
+bool Hmd::ComputeInverseDistortion(
+    vr::HmdVector2_t* pResult, vr::EVREye, uint32_t, float fU, float fV
+) {
+    pResult->v[0] = fU;
+    pResult->v[1] = fV;
+    return true;
+}

--- a/alvr/server_openvr/cpp/alvr_server/HMD.h
+++ b/alvr/server_openvr/cpp/alvr_server/HMD.h
@@ -75,4 +75,7 @@ private:
     virtual void
     GetProjectionRaw(vr::EVREye eEye, float* pfLeft, float* pfRight, float* pfTop, float* pfBottom);
     virtual vr::DistortionCoordinates_t ComputeDistortion(vr::EVREye eEye, float fU, float fV);
+    virtual bool ComputeInverseDistortion(
+        vr::HmdVector2_t* pResult, vr::EVREye eEye, uint32_t unChannel, float fU, float fV
+    );
 };

--- a/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
@@ -144,7 +144,7 @@ public:
             }
 #ifdef __linux__
             else if (event.eventType == vr::VREvent_ChaperoneUniverseHasChanged
-                     || event.eventType == vr::VREvent_ChaperoneRoomSetupFinished
+                     || event.eventType == vr::VREvent_ChaperoneRoomSetupCommitted
                      || event.eventType == vr::VREvent_ChaperoneFlushCache
                      || event.eventType == vr::VREvent_ChaperoneSettingsHaveChanged
                      || event.eventType == vr::VREvent_SeatedZeroPoseReset

--- a/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.cpp
@@ -272,7 +272,7 @@ void OvrDirectModeComponent::Present(vr::SharedTextureHandle_t syncTexture) {
     m_presentMutex.unlock();
 }
 
-void OvrDirectModeComponent::PostPresent() {
+void OvrDirectModeComponent::PostPresent(const vr::IVRDriverDirectModeComponent::Throttling_t*) {
     Debug("OvrDirectModeComponent::PostPresent");
 
     WaitForVSync();

--- a/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.h
+++ b/alvr/server_openvr/cpp/platform/win32/OvrDirectModeComponent.h
@@ -46,7 +46,7 @@ public:
 
     /** Called after Present to allow driver to take more time until vsync after they've
      * successfully acquired the sync texture in Present.*/
-    virtual void PostPresent();
+    virtual void PostPresent(const vr::IVRDriverDirectModeComponent::Throttling_t* pThrottling);
 
     void CopyTexture(uint32_t layerCount);
 


### PR DESCRIPTION
## Summary
- Bumps the openvr submodule from v1.16.8 to v2.15.6
- Updates `OvrDirectModeComponent::PostPresent` signature to match the new
  `IVRDriverDirectModeComponent_009` interface (`Throttling_t*` parameter)
- Implements `ComputeInverseDistortion` (identity, matching existing `ComputeDistortion`)
  required by the new pure virtual in `IVRDisplayComponent_003`

## Test plan
- [x] Linux and Windows check builds pass (no Rust warnings)
- [x] Linux and Windows full builds pass
- [x] Test with SteamVR on Windows + Quest 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)