### PR TITLE
fix(server_core): bind the web server to localhost by default

### DIFF
--- a/alvr/server_core/src/web_server.rs
+++ b/alvr/server_core/src/web_server.rs
@@ -18,7 +18,11 @@ use axum::{
     routing,
 };
 use serde_json as json;
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    path::PathBuf,
+    sync::Arc,
+};
 use tokio::{net::TcpListener, sync::broadcast::error::RecvError};
 use tower_http::{
     cors::{self, CorsLayer},
@@ -46,13 +50,21 @@ async fn ensure_preflight(request: Request, next: middleware::Next) -> Response 
 
 pub async fn web_server(connection_context: Arc<ConnectionContext>) -> Result<()> {
     let allow_untrusted_http;
+    let allow_remote_dashboard;
     let web_server_port;
 
     {
         let session_manager = SESSION_MANAGER.read();
         allow_untrusted_http = session_manager.settings().connection.allow_untrusted_http;
+        allow_remote_dashboard = session_manager.settings().connection.allow_remote_dashboard;
         web_server_port = session_manager.settings().connection.web_server_port;
     }
+
+    let bind_address = if allow_remote_dashboard {
+        Ipv4Addr::UNSPECIFIED
+    } else {
+        Ipv4Addr::LOCALHOST
+    };
 
     let mut cors = CorsLayer::new()
         .allow_methods([Method::GET, Method::POST])
@@ -120,7 +132,7 @@ pub async fn web_server(connection_context: Arc<ConnectionContext>) -> Result<()
         .with_state(connection_context);
 
     axum::serve(
-        TcpListener::bind(SocketAddr::new([0, 0, 0, 0].into(), web_server_port))
+        TcpListener::bind(SocketAddr::new(bind_address.into(), web_server_port))
             .await
             .unwrap(),
         router,

--- a/alvr/session/src/settings.rs
+++ b/alvr/session/src/settings.rs
@@ -1432,6 +1432,15 @@ TCP: Slower than UDP, but more stable. Pick this if you experience video or audi
     ))]
     pub allow_untrusted_http: bool,
 
+    #[schema(flag = "steamvr-restart")]
+    #[schema(strings(
+        display_name = "Allow remote dashboard access",
+        help = "Serve the dashboard on all network interfaces instead of localhost only. \
+                Anyone who can reach this machine can then control ALVR, as the web server \
+                has no authentication."
+    ))]
+    pub allow_remote_dashboard: bool,
+
     #[schema(strings(
         help = r#"If the client, server or the network discarded one packet, discard packets until a IDR packet is found."#
     ))]
@@ -2190,6 +2199,7 @@ pub fn session_settings_default() -> SettingsDefault {
             enable_on_connect_script: false,
             enable_on_disconnect_script: false,
             allow_untrusted_http: false,
+            allow_remote_dashboard: false,
             packet_size: 1400,
             statistics_history_size: 256,
         },


### PR DESCRIPTION
The web server bound 0.0.0.0 unconditionally, so the dashboard API was
reachable from the local network whenever a session was running. The
dashboard connects over 127.0.0.1, and the client does not use the web
server at all, so nothing needs it reachable off the machine by default.

Adds a switch under Connection, below allow_untrusted_http since the two are
related. Off binds 127.0.0.1, on binds 0.0.0.0. It carries the
steamvr-restart flag because the web server reads the setting once at
startup and binds once, so without the flag flipping it saves the value and
appears to do nothing.

Tested on Linux with a stream running. Off, the port is on loopback only and
the LAN address is refused. On, the LAN address answers and loopback still
works, so the local dashboard is unaffected either way.
