### PR TITLE
ci: pin the Rust toolchain to 1.97.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,8 +79,8 @@ jobs:
           submodules: true
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-linux-android
+
+      - run: rustup target add aarch64-linux-android
 
       - uses: Swatinem/rust-cache@v2
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.97.1"
+profile = "default"


### PR DESCRIPTION
Every workflow installed `dtolnay/rust-toolchain@stable`, so each new stable release (1.98.0 on the 18th this time) started failing clippy on every open PR over lints nobody had written against, and the fix landed in whichever PR merged first.

This adds `rust-toolchain.toml` at the root with `channel = "1.97.1"`. rustup resolves the toolchain from that file ahead of the default the action sets, so every `cargo` call in CI and on contributor machines runs 1.97.1 with no version in the workflows. `profile = "default"` is there because the runner images install rustup with a minimal profile and auto-install would inherit it, leaving 1.97.1 without clippy and rustfmt. check-android adds the android target with a plain `rustup target add`, since the action's `targets:` input lands on stable rather than the toolchain the toml selects; the other android jobs add it through xtask.

`rust-version = "1.92"` and the MSRV check are untouched; `cargo xtask check-msrv` installs and runs its own 1.92 through cargo-msrv.

Bumping becomes a one-line change in a PR that fixes the new lints in the same diff. The `@stable` action steps now install a toolchain rustup bypasses and can be removed in a follow-up.

Pinned at 1.97.1 so every open PR goes green today; a follow-up bumps to 1.98.0 with the lint fixes in one place. Say the word and I fold the bump into this PR instead.
