### PR TITLE
Fix steam.exe crash on driver unload (0xc0000005) - fixes #3205

### DIFF
--- a/alvr/server_core/Cargo.toml
+++ b/alvr/server_core/Cargo.toml
@@ -43,4 +43,4 @@ tokio = { version = "1", features = [
 tower-http = { version = "0.6", features = ["cors", "set-header"] }
 serde = "1"
 serde_json = "1"
-sysinfo = "0.38"
+sysinfo = { version = "0.38", default-features = false, features = ["system"] }

--- a/alvr/server_openvr/Cargo.toml
+++ b/alvr/server_openvr/Cargo.toml
@@ -21,7 +21,7 @@ alvr_server_io.workspace = true
 alvr_session.workspace = true
 
 serde_json = "1"
-sysinfo = "0.38"
+sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 
 [build-dependencies]
 alvr_filesystem = { path = "../filesystem" }

--- a/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
@@ -90,7 +90,7 @@ public:
     std::map<uint64_t, TrackedDevice*> tracked_devices;
 
     virtual vr::EVRInitError Init(vr::IVRDriverContext* pContext) override {
-        initialize_runtime(); // sets up rust logging/runtime, keep first
+        InitializeRuntime(); // sets up rust logging/runtime, keep first
         Debug("DriverProvider::Init");
 
         VR_INIT_SERVER_DRIVER_CONTEXT(pContext);
@@ -202,26 +202,6 @@ const char* g_driverRootDir;
 
 Settings g_settings;
 const Settings* Settings_Instance() { return &g_settings; }
-
-void (*LogError)(const char* stringPtr);
-void (*LogWarn)(const char* stringPtr);
-void (*LogInfo)(const char* stringPtr);
-void (*LogDebug)(const char* stringPtr);
-void (*LogEncoder)(const char* stringPtr);
-void (*LogPeriodically)(const char* tag, const char* stringPtr);
-void (*DriverReadyIdle)(bool setDefaultChaprone);
-void (*SetVideoConfigNals)(const unsigned char* configBuffer, int len, int codec);
-void (*VideoSend)(unsigned long long targetTimestampNs, unsigned char* buf, int len, bool isIdr);
-void (*HapticsSend)(unsigned long long path, float duration_s, float frequency, float amplitude);
-void (*ShutdownRuntime)();
-unsigned long long (*PathStringToHash)(const char* path);
-void (*ReportPresent)(unsigned long long timestamp_ns, unsigned long long offset_ns);
-void (*ReportComposed)(unsigned long long timestamp_ns, unsigned long long offset_ns);
-FfiDynamicEncoderParams (*GetDynamicEncoderParams)();
-unsigned long long (*GetSerialNumber)(unsigned long long deviceID, char* outString);
-void (*SetOpenvrProps)(void* instancePtr, unsigned long long deviceID);
-void (*RegisterButtons)(void* instancePtr, unsigned long long deviceID);
-void (*WaitForVSync)();
 
 void CppInit(bool earlyHmdInitialization, Settings settings) {
     g_driver_provider.early_hmd_initialization = earlyHmdInitialization;

--- a/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/alvr_server.cpp
@@ -90,6 +90,7 @@ public:
     std::map<uint64_t, TrackedDevice*> tracked_devices;
 
     virtual vr::EVRInitError Init(vr::IVRDriverContext* pContext) override {
+        initialize_runtime(); // sets up rust logging/runtime, keep first
         Debug("DriverProvider::Init");
 
         VR_INIT_SERVER_DRIVER_CONTEXT(pContext);

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -191,33 +191,31 @@ extern "C" unsigned int RGBTOYUV420_SHADER_COMP_SPV_LEN;
 extern "C" const char* g_sessionPath;
 extern "C" const char* g_driverRootDir;
 
-extern "C" void (*LogError)(const char* stringPtr);
-extern "C" void (*LogWarn)(const char* stringPtr);
-extern "C" void (*LogInfo)(const char* stringPtr);
-extern "C" void (*LogDebug)(const char* stringPtr);
-extern "C" void (*LogEncoder)(const char* stringPtr);
-extern "C" void (*LogPeriodically)(const char* tag, const char* stringPtr);
-extern "C" void (*DriverReadyIdle)(bool setDefaultChaprone);
-extern "C" void (*SetVideoConfigNals)(const unsigned char* configBuffer, int len, int codec);
-extern "C" void (*VideoSend)(
-    unsigned long long targetTimestampNs, unsigned char* buf, int len, bool isIdr
-);
-extern "C" void (*HapticsSend)(
-    unsigned long long path, float duration_s, float frequency, float amplitude
-);
-extern "C" void (*ShutdownRuntime)();
-extern "C" unsigned long long (*PathStringToHash)(const char* path);
-extern "C" void (*ReportPresent)(unsigned long long timestamp_ns, unsigned long long offset_ns);
-extern "C" void (*ReportComposed)(unsigned long long timestamp_ns, unsigned long long offset_ns);
-extern "C" FfiDynamicEncoderParams (*GetDynamicEncoderParams)();
-extern "C" unsigned long long (*GetSerialNumber)(unsigned long long deviceID, char* outString);
-extern "C" void (*SetOpenvrProps)(void* instancePtr, unsigned long long deviceID);
-extern "C" void (*RegisterButtons)(void* instancePtr, unsigned long long deviceID);
-extern "C" void (*WaitForVSync)();
+extern "C" void LogError(const char* stringPtr);
+extern "C" void LogWarn(const char* stringPtr);
+extern "C" void LogInfo(const char* stringPtr);
+extern "C" void LogDebug(const char* stringPtr);
+extern "C" void LogEncoder(const char* stringPtr);
+extern "C" void LogPeriodically(const char* tag, const char* stringPtr);
+extern "C" void DriverReadyIdle(bool setDefaultChaprone);
+extern "C" void SetVideoConfigNals(const unsigned char* configBuffer, int len, int codec);
+extern "C" void
+VideoSend(unsigned long long targetTimestampNs, unsigned char* buf, int len, bool isIdr);
+extern "C" void
+HapticsSend(unsigned long long path, float duration_s, float frequency, float amplitude);
+extern "C" void ShutdownRuntime();
+extern "C" unsigned long long PathStringToHash(const char* path);
+extern "C" void ReportPresent(unsigned long long timestamp_ns, unsigned long long offset_ns);
+extern "C" void ReportComposed(unsigned long long timestamp_ns, unsigned long long offset_ns);
+extern "C" FfiDynamicEncoderParams GetDynamicEncoderParams();
+extern "C" unsigned long long GetSerialNumber(unsigned long long deviceID, char* outString);
+extern "C" void SetOpenvrProps(void* instancePtr, unsigned long long deviceID);
+extern "C" void RegisterButtons(void* instancePtr, unsigned long long deviceID);
+extern "C" void WaitForVSync();
 
 extern "C" void CppInit(bool earlyHmdInitialization, Settings settings);
 extern "C" void* CppOpenvrEntryPoint(const char* pInterfaceName, int* pReturnCode);
-extern "C" void initialize_runtime();
+extern "C" void InitializeRuntime();
 extern "C" bool InitializeStreaming(Settings settings);
 extern "C" void DeinitializeStreaming();
 extern "C" void SendVSync();

--- a/alvr/server_openvr/cpp/alvr_server/bindings.h
+++ b/alvr/server_openvr/cpp/alvr_server/bindings.h
@@ -217,6 +217,7 @@ extern "C" void (*WaitForVSync)();
 
 extern "C" void CppInit(bool earlyHmdInitialization, Settings settings);
 extern "C" void* CppOpenvrEntryPoint(const char* pInterfaceName, int* pReturnCode);
+extern "C" void initialize_runtime();
 extern "C" bool InitializeStreaming(Settings settings);
 extern "C" void DeinitializeStreaming();
 extern "C" void SendVSync();

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -511,6 +511,7 @@ fn spawn_event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
     *EVENT_LOOP_HANDLE.lock() = Some(handle);
 }
 
+#[unsafe(export_name = "DriverReadyIdle")]
 extern "C" fn driver_ready_idle(set_default_chap: bool) {
     let handle = thread::spawn(move || {
         unsafe { InitOpenvrClient() };
@@ -527,6 +528,7 @@ extern "C" fn driver_ready_idle(set_default_chap: bool) {
 
 /// # Safety
 /// `instance_ptr` is a valid pointer to a `TrackedDevice` instance
+#[unsafe(export_name = "RegisterButtons")]
 pub unsafe extern "C" fn register_buttons(instance_ptr: *mut c_void, device_id: u64) {
     let mapped_device_id = if device_id == *HAND_TRACKER_LEFT_ID {
         *HAND_LEFT_ID
@@ -547,6 +549,7 @@ pub unsafe extern "C" fn register_buttons(instance_ptr: *mut c_void, device_id: 
     }
 }
 
+#[unsafe(export_name = "HapticsSend")]
 extern "C" fn send_haptics(device_id: u64, duration_s: f32, frequency: f32, amplitude: f32) {
     if let Ok(duration) = Duration::try_from_secs_f32(duration_s)
         && let Some(context) = &*SERVER_CORE_CONTEXT.read()
@@ -560,6 +563,7 @@ extern "C" fn send_haptics(device_id: u64, duration_s: f32, frequency: f32, ampl
     }
 }
 
+#[unsafe(export_name = "SetVideoConfigNals")]
 extern "C" fn set_video_config_nals(buffer_ptr: *const u8, len: i32, codec: i32) {
     let codec = if codec == 0 {
         CodecType::H264
@@ -578,6 +582,7 @@ extern "C" fn set_video_config_nals(buffer_ptr: *const u8, len: i32, codec: i32)
     }
 }
 
+#[unsafe(export_name = "VideoSend")]
 extern "C" fn send_video(timestamp_ns: u64, buffer_ptr: *mut u8, len: i32, is_idr: bool) {
     if let Some(context) = &*SERVER_CORE_CONTEXT.read() {
         let timestamp = Duration::from_nanos(timestamp_ns);
@@ -609,6 +614,7 @@ extern "C" fn send_video(timestamp_ns: u64, buffer_ptr: *mut u8, len: i32, is_id
     }
 }
 
+#[unsafe(export_name = "GetDynamicEncoderParams")]
 extern "C" fn get_dynamic_encoder_params() -> FfiDynamicEncoderParams {
     if let Some(context) = &*SERVER_CORE_CONTEXT.read()
         && let Some(params) = context.get_dynamic_encoder_params()
@@ -623,6 +629,7 @@ extern "C" fn get_dynamic_encoder_params() -> FfiDynamicEncoderParams {
     }
 }
 
+#[unsafe(export_name = "ReportComposed")]
 extern "C" fn report_composed(timestamp_ns: u64, offset_ns: u64) {
     if let Some(context) = &*SERVER_CORE_CONTEXT.read() {
         context.report_composed(
@@ -632,6 +639,7 @@ extern "C" fn report_composed(timestamp_ns: u64, offset_ns: u64) {
     }
 }
 
+#[unsafe(export_name = "ReportPresent")]
 extern "C" fn report_present(timestamp_ns: u64, offset_ns: u64) {
     if let Some(context) = &*SERVER_CORE_CONTEXT.read() {
         context.report_present(
@@ -641,6 +649,7 @@ extern "C" fn report_present(timestamp_ns: u64, offset_ns: u64) {
     }
 }
 
+#[unsafe(export_name = "WaitForVSync")]
 extern "C" fn wait_for_vsync() {
     // Default 120Hz-ish wait if StatisticsManager isn't up.
     // We use 120Hz-ish so that SteamVR doesn't accidentally get
@@ -669,6 +678,7 @@ extern "C" fn wait_for_vsync() {
     }
 }
 
+#[unsafe(export_name = "ShutdownRuntime")]
 pub extern "C" fn shutdown_driver() {
     SERVER_CORE_CONTEXT.write().take();
 
@@ -704,7 +714,7 @@ pub unsafe extern "C" fn HmdDriverFactory(
 
     // When there is already a ALVR dashboard running, initialize the HMD device early to
     // avoid buggy SteamVR behavior
-    // defer heavy init to initialize_runtime() so a factory probe
+    // defer heavy init to InitializeRuntime() so a factory probe
     // (e.g. steam.exe enumerating drivers) doesn't spawn threads
     *FACTORY_INIT_DATA.lock() = Some(FactoryInitData {
         filesystem_layout,
@@ -714,8 +724,53 @@ pub unsafe extern "C" fn HmdDriverFactory(
     unsafe { CppOpenvrEntryPoint(interface_name, return_code) }
 }
 
-// called from DriverProvider::Init(), must run before C++ touches the Log* pointers
-#[unsafe(no_mangle)]
+#[unsafe(export_name = "LogError")]
+unsafe extern "C" fn log_error(string_ptr: *const c_char) {
+    unsafe { alvr_server_core::alvr_error(string_ptr) };
+}
+
+#[unsafe(export_name = "LogWarn")]
+unsafe extern "C" fn log_warn(string_ptr: *const c_char) {
+    unsafe { alvr_server_core::alvr_warn(string_ptr) };
+}
+
+#[unsafe(export_name = "LogInfo")]
+unsafe extern "C" fn log_info(string_ptr: *const c_char) {
+    unsafe { alvr_server_core::alvr_info(string_ptr) };
+}
+
+#[unsafe(export_name = "LogDebug")]
+unsafe extern "C" fn log_debug(string_ptr: *const c_char) {
+    unsafe { alvr_server_core::alvr_dbg_server_impl(string_ptr) };
+}
+
+#[unsafe(export_name = "LogEncoder")]
+unsafe extern "C" fn log_encoder(string_ptr: *const c_char) {
+    unsafe { alvr_server_core::alvr_dbg_encoder(string_ptr) };
+}
+
+#[unsafe(export_name = "LogPeriodically")]
+unsafe extern "C" fn log_periodically(tag_ptr: *const c_char, string_ptr: *const c_char) {
+    unsafe { alvr_server_core::alvr_log_periodically(tag_ptr, string_ptr) };
+}
+
+#[unsafe(export_name = "PathStringToHash")]
+unsafe extern "C" fn path_string_to_hash(path: *const c_char) -> u64 {
+    unsafe { alvr_server_core::alvr_path_to_id(path) }
+}
+
+#[unsafe(export_name = "GetSerialNumber")]
+extern "C" fn get_serial_number(device_id: u64, out_str: *mut c_char) -> u64 {
+    props::get_serial_number(device_id, out_str)
+}
+
+#[unsafe(export_name = "SetOpenvrProps")]
+extern "C" fn set_openvr_props(instance_ptr: *mut c_void, device_id: u64) {
+    props::set_device_openvr_props(instance_ptr, device_id)
+}
+
+// called from DriverProvider::Init()
+#[unsafe(export_name = "InitializeRuntime")]
 pub extern "C" fn initialize_runtime() {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
@@ -750,26 +805,6 @@ pub extern "C" fn initialize_runtime() {
         graphics::initialize_shaders();
 
         unsafe {
-            LogError = Some(alvr_server_core::alvr_error);
-            LogWarn = Some(alvr_server_core::alvr_warn);
-            LogInfo = Some(alvr_server_core::alvr_info);
-            LogDebug = Some(alvr_server_core::alvr_dbg_server_impl);
-            LogEncoder = Some(alvr_server_core::alvr_dbg_encoder);
-            LogPeriodically = Some(alvr_server_core::alvr_log_periodically);
-            PathStringToHash = Some(alvr_server_core::alvr_path_to_id);
-            GetSerialNumber = Some(props::get_serial_number);
-            SetOpenvrProps = Some(props::set_device_openvr_props);
-            RegisterButtons = Some(register_buttons);
-            DriverReadyIdle = Some(driver_ready_idle);
-            HapticsSend = Some(send_haptics);
-            SetVideoConfigNals = Some(set_video_config_nals);
-            VideoSend = Some(send_video);
-            GetDynamicEncoderParams = Some(get_dynamic_encoder_params);
-            ReportComposed = Some(report_composed);
-            ReportPresent = Some(report_present);
-            WaitForVSync = Some(wait_for_vsync);
-            ShutdownRuntime = Some(shutdown_driver);
-
             CppInit(init_data.early_hmd_initialization, make_settings(None));
         }
 

--- a/alvr/server_openvr/src/lib.rs
+++ b/alvr/server_openvr/src/lib.rs
@@ -41,6 +41,14 @@ use std::{
 static SERVER_CORE_CONTEXT: RwLock<Option<ServerCoreContext>> = RwLock::new(None);
 static LOCAL_VIEW_PARAMS: RwLock<[ViewParams; 2]> = RwLock::new([ViewParams::DUMMY; 2]);
 static HEAD_POSE_QUEUE: Mutex<VecDeque<(Duration, Pose)>> = Mutex::new(VecDeque::new());
+static EVENT_LOOP_HANDLE: Mutex<Option<thread::JoinHandle<()>>> = Mutex::new(None);
+static IDLE_INIT_HANDLE: Mutex<Option<thread::JoinHandle<()>>> = Mutex::new(None);
+static FACTORY_INIT_DATA: Mutex<Option<FactoryInitData>> = Mutex::new(None);
+
+struct FactoryInitData {
+    filesystem_layout: afs::Layout,
+    early_hmd_initialization: bool,
+}
 
 fn make_settings(negotiated: Option<&ServerNegotiatedStreamingConfig>) -> Settings {
     let settings = alvr_server_core::settings();
@@ -239,7 +247,7 @@ fn make_settings(negotiated: Option<&ServerNegotiatedStreamingConfig>) -> Settin
 }
 
 fn spawn_event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
-    thread::spawn(move || {
+    let handle = thread::spawn(move || {
         if let Some(context) = &*SERVER_CORE_CONTEXT.read() {
             context.start_connection();
         }
@@ -500,10 +508,11 @@ fn spawn_event_loop(events_receiver: mpsc::Receiver<ServerCoreEvent>) {
 
         unsafe { ShutdownOpenvrClient() };
     });
+    *EVENT_LOOP_HANDLE.lock() = Some(handle);
 }
 
 extern "C" fn driver_ready_idle(set_default_chap: bool) {
-    thread::spawn(move || {
+    let handle = thread::spawn(move || {
         unsafe { InitOpenvrClient() };
 
         if set_default_chap {
@@ -513,6 +522,7 @@ extern "C" fn driver_ready_idle(set_default_chap: bool) {
             }
         }
     });
+    *IDLE_INIT_HANDLE.lock() = Some(handle);
 }
 
 /// # Safety
@@ -661,6 +671,14 @@ extern "C" fn wait_for_vsync() {
 
 pub extern "C" fn shutdown_driver() {
     SERVER_CORE_CONTEXT.write().take();
+
+    // join driver threads so the dll isn't unloaded while they're still running
+    if let Some(handle) = EVENT_LOOP_HANDLE.lock().take() {
+        handle.join().ok();
+    }
+    if let Some(handle) = IDLE_INIT_HANDLE.lock().take() {
+        handle.join().ok();
+    }
 }
 
 /// This is the SteamVR/OpenVR entry point
@@ -684,8 +702,28 @@ pub unsafe extern "C" fn HmdDriverFactory(
         .processes_by_name(OsStr::new(&afs::dashboard_fname()))
         .collect::<Vec<_>>();
 
+    // When there is already a ALVR dashboard running, initialize the HMD device early to
+    // avoid buggy SteamVR behavior
+    // defer heavy init to initialize_runtime() so a factory probe
+    // (e.g. steam.exe enumerating drivers) doesn't spawn threads
+    *FACTORY_INIT_DATA.lock() = Some(FactoryInitData {
+        filesystem_layout,
+        early_hmd_initialization: !dashboard_processes.is_empty(),
+    });
+
+    unsafe { CppOpenvrEntryPoint(interface_name, return_code) }
+}
+
+// called from DriverProvider::Init(), must run before C++ touches the Log* pointers
+#[unsafe(no_mangle)]
+pub extern "C" fn initialize_runtime() {
     static ONCE: Once = Once::new();
-    ONCE.call_once(move || {
+    ONCE.call_once(|| {
+        let Some(init_data) = FACTORY_INIT_DATA.lock().take() else {
+            return;
+        };
+        let filesystem_layout = init_data.filesystem_layout;
+
         alvr_server_core::initialize_environment(filesystem_layout.clone());
 
         let log_to_disk = alvr_server_core::settings().extra.logging.log_to_disk;
@@ -732,12 +770,7 @@ pub unsafe extern "C" fn HmdDriverFactory(
             WaitForVSync = Some(wait_for_vsync);
             ShutdownRuntime = Some(shutdown_driver);
 
-            // When there is already a ALVR dashboard running, initialize the HMD device early to
-            // avoid buggy SteamVR behavior
-            // NB: we already bail out before if the dashboards don't belong to this streamer
-            let early_hmd_initialization = !dashboard_processes.is_empty();
-
-            CppInit(early_hmd_initialization, make_settings(None));
+            CppInit(init_data.early_hmd_initialization, make_settings(None));
         }
 
         let (context, events_receiver) = ServerCoreContext::new();
@@ -746,6 +779,4 @@ pub unsafe extern "C" fn HmdDriverFactory(
 
         spawn_event_loop(events_receiver);
     });
-
-    unsafe { CppOpenvrEntryPoint(interface_name, return_code) }
 }


### PR DESCRIPTION
steam.exe crashes with an access violation (0xc0000005) in driver_alvr_server.dll_unloaded. Reproduces reliably here: start SteamVR through Steam, then quit. steam.exe crashes on exit.

Steam enumerates VR drivers by loading the DLL, calling HmdDriverFactory, then unloading it with FreeLibrary. The factory currently runs the whole driver init on first call, so a simple probe spawns threads, shutdown_driver() never runs in that process, and the threads are still alive when the DLL gets unmapped. They end up executing freed memory.

WinDbg on the minidumps with local PDBs showed which threads were dying: first a rust thread mid teardown (thread_start into __rust_dealloc), then rayon workers (WorkerThread::find_work, Sleep::sleep). The rayon pool comes from sysinfo::System::new_all() in the factory, sysinfo's default multithread feature spins it up and it's never joined.

The fix: heavy init moved out of the factory into a new initialize_runtime() called from DriverProvider::Init(), so a probe spawns nothing and init only happens when vrserver actually activates the driver. shutdown_driver() now joins the event loop and idle init threads. And sysinfo's multithread feature is disabled in server_openvr and server_core to drop the rayon pool.

Verified on v20.14.1, the crash hit every SteamVR session before and is gone after. This branch is the same fix rebased onto master and it compiles.

Same crash as #3331 but fixed by removing the cause instead of special casing steam.exe. Valve's own driver_vrlink.dll crashes the same way in steam.exe, which fits the probe and unload mechanism.

