### PR TITLE
fix(dashboard): order imports the way edition 2024 rustfmt wants

### DIFF
--- a/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
+++ b/alvr/dashboard/src/steamvr_launcher/linux_steamvr.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::Command;
 
 use alvr_common::{
-    anyhow::{bail, Result},
+    anyhow::{Result, bail},
     debug, error, info, warn,
 };
 use sysinfo::Process;


### PR DESCRIPTION
cargo xtask check-format fails on this branch before it reaches anything else: edition 2024 rustfmt orders Result before bail in this import. One line, and the format gate passes for every future PR against the branch.
