### PR TITLE
Fix stutter: blind stack scan + present-time fallback for pose matching

### DIFF
--- a/alvr/server_openvr/cpp/alvr_server/PoseHistory.cpp
+++ b/alvr/server_openvr/cpp/alvr_server/PoseHistory.cpp
@@ -10,6 +10,9 @@ void PoseHistory::OnPoseUpdated(uint64_t targetTimestampNs, FfiDeviceMotion moti
     TrackingHistoryFrame history;
     history.targetTimestampNs = targetTimestampNs;
     history.motion = motion;
+    history.serverReceiveTimeNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()
+    ).count();
 
     HmdMatrix_QuatToMat(
         motion.pose.orientation.w,
@@ -68,6 +71,14 @@ PoseHistory::GetBestPoseMatch(const vr::HmdMatrix34_t& pose) const {
     return {};
 }
 
+std::optional<PoseHistory::TrackingHistoryFrame> PoseHistory::GetLatestPose() const {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    if (m_poseBuffer.empty()) {
+        return {};
+    }
+    return m_poseBuffer.back();
+}
+
 std::optional<PoseHistory::TrackingHistoryFrame> PoseHistory::GetPoseAt(uint64_t timestampNs
 ) const {
     std::unique_lock<std::mutex> lock(m_mutex);
@@ -77,6 +88,20 @@ std::optional<PoseHistory::TrackingHistoryFrame> PoseHistory::GetPoseAt(uint64_t
     }
 
     Debug("PoseHistory::GetPoseAt: No pose matched.");
+    return {};
+}
+
+std::optional<PoseHistory::TrackingHistoryFrame>
+PoseHistory::GetPoseByPresentTime(uint64_t presentTimeNs) const {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    if (m_poseBuffer.empty()) {
+        return {};
+    }
+    for (auto it = m_poseBuffer.rbegin(); it != m_poseBuffer.rend(); ++it) {
+        if (it->serverReceiveTimeNs <= presentTimeNs) {
+            return *it;
+        }
+    }
     return {};
 }
 

--- a/alvr/server_openvr/cpp/alvr_server/PoseHistory.h
+++ b/alvr/server_openvr/cpp/alvr_server/PoseHistory.h
@@ -3,6 +3,7 @@
 #include "ALVR-common/packet_types.h"
 #include "openvr_driver_wrap.h"
 
+#include <chrono>
 #include <list>
 #include <mutex>
 #include <optional>
@@ -13,13 +14,15 @@ public:
         uint64_t targetTimestampNs;
         FfiDeviceMotion motion;
         vr::HmdMatrix34_t rotationMatrix;
+        uint64_t serverReceiveTimeNs;
     };
 
     void OnPoseUpdated(uint64_t targetTimestampNs, FfiDeviceMotion motion);
 
     std::optional<TrackingHistoryFrame> GetBestPoseMatch(const vr::HmdMatrix34_t& pose) const;
-    // Return the most recent pose known at the given timestamp
+    std::optional<TrackingHistoryFrame> GetLatestPose() const;
     std::optional<TrackingHistoryFrame> GetPoseAt(uint64_t timestampNs) const;
+    std::optional<TrackingHistoryFrame> GetPoseByPresentTime(uint64_t presentTimeNs) const;
 
     void SetTransform(const vr::HmdMatrix34_t& transform);
 

--- a/alvr/server_openvr/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/CEncoder.cpp
@@ -228,7 +228,26 @@ void CEncoder::Run() {
 
             encode_pipeline->SetParams(GetDynamicEncoderParams());
 
-            auto pose = m_poseHistory->GetBestPoseMatch((const vr::HmdMatrix34_t&)frame_info.pose);
+            const vr::HmdMatrix34_t& frame_pose = (const vr::HmdMatrix34_t&)frame_info.pose;
+            bool pose_is_zero = true;
+            for (int i = 0; i < 3 && pose_is_zero; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    if (frame_pose.m[i][j] != 0.0f) {
+                        pose_is_zero = false;
+                        break;
+                    }
+                }
+            }
+            std::optional<PoseHistory::TrackingHistoryFrame> pose;
+            if (!pose_is_zero) {
+                pose = m_poseHistory->GetBestPoseMatch(frame_pose);
+            }
+            if (!pose && frame_info.present_time_ns != 0) {
+                pose = m_poseHistory->GetPoseByPresentTime(frame_info.present_time_ns);
+            }
+            if (!pose) {
+                pose = m_poseHistory->GetLatestPose();
+            }
             if (!pose) {
                 continue;
             }

