### PR TITLE
Fix error 303 on SteamVR v2.16+ and add pico_controller binding files

### DIFF
--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -40,17 +40,65 @@ pub fn maybe_wrap_vrcompositor_launcher() -> alvr_common::anyhow::Result<()> {
     };
 
     let launcher_path = steamvr_bin_dir.join("vrcompositor");
+    let compositor_path = alvr_filesystem::original_vrcompositor_path(&steamvr_bin_dir);
+    let alvr_dir = alvr_filesystem::original_vrcompositor_dir(&steamvr_bin_dir);
+
+    // Older installs have the binary at vrcompositor.real
+    let old_compositor_path = steamvr_bin_dir.join("vrcompositor.real");
+    if old_compositor_path.exists() && !compositor_path.exists() {
+        fs::create_dir_all(&alvr_dir)?;
+        fs::rename(&old_compositor_path, &compositor_path)?;
+        info!("Moved vrcompositor.real to {}", compositor_path.display());
+    }
+
     // In case of SteamVR update, vrcompositor will be restored
     if fs::read_link(&launcher_path).is_ok() {
         fs::remove_file(&launcher_path)?; // recreate the link
-    } else {
-        fs::rename(&launcher_path, steamvr_bin_dir.join("vrcompositor.real"))?;
+    } else if launcher_path.exists() {
+        fs::create_dir_all(&alvr_dir)?;
+        fs::rename(&launcher_path, &compositor_path)?;
     }
 
     std::os::unix::fs::symlink(
         crate::get_filesystem_layout().vrcompositor_wrapper(),
         &launcher_path,
     )?;
+
+    debug!(
+        "Wrapped vrcompositor, real binary at {}",
+        compositor_path.display()
+    );
+
+    // Copy pico_controller binding files to the vrlink driver's resources.
+    // SteamVR v2.16+ requires controller-type-specific binding files and no longer
+    // falls back to generic bindings. These files map the system button to
+    // ToggleDashboard and provide legacy input bindings for pico_controller.
+    let vrlink_input_dir = steamvr_bin_dir
+        .join("..")
+        .join("drivers")
+        .join("vrlink")
+        .join("resources")
+        .join("input");
+    if vrlink_input_dir.exists() {
+        let binding_files = [
+            "legacy_bindings_pico_controller.json",
+            "vrcompositor_bindings_pico_controller.json",
+        ];
+        let alvr_resources_input = std::env::current_exe()
+            .map(|p| p.join("../../share/alvr/server_openvr/resources/input"))
+            .unwrap_or_default();
+        for fname in &binding_files {
+            let src = alvr_resources_input.join(fname);
+            let dst = vrlink_input_dir.join(fname);
+            if src.exists() && !dst.exists() {
+                if let Err(e) = fs::copy(&src, &dst) {
+                    warn!("Failed to copy {} to vrlink driver: {}", fname, e);
+                } else {
+                    info!("Copied {} to vrlink driver resources", fname);
+                }
+            }
+        }
+    }
 
     Ok(())
 }

--- a/alvr/filesystem/src/lib.rs
+++ b/alvr/filesystem/src/lib.rs
@@ -80,6 +80,17 @@ pub fn dashboard_fname() -> &'static str {
     }
 }
 
