### PR TITLE
Fix Linux latency sawtooth by falling back to the latest pose when pose matching fails

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/PoseHistory.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/PoseHistory.cpp
@@ -68,6 +68,14 @@ PoseHistory::GetBestPoseMatch(const vr::HmdMatrix34_t& pose) const {
     return {};
 }
 
+std::optional<PoseHistory::TrackingHistoryFrame> PoseHistory::GetLatestPose() const {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    if (m_poseBuffer.empty()) {
+        return {};
+    }
+    return m_poseBuffer.back();
+}
+
 std::optional<PoseHistory::TrackingHistoryFrame> PoseHistory::GetPoseAt(uint64_t timestampNs
 ) const {
     std::unique_lock<std::mutex> lock(m_mutex);

--- a/alvr/server_openvr/cpp/alvr_server/PoseHistory.h
+++ b/alvr/server_openvr/cpp/alvr_server/PoseHistory.h
@@ -18,6 +18,8 @@ public:
     void OnPoseUpdated(uint64_t targetTimestampNs, FfiDeviceMotion motion);
 
     std::optional<TrackingHistoryFrame> GetBestPoseMatch(const vr::HmdMatrix34_t& pose) const;
+    // Return the most recent pose in the buffer
+    std::optional<TrackingHistoryFrame> GetLatestPose() const;
     // Return the most recent pose known at the given timestamp
     std::optional<TrackingHistoryFrame> GetPoseAt(uint64_t timestampNs) const;
 

--- a/alvr/server_openvr/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/CEncoder.cpp
@@ -228,7 +228,23 @@ void CEncoder::Run() {
 
             encode_pipeline->SetParams(GetDynamicEncoderParams());
 
-            auto pose = m_poseHistory->GetBestPoseMatch((const vr::HmdMatrix34_t&)frame_info.pose);
+            // The vulkan layer ships an all zero pose when it could not recover one
+            // from the compositor (see vulkan_layer/util/pose.cpp). Every rotation
+            // scores the same distance against zeros, so fall back to the newest
+            // pose instead of matching. Exact compare is safe, the source is a zero
+            // initialized static and a real pose is never all zeros.
+            const vr::HmdMatrix34_t& frame_pose = (const vr::HmdMatrix34_t&)frame_info.pose;
+            bool pose_is_zero = true;
+            for (int i = 0; i < 3 && pose_is_zero; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    if (frame_pose.m[i][j] != 0.0f) {
+                        pose_is_zero = false;
+                        break;
+                    }
+                }
+            }
+            auto pose = pose_is_zero ? m_poseHistory->GetLatestPose()
+                                     : m_poseHistory->GetBestPoseMatch(frame_pose);
             if (!pose) {
                 continue;
             }

--- a/alvr/session/build.rs
+++ b/alvr/session/build.rs
@@ -43,7 +43,7 @@ pub enum OpenvrPropKey {",
             mappings_fn_string,
             r"
     {} = {},",
-            &info.name, &info.code
+            info.name, info.code
         )
         .unwrap();
     }
@@ -62,7 +62,7 @@ pub fn openvr_prop_key_to_type(key: OpenvrPropKey) -> OpenvrPropType {
             mappings_fn_string,
             r"
         OpenvrPropKey::{} => OpenvrPropType::{},",
-            &info.name, info.ty
+            info.name, info.ty
         )
         .unwrap();
     }

--- a/alvr/vulkan_layer/util/pose.cpp
+++ b/alvr/vulkan_layer/util/pose.cpp
@@ -72,6 +72,19 @@ const TrackedDevicePose_t & find_pose_in_call_stack()
   if (res != nullptr)
     return *res;
   static TrackedDevicePose_t notfound;
+  // The walk below cannot succeed when the render thread symbol is not
+  // present in vrcompositor (true as of SteamVR 2.17.6), and a full unwind
+  // with symbol name lookup on every present is expensive. After enough
+  // consecutive misses only retry once in a while, so a vrcompositor that
+  // does have the symbol can still populate the cache.
+  constexpr unsigned failure_threshold = 300;
+  constexpr unsigned retry_interval = 1000;
+  static unsigned failures;
+  if (failures >= failure_threshold && failures % retry_interval != 0)
+  {
+    ++failures;
+    return notfound;
+  }
   unw_context_t ctx;
   unw_getcontext(&ctx);
   unw_cursor_t cursor;
