### PR TITLE
Fix double free of AMF components on encoder shutdown

### DIFF
--- a/alvr/server_openvr/cpp/platform/win32/VideoEncoderAMF.cpp
+++ b/alvr/server_openvr/cpp/platform/win32/VideoEncoderAMF.cpp
@@ -687,9 +687,9 @@ void VideoEncoderAMF::Shutdown() {
     delete m_pipeline;
 
     for (auto& component : m_amfComponents) {
-        component->Release();
-        delete component;
+        component->Terminate();
     }
+    m_amfComponents.clear();
 
     m_amfContext->Terminate();
     m_amfContext = NULL;


### PR DESCRIPTION
vrserver.exe crashes at SteamVR shutdown with heap corruption (0xc0000374) when using the AMF encoder on AMD GPUs, causing a "SteamVR crashed last time" prompt on the next start.

VideoEncoderAMF::Shutdown() calls Release() and then delete on each AMF component. AMF components are ref counted objects owned by the AMF runtime, so the manual delete frees memory the runtime still manages and corrupts the heap. Fixed by calling Terminate() instead and clearing the vector, refcounting handles the destruction.

Verified on v20.14.1 with an AMD GPU, the crash and the crash prompt are gone after repeated sessions.