### PR TITLE
reap spawned SteamVR children

### DIFF
--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -7,10 +7,10 @@ use alvr_common::{debug, error, info, warn};
 use sysinfo::Process;
 
 pub fn launch_steamvr_with_steam() {
-    Command::new("steam")
-        .args(["steam://rungameid/250820"])
-        .spawn()
-        .ok();
+    if let Err(e) = super::spawn_and_reap(Command::new("steam").args(["steam://rungameid/250820"]))
+    {
+        error!("Failed to launch SteamVR through Steam: {e}");
+    }
 }
 
 pub fn terminate_process(process: &Process) {

--- a/alvr/dashboard/src/steamvr_launcher/mod.rs
+++ b/alvr/dashboard/src/steamvr_launcher/mod.rs
@@ -25,6 +25,20 @@ use std::{
 use sysinfo::{ProcessesToUpdate, System};
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+// Dropping a Child does not reap it, and a zombie's pid still passes
+// kill(pid, 0), which vrmonitor's single-instance check runs on the last holder
+// of its semaphore. An unreaped child blocks every later launch until this
+// process exits.
+pub(super) fn spawn_and_reap(command: &mut Command) -> Result<()> {
+    let mut child = command.spawn()?;
+
+    thread::spawn(move || {
+        child.wait().ok();
+    });
+
+    Ok(())
+}
 const DRIVER_KEY: &str = "driver_alvr_server";
 const BLOCKED_KEY: &str = "blocked_by_safe_mode";
 
@@ -168,7 +182,7 @@ impl Launcher {
             if start_script.exists() {
                 debug!("Running VR server start script: {}", start_script.display());
 
-                if let Err(e) = Command::new(&start_script).spawn() {
+                if let Err(e) = spawn_and_reap(&mut Command::new(&start_script)) {
                     error!("Failed to run VR server start script: {e}");
                 }
             } else if let Ok(steamvr_bin_dir) =
@@ -182,7 +196,7 @@ impl Launcher {
 
                 debug!("Launching SteamVR from path: {}", steamvr_path.display());
 
-                if let Err(e) = Command::new(&steamvr_path).spawn() {
+                if let Err(e) = spawn_and_reap(&mut Command::new(&steamvr_path)) {
                     error!(
                         "Failed to run SteamVR from automatically detected path {} with error: {e}",
                         steamvr_path.display()


### PR DESCRIPTION
The dashboard spawns SteamVR and drops the Child handle. On Unix that does
not reap, so the process becomes a zombie, and a zombie's pid still passes
kill(pid, 0). vrmonitor treats the holder of its single-instance lock as
alive on that basis, so an unreaped child makes every later launch conclude
SteamVR is already running and exit silently. The button appears dead until
the dashboard itself exits.

Reproducible before the change and fixed after: relaunch failed every time
with the dashboard open, and succeeds now with no zombies left behind.

Every launch path that runs on Unix goes through one helper, so a new one
cannot omit it. The Windows-only Steam launch is untouched, since Windows
has no equivalent zombie state.

Provenance: AI generated, given a quick look over by me, tested on one Linux rig.
