### PR TITLE
Remove the Linux cfg gate on the webserver runtime drop

### DIFF
--- a/alvr/server_core/src/lib.rs
+++ b/alvr/server_core/src/lib.rs
@@ -591,9 +591,6 @@ impl Drop for ServerCoreContext {
             thread::sleep(Duration::from_millis(100));
         }
 
-        // Dropping the webserver runtime is bugged on linux and will prevent StemVR shutdown
-        if !cfg!(target_os = "linux") {
-            self.webserver_runtime.take();
-        }
+        self.webserver_runtime.take();
     }
 }


### PR DESCRIPTION
Removes the cfg gate in `ServerCoreContext::drop` so the webserver runtime is dropped on all platforms instead of leaked on Linux.

The gate came in as a direct commit (a80f3846) with a comment saying the drop prevented SteamVR shutdown on Linux, but no linked issue or PR, so there is no record of what the original hang was. The webserver it was written against has since been replaced, and the hang does not reproduce on a current stack:

- @elektricM tested the #3331 branch, which removes the gate in an equivalent form (`if let Some(runtime) = self.webserver_runtime.take()` instead of a bare `take()`; its other change, a steam.exe filename check, is a no-op on Linux). Repeated launch/quit cycles with no client connected (Arch, 7900 XTX, SteamVR previous branch): no hang, exit time identical to a control build that leaks the runtime. https://github.com/alvr-org/ALVR/pull/3331#issuecomment-5013632696
- I tested this exact change, built as master e9b8e3ac plus this diff, covering the remaining case: shutdown with a client connected and streaming (CachyOS, RX 6900 XT, SteamVR previous branch, Quest 3 over wifi). Fifteen runs across mid-stream shutdown, client closed first, quit from the SteamVR menu, and back to back cycles. Control 1.3-1.9s, gate removed 1.4-2.3s, no hangs, no leftover vrserver/vrcompositor/vrmonitor processes. https://github.com/alvr-org/ALVR/pull/3331#issuecomment-5123423183

Both test setups were on the SteamVR previous branch, not 2.16.

Isolated from #3331 (https://github.com/alvr-org/ALVR/pull/3331#issuecomment-5136186582). Original proposal by @Roboct424.
