### PR TITLE
feat(sockets, server_core): unified socket abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ name = "alvr_sockets"
 version = "21.0.0-dev12"
 dependencies = [
  "alvr_common",
+ "alvr_packets",
  "alvr_session",
  "bincode",
  "profiling",

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -65,7 +65,7 @@ impl VideoStreamingCapabilities {
 pub struct ConnectionAcceptedInfo {
     pub client_protocol_id: u64,
     pub platform_string: String,
-    pub server_ip: IpAddr,
+    pub server_ip: IpAddr, // must be unused for now
     pub streaming_capabilities: Option<VideoStreamingCapabilities>,
 }
 

--- a/alvr/server_core/src/c_api.rs
+++ b/alvr/server_core/src/c_api.rs
@@ -563,13 +563,6 @@ pub unsafe extern "C" fn alvr_duration_until_next_vsync(out_ns: *mut u64) -> boo
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn alvr_restart() {
-    if let Some(context) = SERVER_CORE_CONTEXT.write().take() {
-        context.restart();
-    }
-}
-
-#[unsafe(no_mangle)]
 pub extern "C" fn alvr_shutdown() {
     SERVER_CORE_CONTEXT.write().take();
 }

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -822,6 +822,10 @@ fn connection_pipeline(
         control_sender.send(&ServerControlPacket::Restarting).ok();
 
         crate::notify_restart_driver();
+
+        *lifecycle_state.write() = LifecycleState::ShuttingDown;
+
+        return Ok(());
     }
 
     dbg_connection!("connection_pipeline: Send StartStream packet");

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -2,7 +2,6 @@ use crate::{
     ConnectionContext, FILESYSTEM_LAYOUT, SESSION_MANAGER, ServerCoreEvent,
     ServerNegotiatedStreamingConfig,
     bitrate::BitrateManager,
-    hand_gestures::HandGestureManager,
     input_mapping::ButtonMappingManager,
     sockets::WelcomeSocket,
     statistics::StatisticsManager,
@@ -551,8 +550,6 @@ fn connection_pipeline(
         ClientConnectionsAction::UpdateCurrentIp(Some(client_ip)),
     );
 
-    let disconnect_notif = Arc::new(Condvar::new());
-
     dbg_connection!("connection_pipeline: Getting client status packet");
     let connection_result = match proto_socket.recv(HANDSHAKE_ACTION_TIMEOUT) {
         Ok(r) => r,
@@ -592,8 +589,6 @@ fn connection_pipeline(
     let Some(streaming_caps) = maybe_streaming_caps else {
         con_bail!("Only streaming clients are supported for now");
     };
-
-    dbg_connection!("connection_pipeline: setting up negotiated streaming config");
 
     let initial_settings = session_manager_lock.settings().clone();
 
@@ -839,6 +834,8 @@ fn connection_pipeline(
     }
     dbg_connection!("connection_pipeline: Got StreamReady packet");
 
+    let disconnect_notif = Arc::new(Condvar::new());
+
     *ctx.statistics_manager.write() = Some(StatisticsManager::new(
         initial_settings.connection.statistics_history_size,
         Duration::from_secs_f32(1.0 / fps),
@@ -851,6 +848,8 @@ fn connection_pipeline(
 
     *ctx.bitrate_manager.lock() =
         BitrateManager::new(initial_settings.video.bitrate.history_size, fps);
+    *ctx.tracking_manager.write() =
+        TrackingManager::new(initial_settings.connection.statistics_history_size);
 
     let stream_protocol = if wired {
         SocketProtocol::Tcp
@@ -1063,23 +1062,14 @@ fn connection_pipeline(
         }
     };
 
-    *ctx.tracking_manager.write() =
-        TrackingManager::new(initial_settings.connection.statistics_history_size);
-    let hand_gesture_manager = Arc::new(Mutex::new(HandGestureManager::new()));
-
     let tracking_receive_thread = thread::spawn({
         let ctx = Arc::clone(&ctx);
-        let hand_gesture_manager = Arc::clone(&hand_gesture_manager);
         let initial_settings = initial_settings.clone();
         let client_hostname = client_hostname.clone();
         move || {
-            tracking::tracking_loop(
-                &ctx,
-                initial_settings,
-                hand_gesture_manager,
-                tracking_receiver,
-                || is_streaming(&client_hostname),
-            );
+            tracking::tracking_loop(&ctx, initial_settings, tracking_receiver, || {
+                is_streaming(&client_hostname)
+            });
         }
     });
 
@@ -1378,19 +1368,17 @@ fn connection_pipeline(
         }
     });
 
-    {
-        if initial_settings.connection.enable_on_connect_script {
-            let on_connect_script = FILESYSTEM_LAYOUT.get().map(|l| l.connect_script()).unwrap();
-            info!(
-                "Running on connect script (connect): {}",
-                on_connect_script.display()
-            );
-            if let Err(e) = Command::new(&on_connect_script)
-                .env("ACTION", "connect")
-                .spawn()
-            {
-                warn!("Failed to run connect script: {e}");
-            }
+    if initial_settings.connection.enable_on_connect_script {
+        let on_connect_script = FILESYSTEM_LAYOUT.get().map(|l| l.connect_script()).unwrap();
+        info!(
+            "Running on connect script (connect): {}",
+            on_connect_script.display()
+        );
+        if let Err(e) = Command::new(&on_connect_script)
+            .env("ACTION", "connect")
+            .spawn()
+        {
+            warn!("Failed to run connect script: {e}");
         }
     }
 
@@ -1420,7 +1408,7 @@ fn connection_pipeline(
         ))
         .ok();
 
-    dbg_connection!("connection_pipeline: handshake finished; unlocking streams");
+    dbg_connection!("connection_pipeline: Threads initialized; unlocking streams");
     alvr_common::wait_rwlock(&disconnect_notif, &mut session_manager_lock);
     dbg_connection!("connection_pipeline: Begin connection shutdown");
 

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -29,8 +29,8 @@ use alvr_session::{
     SocketProtocol, SteamvrHmdInitConfig,
 };
 use alvr_sockets::{
-    CONTROL_PORT, KEEPALIVE_INTERVAL, KEEPALIVE_TIMEOUT, PeerType, ProtoControlSocket,
-    StreamSocketBuilder, WIRED_CLIENT_HOSTNAME,
+    CONTROL_PORT, KEEPALIVE_INTERVAL, KEEPALIVE_TIMEOUT, ProtoControlSocket, SocketConnection,
+    StreamSocketConfig, WIRED_CLIENT_HOSTNAME,
 };
 use std::{
     collections::{HashMap, hash_map::DefaultHasher},
@@ -484,9 +484,9 @@ fn try_connect(
 ) -> ConResult {
     dbg_connection!("try_connect: Finding client and creating control socket");
 
-    let (proto_socket, client_ip) = ProtoControlSocket::connect_to(
+    let (socket, client_ip, connection_result) = alvr_sockets::connect_to_client(
+        client_ips.keys().cloned().collect(),
         Duration::from_secs(1),
-        PeerType::AnyClient(client_ips.keys().cloned().collect()),
     )?;
 
     let Some(client_hostname) = client_ips.remove(&client_ip) else {
@@ -501,7 +501,8 @@ fn try_connect(
             if let Err(e) = connection_pipeline(
                 Arc::clone(&ctx),
                 lifecycle_state,
-                proto_socket,
+                socket,
+                connection_result,
                 client_hostname.clone(),
                 client_ip,
             ) {
@@ -529,7 +530,8 @@ fn try_connect(
 fn connection_pipeline(
     ctx: Arc<ConnectionContext>,
     lifecycle_state: Arc<RwLock<LifecycleState>>,
-    mut proto_socket: ProtoControlSocket,
+    socket: ProtoControlSocket,
+    connection_result: ClientConnectionResult,
     client_hostname: String,
     client_ip: IpAddr,
 ) -> ConResult {
@@ -549,19 +551,6 @@ fn connection_pipeline(
         client_hostname.clone(),
         ClientConnectionsAction::UpdateCurrentIp(Some(client_ip)),
     );
-
-    dbg_connection!("connection_pipeline: Getting client status packet");
-    let connection_result = match proto_socket.recv(HANDSHAKE_ACTION_TIMEOUT) {
-        Ok(r) => r,
-        Err(ConnectionError::TryAgain(e)) => {
-            debug!(
-                "Failed to recive client connection packet. This is normal for USB connection.\n{e}"
-            );
-
-            return Ok(());
-        }
-        Err(e) => return Err(e),
-    };
 
     let maybe_streaming_caps =
         if let ClientConnectionResult::ConnectionAccepted(info) = connection_result {
@@ -796,10 +785,6 @@ fn connection_pipeline(
         .with_ext(NegotiatedStreamingConfigExt {}),
     )
     .to_con()?;
-    proto_socket.send(&stream_config_packet).to_con()?;
-
-    let (mut control_sender, mut control_receiver) =
-        proto_socket.split(STREAMING_RECV_TIMEOUT).to_con()?;
 
     let new_steamvr_hmd_init_config = SteamvrHmdInitConfig {
         eye_resolution_width: transcoding_view_resolution.x,
@@ -814,7 +799,7 @@ fn connection_pipeline(
         session.steamvr_hmd_init_config = new_steamvr_hmd_init_config;
         session.restart_settings_hash = new_hash;
 
-        control_sender.send(&ServerControlPacket::Restarting).ok();
+        alvr_sockets::send_restart_signal(socket, stream_config_packet)?;
 
         crate::notify_restart_driver();
 
@@ -823,16 +808,27 @@ fn connection_pipeline(
         return Ok(());
     }
 
-    dbg_connection!("connection_pipeline: Send StartStream packet");
-    control_sender
-        .send(&ServerControlPacket::StartStream)
-        .to_con()?;
+    let stream_protocol = if wired {
+        SocketProtocol::Tcp
+    } else {
+        initial_settings.connection.stream_protocol
+    };
 
-    let signal = control_receiver.recv(HANDSHAKE_ACTION_TIMEOUT)?;
-    if !matches!(signal, ClientControlPacket::StreamReady) {
-        con_bail!("Got unexpected packet waiting for stream ack");
-    }
-    dbg_connection!("connection_pipeline: Got StreamReady packet");
+    dbg_connection!("connection_pipeline: Finishing handshake");
+    let mut socket = SocketConnection::from_client_connection(
+        socket,
+        HANDSHAKE_ACTION_TIMEOUT,
+        stream_config_packet,
+        StreamSocketConfig {
+            protocol: stream_protocol,
+            port: initial_settings.connection.stream_port,
+            buffer_config: initial_settings.connection.server_buffer_config,
+            max_packet_size: initial_settings.connection.packet_size as _,
+            dscp: initial_settings.connection.dscp,
+        },
+    )?;
+
+    dbg_connection!("connection_pipeline: Handshake successful, spawning threads");
 
     let disconnect_notif = Arc::new(Condvar::new());
 
@@ -845,38 +841,23 @@ fn connection_pipeline(
             0.0
         },
     ));
-
     *ctx.bitrate_manager.lock() =
         BitrateManager::new(initial_settings.video.bitrate.history_size, fps);
     *ctx.tracking_manager.write() =
         TrackingManager::new(initial_settings.connection.statistics_history_size);
 
-    let stream_protocol = if wired {
-        SocketProtocol::Tcp
-    } else {
-        initial_settings.connection.stream_protocol
-    };
+    let control_sender = Arc::new(Mutex::new(socket.request_reliable_stream()?));
+    let mut video_sender = socket.request_unreliable_stream(VIDEO);
+    let game_audio_sender: alvr_sockets::StreamSender<()> = socket.request_unreliable_stream(AUDIO);
+    let haptics_sender = socket.request_unreliable_stream(HAPTICS);
 
-    dbg_connection!("connection_pipeline: StreamSocket connect_to_client");
-    let mut stream_socket = StreamSocketBuilder::connect_to_client(
-        HANDSHAKE_ACTION_TIMEOUT,
-        client_ip,
-        initial_settings.connection.stream_port,
-        stream_protocol,
-        initial_settings.connection.dscp,
-        initial_settings.connection.server_buffer_config,
-        initial_settings.connection.packet_size as _,
-    )?;
-
-    let mut video_sender = stream_socket.request_stream(VIDEO);
-    let game_audio_sender: alvr_sockets::StreamSender<()> = stream_socket.request_stream(AUDIO);
+    let mut control_receiver = socket.subscribe_to_reliable_stream()?;
     let mut microphone_receiver: alvr_sockets::StreamReceiver<()> =
-        stream_socket.subscribe_to_stream(AUDIO, MAX_UNREAD_PACKETS);
+        socket.subscribe_to_unreliable_stream(AUDIO, MAX_UNREAD_PACKETS);
     let tracking_receiver =
-        stream_socket.subscribe_to_stream::<TrackingData>(TRACKING, MAX_UNREAD_PACKETS);
-    let haptics_sender = stream_socket.request_stream(HAPTICS);
+        socket.subscribe_to_unreliable_stream::<TrackingData>(TRACKING, MAX_UNREAD_PACKETS);
     let mut statics_receiver =
-        stream_socket.subscribe_to_stream::<ClientStatistics>(STATISTICS, MAX_UNREAD_PACKETS);
+        socket.subscribe_to_unreliable_stream::<ClientStatistics>(STATISTICS, MAX_UNREAD_PACKETS);
 
     let (video_channel_sender, video_channel_receiver) =
         std::sync::mpsc::sync_channel(initial_settings.connection.max_queued_server_video_frames);
@@ -909,7 +890,7 @@ fn connection_pipeline(
         }
     });
 
-    #[cfg_attr(target_os = "linux", allow(unused_variables))]
+    #[cfg_attr(target_os = "linux", expect(unused_variables))]
     let game_audio_thread = if let Switch::Enabled(config) =
         initial_settings.audio.game_audio.clone()
     {
@@ -1107,8 +1088,6 @@ fn connection_pipeline(
             }
         }
     });
-
-    let control_sender = Arc::new(Mutex::new(control_sender));
 
     let real_time_update_thread = thread::spawn({
         let control_sender = Arc::clone(&control_sender);
@@ -1335,7 +1314,7 @@ fn connection_pipeline(
         let client_hostname = client_hostname.clone();
         move || {
             while is_streaming(&client_hostname) {
-                match stream_socket.recv() {
+                match socket.recv_poll() {
                     Ok(()) => (),
                     Err(ConnectionError::TryAgain(_)) => continue,
                     Err(e) => {
@@ -1381,7 +1360,6 @@ fn connection_pipeline(
             warn!("Failed to run connect script: {e}");
         }
     }
-
     if initial_settings.extra.capture.startup_video_recording {
         info!("Creating recording file");
         crate::create_recording_file(&ctx, session_manager_lock.settings());

--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -16,8 +16,8 @@ pub use tracking::HandType;
 
 use crate::connection::VideoPacket;
 use alvr_common::{
-    ConnectionState, DEVICE_ID_TO_PATH, DeviceMotion, LifecycleState, Pose, RelaxedAtomic,
-    ViewParams, dbg_server_core, error,
+    ConnectionState, DEVICE_ID_TO_PATH, DeviceMotion, LifecycleState, Pose, ViewParams,
+    dbg_server_core, error,
     glam::{UVec2, Vec2},
     parking_lot::{Mutex, RwLock},
     settings_schema::Switch,
@@ -185,7 +185,6 @@ pub fn registered_button_set() -> HashSet<u64> {
 
 pub struct ServerCoreContext {
     lifecycle_state: Arc<RwLock<LifecycleState>>,
-    is_restarting: RelaxedAtomic,
     connection_context: Arc<ConnectionContext>,
     connection_thread: Arc<RwLock<Option<JoinHandle<()>>>>,
     webserver_runtime: Option<Runtime>,
@@ -246,9 +245,7 @@ impl ServerCoreContext {
         (
             Self {
                 lifecycle_state: Arc::new(RwLock::new(LifecycleState::StartingUp)),
-                is_restarting: RelaxedAtomic::new(false),
                 connection_context,
-
                 connection_thread: Arc::new(RwLock::new(None)),
                 webserver_runtime: Some(webserver_runtime),
             },
@@ -529,14 +526,6 @@ impl ServerCoreContext {
             .write()
             .as_mut()
             .map(|stats| stats.duration_until_next_vsync())
-    }
-
-    pub fn restart(self) {
-        dbg_server_core!("restart");
-
-        self.is_restarting.set(true);
-
-        // drop is called here for self
     }
 }
 

--- a/alvr/server_core/src/tracking/mod.rs
+++ b/alvr/server_core/src/tracking/mod.rs
@@ -16,7 +16,6 @@ use alvr_common::{
     ConnectionError, DEVICE_ID_TO_PATH, DeviceMotion, Pose, ViewParams,
     glam::{Quat, Vec3},
     inputs as inp,
-    parking_lot::Mutex,
 };
 use alvr_events::{EventType, TrackingEvent};
 use alvr_packets::TrackingData;
@@ -29,7 +28,6 @@ use std::{
     cmp::Ordering,
     collections::{HashMap, VecDeque},
     f32::consts::PI,
-    sync::Arc,
     time::Duration,
 };
 
@@ -266,10 +264,11 @@ impl TrackingManager {
 pub fn tracking_loop(
     ctx: &ConnectionContext,
     initial_settings: Settings,
-    hand_gesture_manager: Arc<Mutex<HandGestureManager>>,
     mut tracking_receiver: StreamReceiver<TrackingData>,
     is_streaming: impl Fn() -> bool,
 ) {
+    let mut hand_gesture_manager = HandGestureManager::new();
+
     let mut gestures_button_mapping_manager =
         initial_settings
             .headset
@@ -408,8 +407,6 @@ pub fn tracking_loop(
                 .and_then(|c| c.hand_tracking_interaction.as_option()),
             &mut gestures_button_mapping_manager,
         ) {
-            let mut hand_gesture_manager_lock = hand_gesture_manager.lock();
-
             if !device_motion_keys.contains(&*inp::HAND_LEFT_ID)
                 && let Some(hand_skeleton) = tracking.hand_skeletons[0]
             {
@@ -418,7 +415,7 @@ pub fn tracking_loop(
                         hand_gestures::trigger_hand_gesture_actions(
                             gestures_button_mapping_manager,
                             *inp::HAND_LEFT_ID,
-                            &hand_gesture_manager_lock.get_active_gestures(
+                            &hand_gesture_manager.get_active_gestures(
                                 &hand_skeleton,
                                 gestures_config,
                                 *inp::HAND_LEFT_ID,
@@ -436,7 +433,7 @@ pub fn tracking_loop(
                         hand_gestures::trigger_hand_gesture_actions(
                             gestures_button_mapping_manager,
                             *inp::HAND_RIGHT_ID,
-                            &hand_gesture_manager_lock.get_active_gestures(
+                            &hand_gesture_manager.get_active_gestures(
                                 &hand_skeleton,
                                 gestures_config,
                                 *inp::HAND_RIGHT_ID,

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -485,16 +485,11 @@ fn spawn_event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
                         }
                     }
                 }
-                ServerCoreEvent::ShutdownPending => {
+                ServerCoreEvent::ShutdownPending | ServerCoreEvent::RestartPending => {
+                    // Dropping the context
                     SERVER_CORE_CONTEXT.write().take();
 
-                    unsafe { ShutdownSteamvr() };
-                }
-                ServerCoreEvent::RestartPending => {
-                    if let Some(context) = SERVER_CORE_CONTEXT.write().take() {
-                        context.restart();
-                    }
-
+                    // todo: send different HUD message for shutdown or restart
                     unsafe { ShutdownSteamvr() };
                 }
                 ServerCoreEvent::ProximityState(headset_is_worn) => unsafe {

--- a/alvr/sockets/Cargo.toml
+++ b/alvr/sockets/Cargo.toml
@@ -11,6 +11,7 @@ trace-performance = ["profiling/profile-with-tracy"]
 
 [dependencies]
 alvr_common.workspace = true
+alvr_packets.workspace = true
 alvr_session.workspace = true
 
 bincode = { version = "2", features = ["serde"] }

--- a/alvr/sockets/src/control_socket.rs
+++ b/alvr/sockets/src/control_socket.rs
@@ -149,9 +149,9 @@ fn framed_recv<R: DeserializeOwned>(
 }
 
 pub struct ControlSocketSender<T> {
-    inner: TcpStream,
-    buffer: Vec<u8>,
-    _phantom: PhantomData<T>,
+    pub(crate) inner: TcpStream,
+    pub(crate) buffer: Vec<u8>,
+    pub(crate) _phantom: PhantomData<T>,
 }
 
 impl<S: Serialize> ControlSocketSender<S> {
@@ -161,10 +161,10 @@ impl<S: Serialize> ControlSocketSender<S> {
 }
 
 pub struct ControlSocketReceiver<T> {
-    inner: TcpStream,
-    buffer: Vec<u8>,
-    recv_cursor: Option<usize>,
-    _phantom: PhantomData<T>,
+    pub(crate) inner: TcpStream,
+    pub(crate) buffer: Vec<u8>,
+    pub(crate) recv_cursor: Option<usize>,
+    pub(crate) _phantom: PhantomData<T>,
 }
 
 impl<R: DeserializeOwned> ControlSocketReceiver<R> {
@@ -187,7 +187,7 @@ pub fn get_server_listener(timeout: Duration) -> Result<TcpListener> {
 // Proto-control-socket that can send and receive any packet. After the split, only the packets of
 // the specified types can be exchanged
 pub struct ProtoControlSocket {
-    inner: TcpStream,
+    pub(crate) inner: TcpStream,
 }
 
 pub enum PeerType<'a> {

--- a/alvr/sockets/src/lib.rs
+++ b/alvr/sockets/src/lib.rs
@@ -1,11 +1,14 @@
 mod control_socket;
 mod stream_socket;
 
-use alvr_common::{anyhow::Result, info};
-use alvr_session::{DscpTos, SocketBufferConfig, SocketBufferSize};
+use alvr_common::{AnyhowToCon, ConResult, ToCon, anyhow::Result, con_bail, info};
+use alvr_packets::{ClientControlPacket, ServerControlPacket};
+use alvr_session::{DscpTos, SocketBufferConfig, SocketBufferSize, SocketProtocol};
+use serde::{Serialize, de::DeserializeOwned};
 use socket2::Socket;
 use std::{
-    net::{IpAddr, Ipv4Addr},
+    marker::PhantomData,
+    net::{IpAddr, Ipv4Addr, TcpListener},
     time::Duration,
 };
 
@@ -86,5 +89,178 @@ fn set_dscp(socket: &Socket, dscp: Option<DscpTos>) {
         };
 
         socket.set_tos_v4((tos << 2) as u32).ok();
+    }
+}
+
+// connect_to_client should be used on the server side.
+// At the moment, the TcpListener is implemened on the client side so the API for this function
+// is non-standard
+// todo: convert to class when storing a TcpListener
+pub fn connect_to_client<T: DeserializeOwned>(
+    client_ips: Vec<IpAddr>,
+    timeout: Duration,
+) -> ConResult<(ProtoControlSocket, IpAddr, T)> {
+    let (mut control_socket, client_ip) =
+        ProtoControlSocket::connect_to(timeout, PeerType::AnyClient(client_ips))?;
+
+    let res = control_socket.recv(timeout)?;
+
+    Ok((control_socket, client_ip, res))
+}
+
+pub fn listen_to_server<T: DeserializeOwned>(
+    listener_socket: &TcpListener,
+    timeout: Duration,
+    client_info: &impl Serialize,
+) -> ConResult<(ProtoControlSocket, T)> {
+    let (mut control_socket, _) =
+        ProtoControlSocket::connect_to(timeout, PeerType::Server(listener_socket))?;
+
+    control_socket.send(client_info).to_con()?;
+
+    let config_packet = control_socket.recv(timeout)?;
+
+    Ok((control_socket, config_packet))
+}
+
+pub fn send_restart_signal(
+    mut control_socket: ProtoControlSocket,
+    stream_config_packet: impl Serialize,
+) -> ConResult<()> {
+    // We must send the config packet before, which will be unused
+    control_socket.send(&stream_config_packet).to_con()?;
+
+    control_socket
+        .send(&ServerControlPacket::Restarting)
+        .to_con()
+}
+
+pub struct StreamSocketConfig {
+    pub protocol: SocketProtocol,
+    pub port: u16,
+    pub buffer_config: SocketBufferConfig,
+    pub max_packet_size: usize,
+    pub dscp: Option<DscpTos>,
+}
+
+pub enum ServerConnectionResult {
+    Connected(SocketConnection),
+    Restarting,
+}
+
+pub struct SocketConnection {
+    control_socket: ProtoControlSocket,
+    stream_socket: StreamSocket,
+}
+
+impl SocketConnection {
+    // Note: the timeout resets after each internal operation
+    pub fn from_client_connection(
+        mut control_socket: ProtoControlSocket,
+        timeout: Duration,
+        stream_config_packet: impl Serialize,
+        socket_config: StreamSocketConfig,
+    ) -> ConResult<Self> {
+        let client_ip = control_socket.inner.peer_addr().to_con()?.ip();
+
+        control_socket.send(&stream_config_packet).to_con()?;
+
+        control_socket
+            .send(&ServerControlPacket::StartStream)
+            .to_con()?;
+
+        let signal = control_socket.recv(timeout)?;
+        if !matches!(signal, ClientControlPacket::StreamReady) {
+            con_bail!("Got unexpected packet waiting for stream ack");
+        }
+
+        let stream_socket = StreamSocketBuilder::connect_to_client(
+            timeout,
+            client_ip,
+            socket_config.port,
+            socket_config.protocol,
+            socket_config.dscp,
+            socket_config.buffer_config,
+            socket_config.max_packet_size,
+        )?;
+
+        Ok(Self {
+            control_socket,
+            stream_socket,
+        })
+    }
+
+    // Note: the timeout resets after each internal operation
+    pub fn from_server_connection(
+        mut control_socket: ProtoControlSocket,
+        timeout: Duration,
+        socket_config: StreamSocketConfig,
+    ) -> ConResult<ServerConnectionResult> {
+        let server_ip = control_socket.inner.peer_addr().to_con()?.ip();
+
+        match control_socket.recv(timeout)? {
+            ServerControlPacket::StartStream => (),
+            ServerControlPacket::Restarting => return Ok(ServerConnectionResult::Restarting),
+            _ => con_bail!("Got unexpected packet waiting for stream start"),
+        }
+
+        let stream_socket_builder = StreamSocketBuilder::listen_for_server(
+            timeout,
+            socket_config.port,
+            socket_config.protocol,
+            socket_config.dscp,
+            socket_config.buffer_config,
+        )
+        .to_con()?;
+
+        control_socket
+            .send(&ClientControlPacket::StreamReady)
+            .to_con()?;
+
+        let stream_socket = stream_socket_builder.accept_from_server(
+            server_ip,
+            socket_config.port,
+            socket_config.max_packet_size,
+            timeout,
+        )?;
+
+        Ok(ServerConnectionResult::Connected(Self {
+            control_socket,
+            stream_socket,
+        }))
+    }
+
+    pub fn request_reliable_stream<T>(&self) -> ConResult<ControlSocketSender<T>> {
+        Ok(ControlSocketSender {
+            inner: self.control_socket.inner.try_clone().to_con()?,
+            buffer: vec![],
+            _phantom: PhantomData,
+        })
+    }
+
+    pub fn subscribe_to_reliable_stream<T>(&self) -> ConResult<ControlSocketReceiver<T>> {
+        Ok(ControlSocketReceiver {
+            inner: self.control_socket.inner.try_clone().to_con()?,
+            buffer: vec![],
+            recv_cursor: None,
+            _phantom: PhantomData,
+        })
+    }
+
+    pub fn request_unreliable_stream<T>(&self, stream_id: u16) -> StreamSender<T> {
+        self.stream_socket.request_stream(stream_id)
+    }
+
+    pub fn subscribe_to_unreliable_stream<T>(
+        &mut self,
+        stream_id: u16,
+        max_concurrent_buffers: usize,
+    ) -> StreamReceiver<T> {
+        self.stream_socket
+            .subscribe_to_stream(stream_id, max_concurrent_buffers)
+    }
+
+    pub fn recv_poll(&mut self) -> ConResult<()> {
+        self.stream_socket.recv()
     }
 }


### PR DESCRIPTION
## Summary

- **Remove `alvr_restart`** from the C API and `ServerCoreContext`; `RestartPending` is now handled identically to `ShutdownPending` in `server_openvr`. Also fixes a latent bug where the restart path was missing `lifecycle_state = ShuttingDown` and an early return, causing fall-through into the `StartStream` handshake.
- **Misc cleanups**: internalize `HandGestureManager` into `tracking_loop` as a local variable (removing the `Arc<Mutex<>>` parameter); move `disconnect_notif` and `tracking_manager` resets to be grouped after the handshake; remove redundant braces and stale log messages; note `server_ip` in `ClientConnectionResult` is currently unused.
- **`SocketConnection` abstraction** (`alvr_sockets`): wraps `ProtoControlSocket` + `StreamSocket` into a unified interface. Adds `connect_to_client`, `listen_to_server`, and `send_restart_signal` free functions. `SocketBufferConfig` replaces separate send/recv buffer fields.
- **Use `SocketConnection` in `connection_pipeline`**: replaces the manual handshake (`proto_socket.split` + `StreamSocketBuilder` + separate per-stream setup) with `SocketConnection::from_client_connection`.

## Test plan

- [x] Server connects to client and streams normally
- [x] Settings change that requires SteamVR restart triggers restart correctly (no fall-through)
- [x] Disconnect / reconnect cycle works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)