### PR TITLE
linux direct: nvidia encoder path

### DIFF
--- a/alvr/server_openvr/cpp/platform/linux/EncodePipeline.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/EncodePipeline.cpp
@@ -34,9 +34,11 @@ std::unique_ptr<alvr::EncodePipeline> alvr::EncodePipeline::Create(
         alvr::HWContext hwCtx(vk_ctx);
         if (vk_ctx.meta.vendor == Vendor::Nvidia) {
             try {
-                // auto nvenc = std::make_unique<alvr::EncodePipelineNvEnc>(render, vk_ctx,
-                // input_frame, vk_frame_ctx, width, height); Info("Using NvEnc encoder"); return
-                // nvenc;
+                auto nvenc = std::make_unique<alvr::EncodePipelineNvEnc>(
+                    hwCtx, vk_ctx, input_frame, width, height
+                );
+                Info("Using NvEnc encoder");
+                return nvenc;
             } catch (std::exception& e) {
                 Error(
                     "Failed to create NvEnc encoder: %s\nPlease make sure you have installed CUDA "

--- a/alvr/server_openvr/cpp/platform/linux/EncodePipelineNvEnc.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/EncodePipelineNvEnc.cpp
@@ -25,7 +25,29 @@ const char* encoder(ALVR_CODEC codec) {
     throw std::runtime_error("invalid codec " + std::to_string(codec));
 }
 
-void set_hwframe_ctx(AVCodecContext* ctx, AVBufferRef* hw_device_ctx) {
+// NvEnc takes an opaque-alpha format, so drop the alpha channel while keeping
+// the channel order of the source. Picking the wrong one here is silent: the
+// encode succeeds and ships swapped red and blue.
+AVPixelFormat nvenc_surface_format(AVPixelFormat inputFormat) {
+    switch (inputFormat) {
+    case AV_PIX_FMT_BGRA:
+        return AV_PIX_FMT_BGR0;
+    case AV_PIX_FMT_RGBA:
+        return AV_PIX_FMT_RGB0;
+    case AV_PIX_FMT_BGR0:
+    case AV_PIX_FMT_RGB0:
+        return inputFormat;
+    default:
+        throw std::runtime_error(
+            std::string("no NvEnc surface format for input pixel format ")
+            + std::to_string((int)inputFormat)
+        );
+    }
+}
+
+void set_hwframe_ctx(
+    AVCodecContext* ctx, AVBufferRef* hw_device_ctx, AVPixelFormat surfaceFormat
+) {
     AVBufferRef* hw_frames_ref;
     AVHWFramesContext* frames_ctx = NULL;
     int err = 0;
@@ -35,17 +57,7 @@ void set_hwframe_ctx(AVCodecContext* ctx, AVBufferRef* hw_device_ctx) {
     }
     frames_ctx = (AVHWFramesContext*)(hw_frames_ref->data);
     frames_ctx->format = AV_PIX_FMT_CUDA;
-    /**
-     * We will recieve a frame from HW as AV_PIX_FMT_VULKAN which will converted to AV_PIX_FMT_BGRA
-     * as SW format when we get it from HW.
-     * But NVEnc support only BGR0 format and we easy can just to force it
-     * Because:
-     * AV_PIX_FMT_BGRA - 28  ///< packed BGRA 8:8:8:8, 32bpp, BGRABGRA...
-     * AV_PIX_FMT_BGR0 - 123 ///< packed BGR 8:8:8,    32bpp, BGRXBGRX...   X=unused/undefined
-     *
-     * We just to ignore the alpha channel and it's done
-     */
-    frames_ctx->sw_format = AV_PIX_FMT_BGR0;
+    frames_ctx->sw_format = surfaceFormat;
     frames_ctx->width = ctx->width;
     frames_ctx->height = ctx->height;
     if ((err = av_hwframe_ctx_init(hw_frames_ref)) < 0) {
@@ -59,22 +71,22 @@ void set_hwframe_ctx(AVCodecContext* ctx, AVBufferRef* hw_device_ctx) {
     av_buffer_unref(&hw_frames_ref);
 }
 
+// Last target the bitrate manager delivered; see initEncoding.
+int64_t last_known_bitrate_bps = 0;
+
 } // namespace
 alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(
-    Renderer* render,
-    HWContext& vk_ctx,
-    VkContext& v_ctx,
-    VkFrame& input_frame,
-    VkFrameCtx& vk_frame_ctx,
-    uint32_t width,
-    uint32_t height
+    HWContext& vk_ctx, VkContext& v_ctx, VkFrame& input_frame, uint32_t width, uint32_t height
 )
-    : v_ctx(v_ctx) {
-    auto input_frame_ctx = (AVHWFramesContext*)vk_frame_ctx.ctx->data;
-    assert(input_frame_ctx->sw_format == AV_PIX_FMT_BGRA);
+    : v_ctx(v_ctx)
+    , frame_ctx(vk_ctx.avCtx, input_frame.imageInfo()) {
+    // The surface format has to follow the output image's channel order. A
+    // mismatch still encodes successfully, with red and blue swapped.
+    auto input_frame_ctx = (AVHWFramesContext*)frame_ctx.ctx->data;
+    auto surface_format = nvenc_surface_format(input_frame_ctx->sw_format);
 
     int err;
-    vk_frame = input_frame.make_av_frame(vk_frame_ctx);
+    vk_frame = input_frame.make_av_frame(frame_ctx);
 
     err = av_hwdevice_ctx_create_derived(&hw_ctx, AV_HWDEVICE_TYPE_CUDA, vk_ctx.avCtx, 0);
     if (err < 0) {
@@ -168,13 +180,18 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(
     encoder_ctx->max_b_frames = 0;
     encoder_ctx->gop_size = INT16_MAX;
     encoder_ctx->color_range = AVCOL_RANGE_JPEG;
-    auto params = FfiDynamicEncoderParams {};
+    // The manager reports a target only once per change, so a rebuild mid
+    // session has to reuse the last one.
+    auto params = GetDynamicEncoderParams();
+    if (!params.updated || params.bitrate_bps <= 0) {
+        params.bitrate_bps = last_known_bitrate_bps > 0 ? last_known_bitrate_bps : 30'000'000;
+    }
     params.updated = true;
-    params.bitrate_bps = 30'000'000;
-    params.framerate = 60.0;
+    params.framerate = settings->m_refreshRate;
+    Info("NvEnc init bitrate: %.1f Mbps\n", params.bitrate_bps / 1e6);
     SetParams(params);
 
-    set_hwframe_ctx(encoder_ctx, hw_ctx);
+    set_hwframe_ctx(encoder_ctx, hw_ctx, surface_format);
 
     err = avcodec_open2(encoder_ctx, codec, NULL);
     if (err < 0) {
@@ -187,6 +204,19 @@ alvr::EncodePipelineNvEnc::EncodePipelineNvEnc(
 alvr::EncodePipelineNvEnc::~EncodePipelineNvEnc() {
     av_buffer_unref(&hw_ctx);
     av_frame_free(&hw_frame);
+}
+
+void alvr::EncodePipelineNvEnc::SetParams(FfiDynamicEncoderParams params) {
+    if (!params.updated) {
+        return;
+    }
+    // Survives encoder rebuilds; see the note on the variable.
+    last_known_bitrate_bps = params.bitrate_bps;
+    encoder_ctx->bit_rate = params.bitrate_bps;
+    encoder_ctx->framerate = AVRational { int(params.framerate * 1000), 1000 };
+    encoder_ctx->rc_buffer_size = encoder_ctx->bit_rate / params.framerate;
+    encoder_ctx->rc_max_rate = encoder_ctx->bit_rate;
+    encoder_ctx->rc_initial_buffer_occupancy = encoder_ctx->rc_buffer_size;
 }
 
 void alvr::EncodePipelineNvEnc::PushFrame(uint64_t targetTimestampNs, bool idr) {

--- a/alvr/server_openvr/cpp/platform/linux/EncodePipelineNvEnc.h
+++ b/alvr/server_openvr/cpp/platform/linux/EncodePipelineNvEnc.h
@@ -10,27 +10,23 @@ extern "C" struct AVBufferRef;
 extern "C" struct AVCodecContext;
 extern "C" struct AVFrame;
 
-class Renderer;
-
 namespace alvr {
 
 class EncodePipelineNvEnc : public EncodePipeline {
 public:
     ~EncodePipelineNvEnc();
     EncodePipelineNvEnc(
-        Renderer* render,
-        HWContext& vk_ctx,
-        VkContext& v_ctx,
-        VkFrame& input_frame,
-        VkFrameCtx& vk_frame_ctx,
-        uint32_t width,
-        uint32_t height
+        HWContext& vk_ctx, VkContext& v_ctx, VkFrame& input_frame, uint32_t width, uint32_t height
     );
 
     void PushFrame(uint64_t targetTimestampNs, bool idr) override;
+    void SetParams(FfiDynamicEncoderParams params) override;
 
 private:
     VkContext& v_ctx;
+    // Declared before vk_frame: make_av_frame takes a reference to this, so
+    // it has to outlive the frame built from it.
+    VkFrameCtx frame_ctx;
     AVBufferRef* hw_ctx = nullptr;
     std::unique_ptr<AVFrame, std::function<void(AVFrame*)>> vk_frame;
     AVFrame* hw_frame = nullptr;

--- a/alvr/server_openvr/cpp/platform/linux/Renderer.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/Renderer.cpp
@@ -351,7 +351,9 @@ Output createOutputImage(
     };
     ctx.dev.bindImageMemory2(bindImgInfo);
 
-    if (haveDmaBuf) {
+    // Only the dma-buf export produces a DRM descriptor; the opaque-fd path
+    // leaves out.drm zeroed.
+    if (handleType == HandleType::DmaBuf) {
         vk::MemoryGetFdInfoKHR memFdInfo {
             .memory = img.memory,
             .handleType = vk::ExternalMemoryHandleTypeFlagBits::eDmaBufEXT,
@@ -465,8 +467,13 @@ Renderer::Renderer(
         img = createImage(vkCtx, stagingImgCI);
     }
 
+    // VAAPI imports through DRM-PRIME and wants a dma-buf; NvEnc imports
+    // through CUDA interop and wants an opaque fd.
     output = createOutputImage(
-        vkCtx, createInfo.outputExtent, stagingImgCI.format, HandleType::DmaBuf
+        vkCtx,
+        createInfo.outputExtent,
+        stagingImgCI.format,
+        vkCtx.meta.vendor == Vendor::Nvidia ? HandleType::OpaqueFd : HandleType::DmaBuf
     );
 
     vk::QueryPoolCreateInfo poolCI {

--- a/alvr/server_openvr/cpp/platform/linux/ffmpeg_helper.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/ffmpeg_helper.cpp
@@ -18,14 +18,22 @@ extern "C" {
 
 namespace {
 
-// TODO: I don't think this selects the optimal format actually
-// Seeing as we don't want any re-encoding here yet
-// We just want it to make the drm image 1:1
+// Scanning the pixel formats for one whose Vulkan mapping matches returns the
+// wrong answer: ffmpeg lists YUYV422's per-plane format as R8G8B8A8_UNORM, and
+// YUYV422 comes before RGBA in the enum, so a scan from the bottom never
+// reaches the right entry. Map the formats the swap textures actually arrive
+// in. sRGB is included because the renderer substitutes the UNORM view for
+// storage, which happens after this in some paths.
 AVPixelFormat vk_format_to_av_format(vk::Format vk_fmt) {
-    for (int f = AV_PIX_FMT_NONE; f < AV_PIX_FMT_NB; ++f) {
-        auto current_fmt = av_vkfmt_from_pixfmt(AVPixelFormat(f));
-        if (current_fmt and *current_fmt == (VkFormat)vk_fmt)
-            return AVPixelFormat(f);
+    switch (vk_fmt) {
+    case vk::Format::eR8G8B8A8Unorm:
+    case vk::Format::eR8G8B8A8Srgb:
+        return AV_PIX_FMT_RGBA;
+    case vk::Format::eB8G8R8A8Unorm:
+    case vk::Format::eB8G8R8A8Srgb:
+        return AV_PIX_FMT_BGRA;
+    default:
+        break;
     }
 
     throw std::runtime_error("unsupported vulkan pixel format " + std::to_string((VkFormat)vk_fmt));

--- a/alvr/server_openvr/cpp/platform/linux/ffmpeg_helper.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/ffmpeg_helper.cpp
@@ -38,30 +38,25 @@ std::string alvr::AvException::makemsg(const std::string& msg, int averror) {
     return msg + " " + av_msg;
 }
 
-// alvr::VkFrameCtx::VkFrameCtx(VkContext & vkContext, vk::ImageCreateInfo image_create_info)
-// {
-//   AVHWFramesContext *frames_ctx = NULL;
-//   int err = 0;
+alvr::VkFrameCtx::VkFrameCtx(AVBufferRef* vulkanDevice, VkImageCreateInfo imageCI) {
+    if (!(ctx = av_hwframe_ctx_alloc(vulkanDevice))) {
+        throw std::runtime_error("Failed to create vulkan frame context.");
+    }
 
-//   if (!(ctx = av_hwframe_ctx_alloc(vkContext.ctx))) {
-//     throw std::runtime_error("Failed to create vulkan frame context.");
-//   }
-//   frames_ctx = (AVHWFramesContext *)(ctx->data);
-//   frames_ctx->format = AV_PIX_FMT_VULKAN;
-//   frames_ctx->sw_format = vk_format_to_av_format(image_create_info.format);
-//   frames_ctx->width = image_create_info.extent.width;
-//   frames_ctx->height = image_create_info.extent.height;
-//   frames_ctx->initial_pool_size = 0;
-//   if ((err = av_hwframe_ctx_init(ctx)) < 0) {
-//     av_buffer_unref(&ctx);
-//     throw alvr::AvException("Failed to initialize vulkan frame context:", err);
-//   }
-// }
+    auto* framesCtx = (AVHWFramesContext*)ctx->data;
+    framesCtx->format = AV_PIX_FMT_VULKAN;
+    framesCtx->sw_format = vk_format_to_av_format(vk::Format(imageCI.format));
+    framesCtx->width = imageCI.extent.width;
+    framesCtx->height = imageCI.extent.height;
+    // The image is ours already; ffmpeg allocates nothing for this context.
+    framesCtx->initial_pool_size = 0;
 
-// alvr::VkFrameCtx::~VkFrameCtx()
-// {
-//   av_buffer_unref(&ctx);
-// }
+    int err = av_hwframe_ctx_init(ctx);
+    if (err < 0) {
+        av_buffer_unref(&ctx);
+        throw alvr::AvException("Failed to initialize vulkan frame context:", err);
+    }
+}
 
 alvr::VkFrameCtx::~VkFrameCtx() { av_buffer_unref(&ctx); }
 
@@ -78,18 +73,22 @@ alvr::VkFrame::VkFrame(
     device = vk_ctx.dev;
     avformat = vk_format_to_av_format(vk::Format(image_info.format));
 
-    av_drmframe = (AVDRMFrameDescriptor*)malloc(sizeof(AVDRMFrameDescriptor));
-    av_drmframe->nb_objects = 1;
-    av_drmframe->objects[0].fd = drm.fd;
-    av_drmframe->objects[0].size = size;
-    av_drmframe->objects[0].format_modifier = drm.modifier;
-    av_drmframe->nb_layers = 1;
-    av_drmframe->layers[0].format = drm.format;
-    av_drmframe->layers[0].nb_planes = drm.planes;
-    for (uint32_t i = 0; i < drm.planes; ++i) {
-        av_drmframe->layers[0].planes[i].object_index = 0;
-        av_drmframe->layers[0].planes[i].pitch = drm.strides[i];
-        av_drmframe->layers[0].planes[i].offset = drm.offsets[i];
+    // An opaque-fd export leaves drm zeroed, and a descriptor built from that
+    // would claim fd 0 with a zero size.
+    if (drm.planes > 0) {
+        av_drmframe = (AVDRMFrameDescriptor*)malloc(sizeof(AVDRMFrameDescriptor));
+        av_drmframe->nb_objects = 1;
+        av_drmframe->objects[0].fd = drm.fd;
+        av_drmframe->objects[0].size = size;
+        av_drmframe->objects[0].format_modifier = drm.modifier;
+        av_drmframe->nb_layers = 1;
+        av_drmframe->layers[0].format = drm.format;
+        av_drmframe->layers[0].nb_planes = drm.planes;
+        for (uint32_t i = 0; i < drm.planes; ++i) {
+            av_drmframe->layers[0].planes[i].object_index = 0;
+            av_drmframe->layers[0].planes[i].pitch = drm.strides[i];
+            av_drmframe->layers[0].planes[i].offset = drm.offsets[i];
+        }
     }
 
     av_vkframe = av_vk_frame_alloc();

--- a/alvr/server_openvr/cpp/platform/linux/ffmpeg_helper.h
+++ b/alvr/server_openvr/cpp/platform/linux/ffmpeg_helper.h
@@ -92,12 +92,17 @@ public:
     ~HWContext() { av_buffer_unref(&avCtx); }
 };
 
+// vulkanDevice is the ffmpeg Vulkan device, HWContext::avCtx. The frames
+// context takes its own reference, so the HWContext may be a temporary.
 class VkFrameCtx {
 public:
-    VkFrameCtx(VkContext& vkContext, vk::ImageCreateInfo image_create_info);
+    VkFrameCtx(AVBufferRef* vulkanDevice, VkImageCreateInfo imageCI);
     ~VkFrameCtx();
 
-    AVBufferRef* ctx;
+    VkFrameCtx(VkFrameCtx const&) = delete;
+    VkFrameCtx& operator=(VkFrameCtx const&) = delete;
+
+    AVBufferRef* ctx = nullptr;
 };
 
 class VkFrame {


### PR DESCRIPTION
Builds the NvEnc pipeline on nvidia.

- Revives VkFrameCtx, whose constructor was commented out and referenced a
  VkContext field that no longer exists.
- Updates EncodePipelineNvEnc to the current interfaces. It now builds its
  own frames context, and gains the SetParams it was missing, which had left
  it abstract and impossible to instantiate.
- Exports the output image as an opaque fd on nvidia, because ffmpeg's
  Vulkan to CUDA interop cannot import a dma-buf. createOutputImage also
  gated its DRM export on a hardcoded true rather than the handle type.
- Takes the surface format from the output image rather than a hardcoded
  BGR0, which encoded with red and blue swapped on RGBA output.

The pipeline is David Rosca's Vulkan/CUDA interop work from #1911, revived.

AMD and Intel are unchanged. Two lines touch shared code: the DRM export
gate becomes handleType == HandleType::DmaBuf, which is what both already
pass, and the output export is chosen by vendor.