### PR TITLE
Fix needless references in build.rs format args

### DIFF
--- a/alvr/session/build.rs
+++ b/alvr/session/build.rs
@@ -43,7 +43,7 @@ pub enum OpenvrPropKey {",
             mappings_fn_string,
             r"
     {} = {},",
-            &info.name, &info.code
+            info.name, info.code
         )
         .unwrap();
     }
@@ -62,7 +62,7 @@ pub fn openvr_prop_key_to_type(key: OpenvrPropKey) -> OpenvrPropType {
             mappings_fn_string,
             r"
         OpenvrPropKey::{} => OpenvrPropType::{},",
-            &info.name, info.ty
+            info.name, info.ty
         )
         .unwrap();
     }


### PR DESCRIPTION
## Summary
- Remove unnecessary `&` references passed to `write!` format args in `alvr/session/build.rs`

## Test plan
- N/A (trivial clippy-style cleanup, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)