### PR TITLE
Fix error 303 on SteamVR 2.16 by not renaming the vrcompositor binary

### DIFF
--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -40,17 +40,34 @@ pub fn maybe_wrap_vrcompositor_launcher() -> alvr_common::anyhow::Result<()> {
     };
 
     let launcher_path = steamvr_bin_dir.join("vrcompositor");
+    let compositor_path = alvr_filesystem::original_vrcompositor_path(&steamvr_bin_dir);
+    let alvr_dir = alvr_filesystem::original_vrcompositor_dir(&steamvr_bin_dir);
+
+    // Older installs have the binary at vrcompositor.real
+    let old_compositor_path = steamvr_bin_dir.join("vrcompositor.real");
+    if old_compositor_path.exists() && !compositor_path.exists() {
+        fs::create_dir_all(&alvr_dir)?;
+        fs::rename(&old_compositor_path, &compositor_path)?;
+        info!("Moved vrcompositor.real to {}", compositor_path.display());
+    }
+
     // In case of SteamVR update, vrcompositor will be restored
     if fs::read_link(&launcher_path).is_ok() {
         fs::remove_file(&launcher_path)?; // recreate the link
-    } else {
-        fs::rename(&launcher_path, steamvr_bin_dir.join("vrcompositor.real"))?;
+    } else if launcher_path.exists() {
+        fs::create_dir_all(&alvr_dir)?;
+        fs::rename(&launcher_path, &compositor_path)?;
     }
 
     std::os::unix::fs::symlink(
         crate::get_filesystem_layout().vrcompositor_wrapper(),
         &launcher_path,
     )?;
+
+    debug!(
+        "Wrapped vrcompositor, real binary at {}",
+        compositor_path.display()
+    );
 
     Ok(())
 }

--- a/alvr/filesystem/src/lib.rs
+++ b/alvr/filesystem/src/lib.rs
@@ -80,6 +80,17 @@ pub fn dashboard_fname() -> &'static str {
     }
 }
 
+// SteamVR 2.16+ only accepts the compositor if the process is named
+// vrcompositor. A suffix does not work, exec takes the process name from
+// the basename and vrcompositor.real gets cut to vrcompositor.re.
+pub fn original_vrcompositor_dir(steamvr_bin_dir: &Path) -> PathBuf {
+    steamvr_bin_dir.join("alvr")
+}
+
+pub fn original_vrcompositor_path(steamvr_bin_dir: &Path) -> PathBuf {
+    original_vrcompositor_dir(steamvr_bin_dir).join("vrcompositor")
+}
+
 // Layout of the ALVR installation. All paths are absolute
 #[derive(Clone, Default, Debug)]
 pub struct Layout {

--- a/alvr/vrcompositor_wrapper/src/main.rs
+++ b/alvr/vrcompositor_wrapper/src/main.rs
@@ -41,7 +41,12 @@ fn main() {
         }
     }
 
-    let err = exec::execvp(argv0 + ".real", std::env::args());
+    // argv0 is the symlink in SteamVR's bin dir, not the wrapper's own
+    // location, so its parent is where the real compositor sits
+    let steamvr_bin_dir = std::path::Path::new(&argv0).parent().unwrap();
+    let compositor_path = alvr_filesystem::original_vrcompositor_path(steamvr_bin_dir);
+
+    let err = exec::execvp(compositor_path, std::env::args());
     println!("Failed to run vrcompositor {err}");
 }
 


### PR DESCRIPTION
Fixes #3294. Should also resolve most reports in #3296.

## Summary
 
- SteamVR 2.16 does not accept the compositor as running unless the process is named `vrcompositor`. Linux takes the process name from the basename of the exec target, capped at 15 characters, so the `vrcompositor.real` rename produced the name `vrcompositor.re` and the check never passed.
- vrmonitor waits 5 seconds for the compositor start reply (message type 136) on VR_ServerPipe, but vrserver stalls about 10.9 seconds before sending it. The reply arrives late, gets discarded on a sequence mismatch, and vrmonitor raises 303. The compositor itself is healthy the whole time, Startup Complete in about 0.23s.
- Keep the binary named `vrcompositor` and move it instead of renaming it: `maybe_wrap_vrcompositor_launcher` now puts it at `bin/linux64/alvr/vrcompositor` and the wrapper execs that path. Existing installs are migrated on the next dashboard launch.
## Notes
 
- The exact check inside vrserver is not visible from outside, but the behaviour is name-check shaped and vrserver's false "vrcompositor process is not running" line says as much. New in 2.16, whose release notes say the compositor became a child of vrserver.
- The failure was isolated by A/B testing with a two-line sh script in place of the wrapper: it fails identically when exec'ing `vrcompositor.real` (within 10ms of the Rust wrapper) and passes when exec'ing a path named `vrcompositor`. This rules out the Rust runtime, SIGPIPE inheritance, and the wrapper's env vars.

## Test plan
 
Tested on CachyOS, RX 6900 XT (RADV), Quest 3 over WiFi, SteamVR 2.16.7 buildid 23791826.
 
- [x] Old layout (exec to `vrcompositor.real`): 303, message 136 timeout at +5.02s, reply discarded at +10.52s
- [x] sh script exec to `vrcompositor.real`: same failure within 10ms
- [x] sh script exec through a path named `vrcompositor`: clean twice, compositor pipe connects in about 300ms
- [x] Same on Wayland with the drm lease shim preloaded: clean, lease granted
- [x] This PR, dashboard launch on an install with the old `.real` layout: migration ran, no 303 (Wayland)
- [x] This PR, second dashboard launch on the migrated install: idempotent path, no 303 (X11)
- [x] This PR, Steam Play button launches on the fixed layout, several runs: no 303, wrap untouched as expected
- [x] comm verified with `ps -eo pid,comm` in passing runs: `vrcompositor` after the exec hop
 