@@ -96,8 +109,10 @@ const TrackedDevicePose_t & find_pose_in_call_stack()
           return *p;
         }
       }
+      ++failures;
       return notfound;
     }
   }
+  ++failures;
   return notfound;
 }


### PR DESCRIPTION
This should fix #3326 and #3297.

## Problem

On SteamVR 2.17.6 for Linux, streaming latency ramps in a sawtooth with peaks around 1.3s, reported under "Game Render" in the statistics, with "Latency is too high. Clamping prediction" spam in the log and the desync loop described in #3297. On my rig (RX 6900 XT, RADV, CachyOS) this made streaming unwearable. The common workaround is pinning SteamVR to the "previous" branch in the Betas tab, which breaks again on every SteamVR update.

## Cause

The vulkan layer recovers the per-frame HMD pose by searching vrcompositor's call stack for the symbol `_ZN13CRenderThread11UpdateAsyncEv` (`alvr/vulkan_layer/util/pose.cpp`). That symbol no longer exists in vrcompositor.real:

```
$ readelf -sW .../SteamVR/bin/linux64/vrcompositor.real | grep -c CRenderThread
0
```

0 hits on both the default branch (buildid 23791826) and the beta branch (buildid 24308756).

`find_pose_in_call_stack()` only caches on success, so every present re-runs a full libunwind walk with symbol resolution. I caught this live with eu-stack: a compositor thread inside `unw_get_proc_name`, reading ELF images off disk, under `wsi_layer_vkQueuePresentKHR`. The walk fails every time, and an all-zero pose is stamped on every frame and shipped to the server.

Server side, `GetBestPoseMatch()` degenerates on that input: every valid rotation matrix scores the same distance (3.0) against a zero matrix, so the "best match" is decided by floating point noise. One arbitrary history entry wins and keeps winning, so frames get tagged with its timestamp, and its age grows at one second per second until the entry expires from the history buffer and a new arbitrary entry takes over at a random younger age. That is the sawtooth. The number lands under "Game Render" because that figure is not a rendering measurement: `game_time_latency` in `server_core/src/statistics.rs` is `frame_present - tracking_received` for the frame matched by `target_timestamp`, so a stale timestamp reads as game time. The inflated motion-to-photon then permanently exceeds `max_prediction_ms`, which produces the clamping spam and feeds the resync loop from #3297 (credit to @pxlwh in #3326 for spotting that loop).

## Fix

Minimal, and behavior-preserving anywhere the symbol still exists:

- `vulkan_layer/util/pose.cpp`: after 300 consecutive misses, back off to a sparse retry (a walk every 1000th call) instead of unwinding on every present. A stripped compositor stops paying unwind and symbol lookup costs, a compositor that has the symbol populates the success cache exactly as before, and the sparse retry means a failing verdict is never permanent for the life of the process.
- `PoseHistory`: new `GetLatestPose()` accessor.
- `CEncoder.cpp`: if the incoming pose matrix is all zeros (impossible for a real pose), fall back to the newest pose instead of the degenerate match. The existing path is untouched otherwise.

Also includes a two-line clippy fix in `alvr/session/build.rs` (needless borrow on current stable Rust) needed for CI to pass.

The two halves are independent: the CEncoder fallback alone fixes the sawtooth, the layer backoff alone fixes the per-present cost. Either can merge standalone if preferred.

## Results

Same rig, before and after: latency graph flat with a ~77ms ceiling instead of sawtoothing to ~1.3s, the "Game Render" figure back to sane values (was 1169ms while encode, network, and decode were each under 6ms), clamping spam gone from the log, and the stream is wearable. Screenshots attached.

## Known limitations

This fixes the failure mode, not the mechanism. Recovering the pose by scanning a closed binary's stack for a mangled symbol name will break again whenever Valve renames or strips it. The structural fix, is probably associating frames to poses by timestamp rather than by matrix matching.

On affected systems the fallback changes what `target_timestamp` means: it becomes the newest tracking sample rather than the sample the frame was rendered with. So "Game Render" reads approximate (slightly low) rather than measured, and reprojection's source pose is a frame or two newer than the true render pose. Negligible next to the bug, but not free.