### PR TITLE
Add Pico Neo 2/eye to the Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a fork of [ALVR](https://github.com/polygraphene/ALVR).
 |       Apple Vision Pro       |    :heavy_check_mark: ([store link](https://apps.apple.com/app/alvr/id6479728026))     |
 |      Quest 1/2/3/3S/Pro      | :heavy_check_mark: ([store link](https://www.meta.com/experiences/7674846229245715) *) |
 |     Pico Neo 3/4/4 Ultra     |                                   :heavy_check_mark:                                   |
-|   Pico Neo 2 / Neo 2 Eye    | :heavy_check_mark: ***** ([unofficial client](https://github.com/Juspertinry/alvr-pico-legacy)) |
+|   Pico Neo 2 / Neo 2 Eye    | :heavy_check_mark: ***** ([repo](https://github.com/Juspertinry/alvr-pico-legacy)) |
 |    Play For Dream YVR 1/2/MR |                                   :heavy_check_mark:                                   |
 | Vive Focus 3/Vision/XR Elite |                                   :heavy_check_mark:                                   |
 |     PhoneVR (smartphone)     |     :heavy_check_mark: ** ([repo](https://github.com/PhoneVR-Developers/PhoneVR))      |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is a fork of [ALVR](https://github.com/polygraphene/ALVR).
 |       Apple Vision Pro       |    :heavy_check_mark: ([store link](https://apps.apple.com/app/alvr/id6479728026))     |
 |      Quest 1/2/3/3S/Pro      | :heavy_check_mark: ([store link](https://www.meta.com/experiences/7674846229245715) *) |
 |     Pico Neo 3/4/4 Ultra     |                                   :heavy_check_mark:                                   |
+|   Pico Neo 2 / Neo 2 Eye    | :heavy_check_mark: ***** ([unofficial client](https://github.com/Juspertinry/alvr-pico-legacy)) |
 |    Play For Dream YVR 1/2/MR |                                   :heavy_check_mark:                                   |
 | Vive Focus 3/Vision/XR Elite |                                   :heavy_check_mark:                                   |
 |     PhoneVR (smartphone)     |     :heavy_check_mark: ** ([repo](https://github.com/PhoneVR-Developers/PhoneVR))      |
@@ -27,6 +28,7 @@ This is a fork of [ALVR](https://github.com/polygraphene/ALVR).
 \* ALVR for Quest 1 is not available through the Meta store.  
 \** Works on some smartphones, but has not been extensively tested.
 \*** Temporarily removed, last supported on version [20.14.1](https://github.com/alvr-org/ALVR/releases/tag/v20.14.1).
+\***** Unofficial community port, not maintained by the ALVR team. Use the linked client build together with ALVR server [20.14.1](https://github.com/alvr-org/ALVR/releases/tag/v20.14.1).
 
 |     PC OS      |                                    Support                                    |
 | :------------: | :---------------------------------------------------------------------------: |


### PR DESCRIPTION
This change adds the Pico Neo 2 and Pico Neo 2 eye as a client for ALVR. This is very simulator to the PhoneVR listing where its a external application. 

## Old
<img width="692" height="659" alt="image" src="https://github.com/user-attachments/assets/9eafe201-9ec5-47db-8791-6033cab38b71" />

## New
<img width="686" height="705" alt="image" src="https://github.com/user-attachments/assets/04a971af-5352-4737-866c-22ffe32c4b6f" />
