### PR TITLE
Add try/catch to drm-lease-shim session config parsing

### DIFF
--- a/alvr/vrcompositor_wrapper/drm-lease-shim.cpp
+++ b/alvr/vrcompositor_wrapper/drm-lease-shim.cpp
@@ -211,16 +211,20 @@ extern "C" drmModeConnectorPtr drmModeGetConnector(int fd, uint32_t connectorId)
 
     auto con = real_drmModeGetConnector(fd, connectorId);
     if (con) {
-        auto sessionFile = std::ifstream(getenv("ALVR_SESSION_JSON"));
-        auto json = std::string(std::istreambuf_iterator<char>(sessionFile), std::istreambuf_iterator<char>());
-        picojson::value v;
-        picojson::parse(v, json);
-        auto config = v.get("steamvr_hmd_init_config");
+        try {
+            auto sessionFile = std::ifstream(getenv("ALVR_SESSION_JSON"));
+            auto json = std::string(std::istreambuf_iterator<char>(sessionFile), std::istreambuf_iterator<char>());
+            picojson::value v;
+            picojson::parse(v, json);
+            auto config = v.get("steamvr_hmd_init_config");
 
-        con->count_modes = 1;
-        con->modes = (drmModeModeInfo*)calloc(1, sizeof(drmModeModeInfo));
-        con->modes->hdisplay = config.get("eye_resolution_width").get<int64_t>() * 2;
-        con->modes->vdisplay = config.get("eye_resolution_height").get<int64_t>();
+            con->count_modes = 1;
+            con->modes = (drmModeModeInfo*)calloc(1, sizeof(drmModeModeInfo));
+            con->modes->hdisplay = config.get("eye_resolution_width").get<int64_t>() * 2;
+            con->modes->vdisplay = config.get("eye_resolution_height").get<int64_t>();
+        } catch (std::exception &e) {
+            ERR("ALVR: failed to parse session config: %s", e.what());
+        }
     }
     return con;
 }


### PR DESCRIPTION
# Add try/catch to drm-lease-shim session config parsing

## Problem

The `drmModeGetConnector` shim in `alvr/vrcompositor_wrapper/drm-lease-shim.cpp` reads `ALVR_SESSION_JSON` and parses it with picojson to extract `eye_resolution_width` and `eye_resolution_height` for the DRM mode. If the file is missing, empty, or has an unexpected JSON structure, picojson throws an uncaught exception → vrcompositor crashes.

This can happen when:
- `ALVR_SESSION_JSON` environment variable points to a non-existent file
- The session JSON is being written (race condition — partial read)
- The JSON structure changes between ALVR versions (e.g., `steamvr_hmd_init_config` key renamed)

## Fix

Wrap the parsing logic in a `try/catch` block. On failure, log an error and return the connector without modified modes — SteamVR falls back to default mode resolution.

## Files changed

- `alvr/vrcompositor_wrapper/drm-lease-shim.cpp` — wrap picojson parsing in try/catch

## Testing

Tested on SteamVR v2.17.6 beta with Pico 4. No regression — normal operation (valid session JSON) works identically. Error path tested by temporarily pointing `ALVR_SESSION_JSON` to a non-existent file — vrcompositor no longer crashes, logs error, continues with default modes.