--- a/alvr/server_openvr/cpp/platform/linux/protocol.h
+++ b/alvr/server_openvr/cpp/platform/linux/protocol.h
@@ -13,6 +13,7 @@ struct present_packet {
     uint32_t frame;
     uint64_t semaphore_value;
     float pose[3][4];
+    uint64_t present_time_ns;
 };
 
 struct init_packet {

--- a/alvr/vulkan_layer/util/pose.cpp
+++ b/alvr/vulkan_layer/util/pose.cpp
@@ -72,10 +72,21 @@ const TrackedDevicePose_t & find_pose_in_call_stack()
   if (res != nullptr)
     return *res;
   static TrackedDevicePose_t notfound;
+  constexpr unsigned failure_threshold = 300;
+  constexpr unsigned retry_interval = 1000;
+  static unsigned failures;
+  if (failures >= failure_threshold && failures % retry_interval != 0)
+  {
+    ++failures;
+    return notfound;
+  }
   unw_context_t ctx;
   unw_getcontext(&ctx);
   unw_cursor_t cursor;
   unw_init_local(&cursor, &ctx);
+
+  // Phase 1: Try to find CRenderThread::UpdateAsync by symbol name.
+  // This works on non-stripped binaries (SteamVR < 2.16).
   while (unw_step(&cursor) > 0)
   {
     char name[1024];
@@ -99,5 +110,44 @@ const TrackedDevicePose_t & find_pose_in_call_stack()
       return notfound;
     }
   }
+
+  // Phase 2: Blind stack scan (SteamVR 2.16+ stripped binary).
+  // Walk frames without symbol name lookup and scan each frame's
+  // local variable region for a valid TrackedDevicePose_t.
+  // The result is cached in res, so this scan runs at most once.
+  unw_getcontext(&ctx);
+  unw_init_local(&cursor, &ctx);
+  unsigned frame_count = 0;
+  constexpr unsigned max_frames = 20;
+  while (unw_step(&cursor) > 0 && frame_count < max_frames)
+  {
+    ++frame_count;
+    unw_word_t sp, sp_end;
+    unw_get_reg(&cursor, UNW_REG_SP, &sp);
+    unw_cursor_t next_cursor = cursor;
+    if (unw_step(&next_cursor) > 0)
+    {
+      unw_get_reg(&next_cursor, UNW_REG_SP, &sp_end);
+    }
+    else
+    {
+      sp_end = sp + 4096;
+    }
+
+    if (sp_end <= sp)
+      continue;
+
+    for (uintptr_t addr = sp; addr + sizeof(TrackedDevicePose_t) <= sp_end; addr += 8)
+    {
+      TrackedDevicePose_t * p = (TrackedDevicePose_t *) addr;
+      if (check_pose(*p))
+      {
+        res = p;
+        return *p;
+      }
+    }
+  }
+
+  ++failures;
   return notfound;
 }

--- a/alvr/vulkan_layer/wsi/headless/swapchain.cpp
+++ b/alvr/vulkan_layer/wsi/headless/swapchain.cpp
@@ -311,6 +311,7 @@ void swapchain::submit_image(uint32_t pending_index) {
         packet.frame = m_display.m_vsync_count;
         packet.semaphore_value = m_swapchain_images[pending_index].semaphore_value;
         memcpy(&packet.pose, pose, sizeof(packet.pose));
+        packet.present_time_ns = m_swapchain_images[pending_index].present_time_ns;
         ret = write(m_socket, &packet, sizeof(packet));
         if (ret == -1) {
             //FIXME: try to reconnect?

--- a/alvr/vulkan_layer/wsi/swapchain_base.cpp
+++ b/alvr/vulkan_layer/wsi/swapchain_base.cpp
@@ -36,6 +36,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
+#include <chrono>
 
 #include <unistd.h>
 #include <vulkan/vulkan.h>
@@ -350,6 +351,9 @@ VkResult swapchain_base::acquire_next_image(uint64_t timeout, VkSemaphore semaph
             m_swapchain_images[i].status = swapchain_image::ACQUIRED;
             *image_index = i;
             m_last_acquired_image = i;
+            m_swapchain_images[i].acquire_time_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::steady_clock::now().time_since_epoch()
+            ).count();
             break;
         }
     }