+// SteamVR 2.16+ only accepts the compositor if the process is named
+// vrcompositor. A suffix does not work, exec takes the process name from
+// the basename and vrcompositor.real gets cut to vrcompositor.re.
+pub fn original_vrcompositor_dir(steamvr_bin_dir: &Path) -> PathBuf {
+    steamvr_bin_dir.join("alvr")
+}
+
+pub fn original_vrcompositor_path(steamvr_bin_dir: &Path) -> PathBuf {
+    original_vrcompositor_dir(steamvr_bin_dir).join("vrcompositor")
+}
+
 // Layout of the ALVR installation. All paths are absolute
 #[derive(Clone, Default, Debug)]
 pub struct Layout {

--- a/alvr/server_openvr/resources/input/legacy_bindings_pico_controller.json
+++ b/alvr/server_openvr/resources/input/legacy_bindings_pico_controller.json
@@ -1,0 +1,169 @@
+{
+    "bindings": {
+        "/actions/legacy": {
+            "haptics": [
+                {
+                    "output": "/actions/legacy/out/left_haptic",
+                    "path": "/user/hand/left/output/haptic"
+                },
+                {
+                    "output": "/actions/legacy/out/right_haptic",
+                    "path": "/user/hand/right/output/haptic"
+                }
+            ],
+            "poses": [
+                {
+                    "output": "/actions/legacy/in/Left_Pose",
+                    "path": "/user/hand/left/pose/raw"
+                },
+                {
+                    "output": "/actions/legacy/in/Right_Pose",
+                    "path": "/user/hand/right/pose/raw"
+                }
+            ],
+            "sources": [
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/left_system_press"
+                        }
+                    },
+                    "mode": "button",
+                    "path": "/user/hand/left/input/system"
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/left_axis1_press"
+                        },
+                        "pull": {
+                            "output": "/actions/legacy/in/left_axis1_value"
+                        },
+                        "touch": {
+                            "output": "/actions/legacy/in/left_axis1_touch"
+                        }
+                    },
+                    "parameters": {
+                        "haptic_amplitude": "0"
+                    },
+                    "mode": "trigger",
+                    "path": "/user/hand/left/input/trigger"
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/right_system_press"
+                        }
+                    },
+                    "mode": "button",
+                    "path": "/user/hand/right/input/system"
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/right_grip_press"
+                        }
+                    },
+                    "mode": "button",
+                    "path": "/user/hand/right/input/grip"
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/left_grip_press"
+                        }
+                    },
+                    "mode": "button",
+                    "path": "/user/hand/left/input/grip"
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/left_applicationmenu_press"
+                        }
+                    },
+                    "mode": "button",
+                    "path": "/user/hand/left/input/application_menu"
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/right_applicationmenu_press"
+                        }
+                    },
+                    "mode": "button",
+                    "path": "/user/hand/right/input/application_menu"
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/left_axis0_press"
+                        },
+                        "position": {
+                            "output": "/actions/legacy/in/left_axis0_value"
+                        },
+                        "touch": {
+                            "output": "/actions/legacy/in/left_axis0_touch"
+                        }
+                    },
+                    "mode": "trackpad",
+                    "path": "/user/hand/left/input/trackpad"
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/right_axis0_press"
+                        },
+                        "position": {
+                            "output": "/actions/legacy/in/right_axis0_value"
+                        },
+                        "touch": {
+                            "output": "/actions/legacy/in/right_axis0_touch"
+                        }
+                    },
+                    "mode": "trackpad",
+                    "path": "/user/hand/right/input/trackpad"
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/legacy/in/right_axis1_press"
+                        },
+                        "pull": {
+                            "output": "/actions/legacy/in/right_axis1_value"
+                        },
+                        "touch": {
+                            "output": "/actions/legacy/in/right_axis1_touch"
+                        }
+                    },
+                    "parameters": {
+                        "haptic_amplitude": "0"
+                    },
+                    "mode": "trigger",
+                    "path": "/user/hand/right/input/trigger"
+                },
+                {
+                    "inputs": {
+                        "position": {
+                            "output": "/actions/legacy/in/left_axis2_value2"
+                        }
+                    },
+                    "mode": "joystick",
+                    "path": "/user/hand/left/input/joystick"
+                },
+                {
+                    "inputs": {
+                        "position": {
+                            "output": "/actions/legacy/in/right_axis2_value2"
+                        }
+                    },
+                    "mode": "joystick",
+                    "path": "/user/hand/right/input/joystick"
+                }
+            ]
+        }
+    },
+    "controller_type": "pico_controller",
+    "description": "",
+    "name": "Pico Controller Legacy Bindings"
+}

