### PR TITLE
fix(audio): prevent handshake timeouts and duplicate client connections

### DIFF
--- a/alvr/audio/src/lib.rs
+++ b/alvr/audio/src/lib.rs
@@ -86,6 +86,23 @@ fn microphone_pair_from_sink_name(host: &Host, sink_name: &str) -> Result<(Devic
     }
 }
 
+fn virtual_microphone_pair_names(
+    config: &MicrophoneDevicesConfig,
+) -> Option<(&'static str, &'static str)> {
+    match config {
+        MicrophoneDevicesConfig::VAC => Some(("Line 1", "Line 1")),
+        MicrophoneDevicesConfig::VBCable => Some(("CABLE Input", "CABLE Output")),
+        MicrophoneDevicesConfig::VoiceMeeter => Some(("VoiceMeeter Input", "VoiceMeeter Output")),
+        MicrophoneDevicesConfig::VoiceMeeterAux => {
+            Some(("VoiceMeeter Aux Input", "VoiceMeeter Aux Output"))
+        }
+        MicrophoneDevicesConfig::VoiceMeeterVaio3 => {
+            Some(("VoiceMeeter VAIO3 Input", "VoiceMeeter VAIO3 Output"))
+        }
+        MicrophoneDevicesConfig::Automatic | MicrophoneDevicesConfig::Custom { .. } => None,
+    }
+}
+
 #[allow(dead_code)]
 pub struct AudioDevice {
     inner: Device,
@@ -189,6 +206,46 @@ pub fn is_same_device(device1: &AudioDevice, device2: &AudioDevice) -> bool {
         name1 == name2 && device1.is_output == device2.is_output
     } else {
         false
+    }
+}
+
+/// Check the configured virtual microphone endpoint names without enumerating audio devices.
+///
+/// Device enumeration can take multiple seconds on Windows. This helper is used during connection
+/// setup so enabling game audio and microphone together cannot delay the handshake response.
+pub fn is_virtual_microphone_device(
+    device: &AudioDevice,
+    config: &MicrophoneDevicesConfig,
+) -> bool {
+    let Some((sink_name, source_name)) = virtual_microphone_pair_names(config) else {
+        return false;
+    };
+
+    device
+        .inner
+        .name()
+        .map(|name| name.contains(sink_name) || name.contains(source_name))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn virtual_microphone_endpoint_names_match_search_names() {
+        assert_eq!(
+            virtual_microphone_pair_names(&MicrophoneDevicesConfig::VAC),
+            Some(("Line 1", "Line 1"))
+        );
+        assert_eq!(
+            virtual_microphone_pair_names(&MicrophoneDevicesConfig::VBCable),
+            Some(("CABLE Input", "CABLE Output"))
+        );
+        assert_eq!(
+            virtual_microphone_pair_names(&MicrophoneDevicesConfig::Automatic),
+            None
+        );
     }
 }
 

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -737,10 +737,6 @@ fn connection_pipeline(
             let game_audio_device =
                 alvr_audio::AudioDevice::new_output(game_audio_config.device.as_ref()).to_con()?;
             if let Switch::Enabled(microphone_config) = &initial_settings.audio.microphone {
-                let (sink, source) = alvr_audio::AudioDevice::new_virtual_microphone_pair(
-                    microphone_config.devices.clone(),
-                )
-                .to_con()?;
                 if matches!(
                     microphone_config.devices,
                     alvr_session::MicrophoneDevicesConfig::VAC
@@ -748,9 +744,10 @@ fn connection_pipeline(
                 ) {
                     // VoiceMeeter and Custom devices may have arbitrary internal routing.
                     // Therefore, we cannot detect the loopback issue without knowing the routing.
-                    if alvr_audio::is_same_device(&game_audio_device, &sink)
-                        || alvr_audio::is_same_device(&game_audio_device, &source)
-                    {
+                    if alvr_audio::is_virtual_microphone_device(
+                        &game_audio_device,
+                        &microphone_config.devices,
+                    ) {
                         con_bail!("Game audio and microphone cannot point to the same device!");
                     }
                 }
@@ -975,29 +972,37 @@ fn connection_pipeline(
         thread::spawn(|| ())
     };
 
-    let microphone_thread =
-        if let Switch::Enabled(config) = initial_settings.audio.microphone.clone() {
+    let microphone_thread = if let Switch::Enabled(config) =
+        initial_settings.audio.microphone.clone()
+    {
+        let client_hostname = client_hostname.clone();
+        #[cfg(not(target_os = "linux"))]
+        let ctx = Arc::clone(&ctx);
+        thread::spawn(move || {
             #[cfg(not(target_os = "linux"))]
-            #[allow(unused_variables)]
-            let (sink, source) =
-                alvr_audio::AudioDevice::new_virtual_microphone_pair(config.devices).to_con()?;
+            {
+                let (sink, source) =
+                    match alvr_audio::AudioDevice::new_virtual_microphone_pair(config.devices) {
+                        Ok(pair) => pair,
+                        Err(e) => {
+                            error!("Microphone device initialization failed: {e:?}");
+                            return;
+                        }
+                    };
 
-            #[cfg(windows)]
-            if let Ok(id) = alvr_audio::get_windows_device_id(&source) {
-                ctx.events_sender
-                    .send(ServerCoreEvent::SetOpenvrProperty {
-                        device_id: *alvr_common::HEAD_ID,
-                        prop: alvr_session::OpenvrProperty {
-                            key: alvr_session::OpenvrPropKey::AudioDefaultRecordingDeviceIdString,
-                            value: id,
-                        },
-                    })
-                    .ok();
-            }
+                #[cfg(windows)]
+                if let Ok(id) = alvr_audio::get_windows_device_id(&source) {
+                    ctx.events_sender
+                            .send(ServerCoreEvent::SetOpenvrProperty {
+                                device_id: *alvr_common::HEAD_ID,
+                                prop: alvr_session::OpenvrProperty {
+                                    key: alvr_session::OpenvrPropKey::AudioDefaultRecordingDeviceIdString,
+                                    value: id,
+                                },
+                            })
+                            .ok();
+                }
 
-            let client_hostname = client_hostname.clone();
-            thread::spawn(move || {
-                #[cfg(not(target_os = "linux"))]
                 alvr_common::show_err(alvr_audio::play_audio_loop(
                     {
                         let client_hostname = client_hostname.clone();
@@ -1009,21 +1014,22 @@ fn connection_pipeline(
                     config.buffering,
                     &mut microphone_receiver,
                 ));
-                #[cfg(target_os = "linux")]
-                alvr_common::show_err(alvr_audio::linux::play_microphone_loop_pipewire(
-                    {
-                        let client_hostname = client_hostname.clone();
-                        move || is_streaming(&client_hostname)
-                    },
-                    1,
-                    streaming_caps.microphone_sample_rate,
-                    config.buffering,
-                    &mut microphone_receiver,
-                ));
-            })
-        } else {
-            thread::spawn(|| ())
-        };
+            }
+            #[cfg(target_os = "linux")]
+            alvr_common::show_err(alvr_audio::linux::play_microphone_loop_pipewire(
+                {
+                    let client_hostname = client_hostname.clone();
+                    move || is_streaming(&client_hostname)
+                },
+                1,
+                streaming_caps.microphone_sample_rate,
+                config.buffering,
+                &mut microphone_receiver,
+            ));
+        })
+    } else {
+        thread::spawn(|| ())
+    };
 
     *ctx.tracking_manager.write() =
         TrackingManager::new(initial_settings.connection.statistics_history_size);

--- a/alvr/server_core/src/connection.rs
+++ b/alvr/server_core/src/connection.rs
@@ -257,6 +257,20 @@ pub fn handshake_loop(ctx: Arc<ConnectionContext>, lifecycle_state: Arc<RwLock<L
     let mut wired_connection = None;
 
     while *lifecycle_state.read() != LifecycleState::ShuttingDown {
+        // Only one client can stream at a time. In particular, do not also try the wireless
+        // discovery entry for a headset that is already connecting or streaming over USB. Besides
+        // producing misleading timeout errors, the redundant control connection can make the
+        // headset appear to disconnect and reconnect.
+        if SESSION_MANAGER
+            .read()
+            .client_list()
+            .values()
+            .any(|info| info.connection_state != ConnectionState::Disconnected)
+        {
+            thread::sleep(RETRY_CONNECT_MIN_INTERVAL);
+            continue;
+        }
+
         dbg_connection!("handshake_loop: Try connect to wired device");
 
         let mut wired_client_ips = HashMap::new();


### PR DESCRIPTION
## Summary
- avoid synchronous virtual microphone endpoint enumeration before the stream handshake completes
- initialize the virtual microphone pair inside the microphone worker instead
- skip manual/discovery connection attempts while another client is connecting or streaming

## Problem
With headset speaker and headset microphone enabled together on Windows, enumerating the output device and both virtual microphone endpoints can delay the stream configuration response long enough for the Quest client to hit its handshake timeout (`os error 11`).

A wired Quest can also appear as a trusted wireless entry. The handshake loop may start a redundant wireless control connection to that entry while `client.wired` is already connecting or streaming, producing `Could not initiate connection ... connection timed out` and apparent disconnect/reconnect behavior.

## Testing
- `cargo test -p alvr_audio`
- `cargo check -p alvr_server_core`
- `cargo xtask build-streamer --release --platform windows --ci`
- Quest 3 client v20.14.0 against streamer v20.14.1
- headset speaker: System Default; headset microphone: VB Cable
- verified wired streaming, controlled client restart recovery, and post-reconnect stability
- no repeated `handshake os error 11` or `1802.client: connection timed out` after the fix