@@ -416,6 +420,11 @@ VkResult swapchain_base::queue_present(VkQueue queue, const VkPresentInfoKHR *pr
 
     const auto & pose = find_pose_in_call_stack();
 
+    // Use the acquire timestamp as the present_time_ns — it's closer to when
+    // the compositor queried the pose (before rendering). The present timestamp
+    // would be ~5-11ms later (after rendering completes).
+    auto present_time_ns = m_swapchain_images[image_index].acquire_time_ns;
+
     if (m_descendant != VK_NULL_HANDLE) {
         auto *desc = reinterpret_cast<swapchain_base *>(m_descendant);
         for (auto &img : desc->m_swapchain_images) {
@@ -479,6 +488,7 @@ VkResult swapchain_base::queue_present(VkQueue queue, const VkPresentInfoKHR *pr
 
     m_swapchain_images[image_index].status = swapchain_image::PENDING;
     m_swapchain_images[image_index].pose = pose;
+    m_swapchain_images[image_index].present_time_ns = present_time_ns;
 
     m_pending_buffer_pool.ring[m_pending_buffer_pool.tail] = image_index;
     m_pending_buffer_pool.tail = (m_pending_buffer_pool.tail + 1) % m_pending_buffer_pool.size;

--- a/alvr/vulkan_layer/wsi/swapchain_base.hpp
+++ b/alvr/vulkan_layer/wsi/swapchain_base.hpp
@@ -61,6 +61,8 @@ struct swapchain_image {
     uint64_t semaphore_value = 0;
 
     TrackedDevicePose_t pose;
+    uint64_t present_time_ns = 0;
+    uint64_t acquire_time_ns = 0;
 };
 
 /**


### PR DESCRIPTION
# Fix stutter: blind stack scan + present-time fallback for pose matching

## Problem

SteamVR v2.16+ strips the `vrcompositor` binary, removing the symbol names that `find_pose_in_call_stack()` needs to locate `CRenderThread::UpdateAsync`. Without the symbol, `unw_get_proc_name` fails 100% of the time → the pose is always zero → `GetLatestPose()` fallback → wrong timestamp sent as PTS → stutter on head rotation.

On SteamVR < v2.16, the stack walk succeeds because the binary has enough symbol information. The pose is read directly from the compositor's stack frame — the exact pose used for rendering. This is perfectly accurate.

## Root cause

`find_pose_in_call_stack()` in `alvr/vulkan_layer/util/pose.cpp` uses `unw_get_proc_name` to find `_ZN13CRenderThread11UpdateAsyncEv` by name, then scans that function's stack frame for a `TrackedDevicePose_t`. On stripped binaries, the name lookup fails and no pose is ever found.

## Fix

Three-layer pose recovery:

### 1. Blind stack scan (primary fix)

When `unw_get_proc_name` fails to find the target function (stripped binary), fall back to scanning all stack frames' local variable regions for `TrackedDevicePose_t` candidates — **without needing symbol names**.

The existing `check_pose()` function validates candidates:
- `bPoseIsValid == 1`
- `bDeviceIsConnected == 1`
- `eTrackingResult == 200` (VR::TrackingResult_Running_OK)
- Rotation matrix `A * A^T ≈ I` (identity, within 0.1 tolerance)

This is very restrictive — random stack data is extremely unlikely to pass all checks (especially the rotation matrix validation). The result is cached (same as the current code), so the scan runs at most once, then the pointer is reused every frame.

### 2. Present-time timestamp matching (fallback)

If the blind stack scan also fails, `GetPoseByPresentTime()` finds the pose available at the frame's acquire time. `steady_clock` (`CLOCK_MONOTONIC`) is system-wide on Linux, so timestamps from vrcompositor and vrserver are directly comparable.

A new `serverReceiveTimeNs` field is set in `OnPoseUpdated()` to `steady_clock::now()`. The vulkan layer captures `acquire_time_ns` at `vkAcquireNextImageKHR` time. `GetPoseByPresentTime()` searches the pose buffer (newest→oldest) for the first pose with `serverReceiveTimeNs <= presentTimeNs`.

### 3. GetLatestPose (last resort)

No matching — just returns the newest pose in the buffer. Same as PR #3342's fallback.

### CEncoder priority

```cpp
if (!pose_is_zero) {
    // Stack scan found a pose — exact matrix matching (same as pre-v2.16)
    pose = GetBestPoseMatch(frame_pose);
}
if (!pose && present_time_ns != 0) {
    // Stack scan failed — timestamp matching
    pose = GetPoseByPresentTime(present_time_ns);
}
if (!pose) {
    // Last resort
    pose = GetLatestPose();
}
```

When the blind scan succeeds (which it does on v2.17.6), `GetBestPoseMatch` is used — **identical to pre-v2.16 behavior**. The timestamp matching is only a safety net.

## Alternatives tried and rejected

### Timestamp at present time (`vkQueuePresentKHR`)
Captured `steady_clock::now()` at `queue_present` instead of `acquire_next_image`. The gap between pose query and present is the render time (~5-11ms). This caused a consistent ~5-11ms pose error. Result: reduced stutter but not perfect

### Timestamp at acquire time (`vkAcquireNextImageKHR`)
Captured the timestamp earlier in the pipeline, closer to when the pose is queried. Better on average, but `acquire_next_image` can be called **before** the pose is queried (compositor acquires image, then queries pose, then renders). When this happens, `acquire_time_ns` is earlier than the pose update, and `GetPoseByPresentTime` finds the **previous** pose — wrong by a full frame. Result: Usually better but when it stutters it feels worse than above.

### Why the blind stack scan is better
The blind scan recovers the **exact pose** the compositor used for rendering — same as the original symbol-name approach, just without needing symbols. This enables `GetBestPoseMatch` (exact matrix matching), which is perfectly accurate. The timestamp approaches can only approximate.

## Overlap with PR #3342

The backoff logic in `pose.cpp` and the `GetLatestPose()` fallback in `CEncoder.cpp` are identical to PR #3342 by @besauce. If #3342 merges first, this PR should be rebased to keep only:
- Blind stack scan (Phase 2 in `pose.cpp`)
- `present_time_ns` in `protocol.h` / `swapchain_base` / `headless/swapchain.cpp`
- `GetPoseByPresentTime()` in `PoseHistory.cpp/h`
- `serverReceiveTimeNs` field in `PoseHistory`
- Updated CEncoder fallback chain (priority: `GetBestPoseMatch` → `GetPoseByPresentTime` → `GetLatestPose`)

## Files changed

- `alvr/vulkan_layer/util/pose.cpp` — blind stack scan (Phase 2) + backoff
- `alvr/vulkan_layer/wsi/swapchain_base.cpp` — capture `steady_clock` at acquire time
- `alvr/vulkan_layer/wsi/swapchain_base.hpp` — `acquire_time_ns` + `present_time_ns` fields
- `alvr/vulkan_layer/wsi/headless/swapchain.cpp` — send `present_time_ns` in packet
- `alvr/server_openvr/cpp/platform/linux/protocol.h` — add `present_time_ns` to `present_packet`
- `alvr/server_openvr/cpp/platform/linux/CEncoder.cpp` — 3-layer fallback + `pose_is_zero` detection
- `alvr/server_openvr/cpp/alvr_server/PoseHistory.cpp` — `GetPoseByPresentTime()` + `serverReceiveTimeNs`
- `alvr/server_openvr/cpp/alvr_server/PoseHistory.h` — new field + method declarations

## Testing

Tested on SteamVR v2.17.6 beta (v1784611593) with Pico 4 (A81X0, OS 5.4.0)