--- a/alvr/server_openvr/resources/input/vrcompositor_bindings_pico_controller.json
+++ b/alvr/server_openvr/resources/input/vrcompositor_bindings_pico_controller.json
@@ -1,0 +1,261 @@
+{
+    "controller_type": "pico_controller",
+    "bindings": {
+        "/actions/lasermouse": {
+            "sources": [
+                {
+                    "path": "/user/hand/right/input/trigger",
+                    "mode": "button",
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse/in/LeftClick"
+                        }
+                    }
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse/in/LockMousePosition"
+                        }
+                    },
+                    "mode": "button",
+                    "parameters": {
+                        "click_activate_threshold": "0.1",
+                        "click_deactivate_threshold": "0.05",
+                        "haptic_amplitude": "0"
+                    },
+                    "path": "/user/hand/right/input/trigger"
+                },
+                {
+                    "path": "/user/hand/right/input/grip",
+                    "mode": "button",
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse/in/Back"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/right/input/application_menu",
+                    "mode": "button",
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse/in/Home"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/right/input/trackpad",
+                    "mode": "trackpad",
+                    "inputs": {
+                        "touch": {
+                            "output": "/actions/lasermouse/in/TrackpadTouch"
+                        },
+                        "position": {
+                            "output": "/actions/lasermouse/in/TrackpadValue"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/right/input/trackpad",
+                    "mode": "trackpad_scroll",
+                    "inputs": {
+                        "scroll": {
+                            "output": "/actions/lasermouse/in/TrackpadScroll"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/right/input/trackpad",
+                    "mode": "dpad_click",
+                    "inputs": {
+                        "east": {
+                            "output": "/actions/lasermouse/in/RightClick"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/left/input/trigger",
+                    "mode": "button",
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse/in/LeftClick"
+                        }
+                    }
+                },
+                {
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse/in/LockMousePosition"
+                        }
+                    },
+                    "mode": "button",
+                    "parameters": {
+                        "click_activate_threshold": "0.1",
+                        "click_deactivate_threshold": "0.05",
+                        "haptic_amplitude": "0"
+                    },
+                    "path": "/user/hand/left/input/trigger"
+                },
+                {
+                    "path": "/user/hand/left/input/grip",
+                    "mode": "button",
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse/in/Back"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/left/input/application_menu",
+                    "mode": "button",
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse/in/Home"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/left/input/trackpad",
+                    "mode": "trackpad",
+                    "inputs": {
+                        "touch": {
+                            "output": "/actions/lasermouse/in/TrackpadTouch"
+                        },
+                        "position": {
+                            "output": "/actions/lasermouse/in/TrackpadValue"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/left/input/trackpad",
+                    "mode": "trackpad_scroll",
+                    "inputs": {
+                        "scroll": {
+                            "output": "/actions/lasermouse/in/TrackpadScroll"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/left/input/trackpad",
+                    "mode": "dpad_click",
+                    "inputs": {
+                        "east": {
+                            "output": "/actions/lasermouse/in/RightClick"
+                        }
+                    }
+                }
+            ],
+            "poses": [
+                {
+                    "output": "/actions/lasermouse/in/Pointer",
+                    "path": "/user/hand/left/pose/tip"
+                },
+                {
+                    "output": "/actions/lasermouse/in/Pointer",
+                    "path": "/user/hand/right/pose/tip"
+                }
+            ]
+        },
+        "/actions/lasermouse_secondary": {
+            "sources": [
+                {
+                    "path": "/user/hand/left/input/trigger",
+                    "mode": "button",
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse_secondary/in/SwitchLaserHand"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/right/input/trigger",
+                    "mode": "button",
+                    "inputs": {
+                        "click": {
+                            "output": "/actions/lasermouse_secondary/in/SwitchLaserHand"
+                        }
+                    }
+                }
+            ],
+            "poses": []
+        },
+        "/actions/system": {
+            "chords": [
+                {
+                    "output": "/actions/system/in/TakeScreenshot",
+                    "inputs": [
+                        [
+                            "/user/hand/left/input/system",
+                            "held"
+                        ],
+                        [
+                            "/user/hand/left/input/trigger",
+                            "click"
+                        ]
+                    ]
+                },
+                {
+                    "output": "/actions/system/in/TakeScreenshot",
+                    "inputs": [
+                        [
+                            "/user/hand/right/input/system",
+                            "held"
+                        ],
+                        [
+                            "/user/hand/right/input/trigger",
+                            "click"
+                        ]
+                    ]
+                }
+            ],
+            "sources": [
+                {
+                    "path": "/user/hand/left/input/trigger",
+                    "parameters": {
+                        "haptic_amplitude": "0"
+                    },
+                    "mode": "button"
+                },
+                {
+                    "path": "/user/hand/right/input/trigger",
+                    "parameters": {
+                        "haptic_amplitude": "0"
+                    },
+                    "mode": "button"
+                },
+                {
+                    "path": "/user/hand/left/input/system",
+                    "mode": "button",
+                    "inputs": {
+                        "held": {
+                            "output": "/actions/system/in/SystemButtonChord"
+                        },
+                        "click": {
+                            "output": "/actions/system/in/ToggleDashboard"
+                        },
+                        "double": {
+                            "output": "/actions/system/in/ToggleRoomView"
+                        }
+                    }
+                },
+                {
+                    "path": "/user/hand/right/input/system",
+                    "mode": "button",
+                    "inputs": {
+                        "held": {
+                            "output": "/actions/system/in/SystemButtonChord"
+                        },
+                        "click": {
+                            "output": "/actions/system/in/ToggleDashboard"
+                        },
+                        "double": {
+                            "output": "/actions/system/in/ToggleRoomView"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "name": "Default VR Dashboard bindings for Pico Controller"
+}

--- a/alvr/vrcompositor_wrapper/src/main.rs
+++ b/alvr/vrcompositor_wrapper/src/main.rs
@@ -41,7 +41,12 @@ fn main() {
         }
     }
 
-    let err = exec::execvp(argv0 + ".real", std::env::args());
+    // argv0 is the symlink in SteamVR's bin dir, not the wrapper's own
+    // location, so its parent is where the real compositor sits
+    let steamvr_bin_dir = std::path::Path::new(&argv0).parent().unwrap();
+    let compositor_path = alvr_filesystem::original_vrcompositor_path(steamvr_bin_dir);
+
+    let err = exec::execvp(compositor_path, std::env::args());
     println!("Failed to run vrcompositor {err}");
 }
 

--- a/alvr/xtask/src/build.rs
+++ b/alvr/xtask/src/build.rs
@@ -268,6 +268,22 @@ pub fn build_streamer(
             build_layout.openvr_driver_manifest(),
         )
         .unwrap();
+
+        // copy pico_controller binding files
+        let input_resources_dir = build_layout.resources_dir().join("input");
+        sh.create_dir(&input_resources_dir).unwrap();
+        for fname in [
+            "legacy_bindings_pico_controller.json",
+            "vrcompositor_bindings_pico_controller.json",
+        ] {
+            sh.copy_file(
+                afs::crate_dir("server_openvr")
+                    .join("resources/input")
+                    .join(fname),
+                input_resources_dir.join(fname),
+            )
+            .unwrap();
+        }
     }
 }
 


### PR DESCRIPTION
# Fix error 303 on SteamVR v2.16+ and add pico_controller binding files

## Problem

Two issues on SteamVR v2.16+ (beta branch):

### 1. Error 303 (VRInitError_IPC_CompositorInitFailed)

SteamVR v2.16+ checks the compositor process name == `vrcompositor`. Linux caps `/proc/pid/comm` at 15 chars (`TASK_COMM_LEN=16`), so `vrcompositor.real` becomes `vrcompositor.re` → name check fails → error 303.

### 2. Dashboard button not working for pico_controller

SteamVR v2.16+ no longer falls back to generic bindings when controller-type-specific binding files are missing. The vrlink driver ships `pico_controller_profile.json` but not `legacy_bindings_pico_controller.json` or `vrcompositor_bindings_pico_controller.json`. Without these, the system button has no `ToggleDashboard` mapping → dashboard won't open.

## Fix

### Error 303

Move the original binary to `bin/linux64/alvr/vrcompositor` instead of renaming to `vrcompositor.real`. The wrapper symlink preserves the correct process name (`vrcompositor`, 13 chars). Includes migration from old installs that have `vrcompositor.real`.

Files changed:
- `alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs` — migration + new path
- `alvr/filesystem/src/lib.rs` — `original_vrcompositor_path()` / `original_vrcompositor_dir()` helpers
- `alvr/vrcompositor_wrapper/src/main.rs` — exec new path instead of `argv0 + ".real"`

### Binding files

Added two binding files copied from SteamVR's generic bindings with `controller_type` changed to `pico_controller`:
- `legacy_bindings_pico_controller.json` — legacy input mappings (joystick, trigger, grip, system, ABXY)
- `vrcompositor_bindings_pico_controller.json` — system button → `ToggleDashboard`, `double` → `ToggleRoomView`

Build system (`xtask/build.rs`) copies them to the driver resources dir. Dashboard (`linux_steamvr.rs`) copies them to the vrlink driver's `resources/input/` on launch if they don't already exist.

Files added:
- `alvr/server_openvr/resources/input/legacy_bindings_pico_controller.json`
- `alvr/server_openvr/resources/input/vrcompositor_bindings_pico_controller.json`

Files changed:
- `alvr/xtask/src/build.rs` — copy step for binding files

## Overlap with other PRs

**PR #3348**: The vrcompositor rename fix is identical to PR #3348 by @besauce. If #3348 merges first, this PR should be rebased to keep only the binding file changes.

## Testing

Tested on SteamVR v2.17.6 beta (v1784611593) with Pico 4 (A81X0, OS 5.4.0):
- Error 303 resolved — vrcompositor starts with correct process name
- Controllers visible and tracking (both left and right)
- Dashboard button (system button) opens SteamVR dashboard
- Streaming stable at 90fps, 27-33ms MTP
- No spurious dashboard opens
