### PR TITLE
linux direct: move render and encode onto a worker thread

### DIFF
--- a/alvr/server_openvr/cpp/platform/linux/OvrDirectModeComponent.cpp
+++ b/alvr/server_openvr/cpp/platform/linux/OvrDirectModeComponent.cpp
@@ -13,9 +13,93 @@
 #include "alvr_server/Logger.h"
 #include <vector>
 
+// Multiples of the frame interval. A job older than this when the worker picks
+// it up is from a stall, and the swap texture sets are only three deep, so the
+// slot is close to its next writer.
+constexpr double JobAgeLimitFrames = 1.5;
+
+// The negotiated refresh rate expressed as a frame period.
+static std::chrono::nanoseconds frameInterval() {
+    return std::chrono::nanoseconds((int64_t)(1e9 / Settings_Instance()->m_refreshRate));
+}
+
 OvrDirectModeComponent::OvrDirectModeComponent(std::shared_ptr<PoseHistory> poseHistory)
     : m_poseHistory(poseHistory)
-    , m_submitLayer(0) { }
+    , m_submitLayer(0) {
+    m_encodeWorker = std::thread(&OvrDirectModeComponent::EncodeWorkerLoop, this);
+}
+
+OvrDirectModeComponent::~OvrDirectModeComponent() {
+    {
+        std::lock_guard<std::mutex> lock(m_jobMutex);
+        m_workerExit = true;
+        m_jobPending = false;
+    }
+    m_jobCv.notify_one();
+    if (m_encodeWorker.joinable()) {
+        m_encodeWorker.join();
+    }
+}
+
+void OvrDirectModeComponent::DrainPendingJob() {
+    std::lock_guard<std::mutex> lock(m_jobMutex);
+    m_jobPending = false;
+}
+
+void OvrDirectModeComponent::EncodeWorkerLoop() {
+    while (true) {
+        FrameJob job;
+        {
+            std::unique_lock<std::mutex> lock(m_jobMutex);
+            m_jobCv.wait(lock, [this] { return m_jobPending || m_workerExit; });
+            if (m_workerExit) {
+                break;
+            }
+            job = m_job;
+            m_jobPending = false;
+        }
+
+        auto const ageLimit = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            frameInterval() * JobAgeLimitFrames
+        );
+        if (std::chrono::steady_clock::now() - job.enqueueTime > ageLimit) {
+            continue;
+        }
+
+        try {
+            std::lock_guard<std::mutex> encLock(m_encMutex);
+
+            if (job.generation != m_encGeneration) {
+                continue;
+            }
+
+            enc.present(job.leftIdx, job.rightIdx, job.targetTimestampNs);
+        } catch (std::exception const& e) {
+            // An exception escaping a thread's start function is
+            // std::terminate, which takes vrserver with it. Same recovery as
+            // the compositor-thread paths: log, tear the encoder down, go
+            // idle until the next client connect.
+            Error("Encode worker: %s. Tearing down encoder and going idle.\n", e.what());
+            std::lock_guard<std::mutex> encLock(m_encMutex);
+            // The try block's lock released when the exception left it, so a
+            // rebuild may have swapped the encoder in between. A moved
+            // generation means this failure belongs to an encoder that no
+            // longer exists; leave the new one alone.
+            if (job.generation != m_encGeneration) {
+                continue;
+            }
+            m_encGeneration++;
+            try {
+                enc.shutdown();
+            } catch (std::exception const& e2) {
+                // Teardown of already-broken state must not become the
+                // std::terminate this handler exists to prevent.
+                Error("Encode worker: teardown also failed: %s\n", e2.what());
+            }
+            m_encoderState = EncoderState::Idle;
+        }
+    }
+}
 
 void OvrDirectModeComponent::CreateSwapTextureSet(
     uint32_t unPid,
@@ -208,17 +292,25 @@ void OvrDirectModeComponent::Present(vr::SharedTextureHandle_t syncTexture) {
     m_submitLayer = 0;
 
     switch (m_encoderState.load()) {
-    case EncoderState::RebuildRequested:
+    case EncoderState::RebuildRequested: {
         Info("Rebuilding encoder from negotiated settings\n");
+        DrainPendingJob();
+        std::lock_guard<std::mutex> encLock(m_encMutex);
+        m_encGeneration++;
         enc.shutdown();
         layer0Texts.fill(0);
         m_encoderState = EncoderState::Streaming;
         break;
-    case EncoderState::ShutdownRequested:
+    }
+    case EncoderState::ShutdownRequested: {
+        DrainPendingJob();
+        std::lock_guard<std::mutex> encLock(m_encMutex);
+        m_encGeneration++;
         enc.shutdown();
         layer0Texts.fill(0);
         m_encoderState = EncoderState::Idle;
         return;
+    }
     // Before a client connects there are no negotiated settings, so building
     // an encoder here would use wrong defaults and fail noisily. Do nothing
     // until streaming starts.
@@ -298,6 +390,10 @@ void OvrDirectModeComponent::Present(vr::SharedTextureHandle_t syncTexture) {
 
         // Renderer and encoder setup can throw (Vulkan import, VAAPI). An
         // exception escaping Present kills vrserver, so log and stay idle.
+        DrainPendingJob();
+        std::lock_guard<std::mutex> encLock(m_encMutex);
+        m_encGeneration++;
+
         try {
             enc.createImages(rendererCI);
             enc.initEncoding();
@@ -317,7 +413,23 @@ void OvrDirectModeComponent::Present(vr::SharedTextureHandle_t syncTexture) {
 
     // TODO: Merge layers or something
 
-    enc.present(leftIdx.value(), rightIdx.value(), m_targetTimestampNs);
+    FrameJob job {};
+    job.leftIdx = leftIdx.value();
+    job.rightIdx = rightIdx.value();
+    job.targetTimestampNs = m_targetTimestampNs;
+    job.generation = m_encGeneration;
+    job.enqueueTime = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(m_jobMutex);
+        if (m_workerExit) {
+            // Teardown already drained the mailbox; do not repopulate it.
+            return;
+        }
+        m_job = job;
+        m_jobPending = true;
+    }
+    m_jobCv.notify_one();
 }
 
 void OvrDirectModeComponent::PostPresent(const Throttling_t* pThrottling) {  

--- a/alvr/server_openvr/cpp/platform/linux/OvrDirectModeComponent.h
+++ b/alvr/server_openvr/cpp/platform/linux/OvrDirectModeComponent.h
@@ -7,7 +7,10 @@
 
 #include <map>
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <mutex>
+#include <thread>
 
 #include <vulkan/vulkan.h>
 
@@ -18,6 +21,7 @@ public:
     OvrDirectModeComponent(
         /* std::shared_ptr<Renderer> pVKRender,  */ std::shared_ptr<PoseHistory> poseHistory
     );
+    ~OvrDirectModeComponent();
 
     void RequestIdr() { enc.requestIdr(); }
 
@@ -95,4 +99,37 @@ private:
     std::atomic<EncoderState> m_encoderState { EncoderState::Idle };
 
     std::mutex m_presentMutex;
+
+    // Single-slot latest-wins mailbox: at steady state the worker drains
+    // faster than frames arrive, and if it falls behind, the newest frame
+    // replaces the stale pending one.
+    struct FrameJob {
+        uint32_t leftIdx;
+        uint32_t rightIdx;
+        uint64_t targetTimestampNs;
+        // Encoder-state generation this job was built against. The worker
+        // discards the job if the generation moved (rebuild, shutdown, set
+        // switch) between enqueue and processing.
+        uint64_t generation;
+        std::chrono::steady_clock::time_point enqueueTime;
+    };
+    void EncodeWorkerLoop();
+    // Drop a pending job. Call before any path that touches the encoder from
+    // the compositor thread.
+    void DrainPendingJob();
+
+    std::thread m_encodeWorker;
+    std::mutex m_jobMutex;
+    std::condition_variable m_jobCv;
+    FrameJob m_job {};
+    bool m_jobPending = false;
+    bool m_workerExit = false;
+    // Serializes encoder access: the worker's per-frame enc.present against
+    // the compositor thread's rebuild and shutdown paths. Never held together
+    // with m_jobMutex.
+    std::mutex m_encMutex;
+    // Incremented under m_encMutex by every compositor-thread path that
+    // mutates encoder state. A job whose generation is stale gets dropped
+    // instead of presenting old indices against rebuilt state.
+    uint64_t m_encGeneration = 0;
 };


### PR DESCRIPTION
linux direct ran render, encode, output blocking, and send inline in Present, on SteamVR's compositor frame loop. Every millisecond spent there delays the compositor directly. This moves the chain to a worker thread behind a single-slot latest-wins mailbox, so Present stamps, enqueues, and returns.

Frame drops are deliberate and bounded: when the worker falls behind, the newest submission replaces the pending one, and a job older than 1.5 frame intervals at pickup is dropped because the three-deep swap texture sets put a stale slot close to its next writer. A generation counter keeps jobs from presenting against an encoder that was rebuilt after they were enqueued, and the worker's exception recovery tears the encoder down and goes idle instead of taking vrserver with it.
