### PR TITLE
feat(packets): parse index segments in settings paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ cmake-build-debug/
 
 *.jks
 settings.local.json
+
+# Claude Code
+CLAUDE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ version = "21.0.0-dev12"
 dependencies = [
  "alvr_common",
  "alvr_session",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/alvr/dashboard/src/dashboard/components/new_version_popup.rs
+++ b/alvr/dashboard/src/dashboard/components/new_version_popup.rs
@@ -94,7 +94,8 @@ impl NewVersionPopup {
                     ServerRequest::SetSessionValues(vec![PathValuePair {
                         path: alvr_packets::parse_path(
                             "session_settings.extra.new_version_popup.content.hide_while_version",
-                        ),
+                        )
+                        .unwrap(),
                         value: serde_json::Value::String(self.version.clone()),
                     }]),
                 ))

--- a/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
+++ b/alvr/dashboard/src/dashboard/components/settings_controls/presets/higher_order_choice.rs
@@ -1,5 +1,6 @@
 use super::schema::{HigherOrderChoiceSchema, PresetModifierOperation};
 use crate::dashboard::components::{self, NestingInfo, SettingControl};
+use alvr_common::debug;
 use alvr_packets::{PathSegment, PathValuePair};
 use eframe::egui::Ui;
 use serde_json as json;
@@ -26,7 +27,10 @@ impl Control {
                         .iter()
                         .map(|modifier| match &modifier.operation {
                             PresetModifierOperation::Assign(value) => PathValuePair {
-                                path: alvr_packets::parse_path(&modifier.target_path),
+                                path: alvr_common::show_err(alvr_packets::parse_path(
+                                    &modifier.target_path,
+                                ))
+                                .unwrap_or_default(),
                                 value: value.clone(),
                             },
                         })
@@ -94,24 +98,23 @@ impl Control {
             for desc in descs {
                 let mut session_ref = session_setting_json;
 
-                // Note: the first path segment is always "settings_schema". Skip that.
-                for segment in &desc.path[1..] {
-                    session_ref = match segment {
-                        PathSegment::Name(name) => {
-                            if let Some(name) = session_ref.get(name) {
-                                name
-                            } else {
-                                continue 'outer;
-                            }
-                        }
-                        PathSegment::Index(index) => {
-                            if let Some(index) = session_ref.get(index) {
-                                index
-                            } else {
-                                continue 'outer;
-                            }
-                        }
+                // Note: the first path segment should be "settings_schema". Skip that.
+                let Some(segments) = desc.path.get(1..) else {
+                    continue 'outer;
+                };
+                for segment in segments {
+                    let next = match segment {
+                        PathSegment::Name(name) => session_ref.get(name),
+                        PathSegment::Index(index) => session_ref.get(index),
                     };
+                    let Some(next) = next else {
+                        debug!(
+                            "Preset modifier targets \"{}\", which is not in the current session",
+                            alvr_packets::path_to_string(&desc.path)
+                        );
+                        continue 'outer;
+                    };
+                    session_ref = next;
                 }
 
                 if !components::json_values_eq(session_ref, &desc.value) {

--- a/alvr/dashboard/src/dashboard/mod.rs
+++ b/alvr/dashboard/src/dashboard/mod.rs
@@ -221,7 +221,8 @@ impl eframe::App for Dashboard {
                                     PathValuePair {
                                         path: alvr_packets::parse_path(
                                             "session_settings.extra.open_setup_wizard",
-                                        ),
+                                        )
+                                        .unwrap(),
                                         value: serde_json::Value::Bool(false),
                                     },
                                 ]))

--- a/alvr/packets/Cargo.toml
+++ b/alvr/packets/Cargo.toml
@@ -10,5 +10,6 @@ license.workspace = true
 alvr_common.workspace = true
 alvr_session.workspace = true
 
+regex = { version = "1", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/alvr/packets/src/lib.rs
+++ b/alvr/packets/src/lib.rs
@@ -1,6 +1,6 @@
 use alvr_common::{
     BodySkeleton, ConnectionState, DeviceMotion, LogSeverity, Pose, ViewParams,
-    anyhow::Result,
+    anyhow::{Error, Result},
     glam::{Quat, UVec2, Vec2},
     semver::Version,
 };
@@ -8,12 +8,14 @@ use alvr_session::{
     ClientsidePostProcessingConfig, CodecType, PassthroughMode, PerformanceLevel, SessionConfig,
     Settings,
 };
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 use std::{
     collections::HashSet,
-    fmt::{self, Debug},
+    fmt::{self, Debug, Write as _},
     net::IpAddr,
+    sync::LazyLock,
     time::Duration,
 };
 
@@ -256,12 +258,18 @@ pub enum PathSegment {
     Index(usize),
 }
 
-impl Debug for PathSegment {
+impl fmt::Display for PathSegment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PathSegment::Name(name) => write!(f, "{name}"),
             PathSegment::Index(index) => write!(f, "[{index}]"),
         }
+    }
+}
+
+impl Debug for PathSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self}")
     }
 }
 
@@ -283,9 +291,65 @@ impl From<usize> for PathSegment {
     }
 }
 
-// todo: support indices
-pub fn parse_path(path: &str) -> Vec<PathSegment> {
-    path.split('.').map(|s| s.into()).collect()
+// A name segment + a (possibly empty) list of `[index]` segments.
+static COMPOUND_SEGMENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^([A-Za-z0-9_]+)((?:\[[0-9]+\])*)").unwrap());
+
+/// Parses a settings path like `"video.foveated_encoding.enable"` or
+/// `"headset.controllers.content.gestures[2].joystick_range"` into name/index segments.
+pub fn parse_path(path: &str) -> Result<Vec<PathSegment>> {
+    fn parse_error(path: &str, rest: &str, expected: &str) -> Error {
+        let found = rest
+            .chars()
+            .next()
+            .map_or_else(|| "end of input".to_owned(), |c| format!("`{c}`"));
+        Error::msg(format!(
+            "invalid path \"{path}\" at column {}: expected {expected}, found {found}",
+            path.len() - rest.len() + 1,
+        ))
+    }
+
+    let mut segments = Vec::new();
+    let mut rest = path;
+
+    loop {
+        let Some(caps) = COMPOUND_SEGMENT.captures(rest) else {
+            return Err(parse_error(path, rest, "a name `[A-Za-z0-9_]+`"));
+        };
+        segments.push(PathSegment::Name(caps[1].to_owned()));
+        for index in caps[2].split(['[', ']']).filter(|s| !s.is_empty()) {
+            match index.parse() {
+                Ok(index) => segments.push(PathSegment::Index(index)),
+                Err(_) => {
+                    let at = &rest[caps[1].len()..];
+                    return Err(parse_error(
+                        path,
+                        at,
+                        &format!("index `{index}` to fit in a usize"),
+                    ));
+                }
+            }
+        }
+        rest = &rest[caps[0].len()..];
+
+        if rest.is_empty() {
+            return Ok(segments);
+        }
+        rest = rest
+            .strip_prefix('.')
+            .ok_or_else(|| parse_error(path, rest, "`.` or end of input"))?;
+    }
+}
+
+pub fn path_to_string(path: &[PathSegment]) -> String {
+    let mut string = String::new();
+    for (i, segment) in path.iter().enumerate() {
+        if i != 0 && matches!(segment, PathSegment::Name(_)) {
+            string.push('.');
+        }
+        let _ = write!(string, "{segment}");
+    }
+    string
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -349,5 +413,108 @@ impl RealTimeConfig {
             gpu_performance_level: settings.headset.performance_level.clone().gpu.into_option(),
             ext_str: String::new(), // No extensions for now
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PathSegment, parse_path, path_to_string};
+
+    fn debug_path(path: &str) -> String {
+        format!("{:?}", parse_path(path).unwrap())
+    }
+
+    #[test]
+    fn parses_names_only() {
+        assert_eq!(debug_path("my.element.content"), "[my, element, content]");
+    }
+
+    #[test]
+    fn parses_index_between_names() {
+        let segments = parse_path("my.element[1].content").unwrap();
+        assert!(matches!(
+            segments.as_slice(),
+            [
+                PathSegment::Name(a),
+                PathSegment::Name(b),
+                PathSegment::Index(1),
+                PathSegment::Name(c),
+            ] if a == "my" && b == "element" && c == "content"
+        ));
+    }
+
+    #[test]
+    fn parses_chained_indices() {
+        assert_eq!(debug_path("matrix[1][2]"), "[matrix, [1], [2]]");
+        assert_eq!(debug_path("a[0][12][345]"), "[a, [0], [12], [345]]");
+    }
+
+    #[test]
+    fn accepts_underscores_and_digits_in_names() {
+        assert_eq!(debug_path("_priv.x1[0]._2y"), "[_priv, x1, [0], _2y]");
+    }
+
+    #[test]
+    fn rejects_malformed_paths() {
+        for path in [
+            "",
+            ".foo",
+            "foo.",
+            "foo..bar",
+            ".[1]",
+            "foo.[1]",
+            "[0].foo",
+            "foo[]",
+            "foo[",
+            "foo[1",
+            "foo[1]bar",
+            "foo[-1]",
+            "foo[1.5]",
+            "foo[key]",
+            "foo-bar",
+            "foo bar",
+            "foo.bar!",
+            "foé",
+        ] {
+            assert!(
+                parse_path(path).is_err(),
+                "expected \"{path}\" to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_index_overflow() {
+        assert!(parse_path("foo[99999999999999999999999999]").is_err());
+    }
+
+    #[test]
+    fn path_to_string_round_trips() {
+        for path in [
+            "a",
+            "a.b.c",
+            "a[0]",
+            "a[1][2].b",
+            "video.foveated_encoding.strength",
+            "headset.controllers.content.gestures[2].joystick_range",
+        ] {
+            assert_eq!(path_to_string(&parse_path(path).unwrap()), path);
+        }
+    }
+
+    #[test]
+    fn error_points_at_the_failing_column() {
+        assert_eq!(
+            parse_path("foo..bar").unwrap_err().to_string(),
+            "invalid path \"foo..bar\" at column 5: expected a name `[A-Za-z0-9_]+`, found `.`",
+        );
+        assert_eq!(
+            parse_path("foo[1]x").unwrap_err().to_string(),
+            "invalid path \"foo[1]x\" at column 7: expected `.` or end of input, found `x`",
+        );
+        assert_eq!(
+            parse_path("foo[]").unwrap_err().to_string(),
+            "invalid path \"foo[]\" at column 4: expected `.` or end of input, found `[`",
+        );
     }
 }

--- a/alvr/server_core/src/web_server.rs
+++ b/alvr/server_core/src/web_server.rs
@@ -180,7 +180,9 @@ async fn update_session(Json(config): Json<SessionConfig>) {
 }
 
 async fn set_session_values(Json(descs): Json<Vec<PathValuePair>>) {
-    SESSION_MANAGER.write().set_session_values(descs).ok();
+    if let Err(e) = SESSION_MANAGER.write().set_session_values(descs) {
+        error!("Failed to set session values: {e}");
+    }
 }
 
 async fn update_client_connections(

--- a/alvr/server_io/src/lib.rs
+++ b/alvr/server_io/src/lib.rs
@@ -159,21 +159,16 @@ impl ServerSessionManager {
         for desc in descs {
             let mut session_ref = &mut session_json;
             for segment in &desc.path {
-                session_ref = match segment {
-                    PathSegment::Name(name) => {
-                        if let Some(name) = session_ref.get_mut(name) {
-                            name
-                        } else {
-                            bail!("From path {:?}: segment \"{name}\" not found", desc.path);
-                        }
-                    }
-                    PathSegment::Index(index) => {
-                        if let Some(index) = session_ref.get_mut(index) {
-                            index
-                        } else {
-                            bail!("From path {:?}: segment [{index}] not found", desc.path);
-                        }
-                    }
+                let next = match segment {
+                    PathSegment::Name(name) => session_ref.get_mut(name),
+                    PathSegment::Index(index) => session_ref.get_mut(index),
+                };
+                session_ref = match next {
+                    Some(value) => value,
+                    None => bail!(
+                        "path \"{}\": segment {segment} not found",
+                        alvr_packets::path_to_string(&desc.path)
+                    ),
                 };
             }
             *session_ref = desc.value.clone();


### PR DESCRIPTION
<!--
CONTRIBUTING RULES (see CONTRIBUTING.md for the full rules):
- Be respectful to other people in this PR and its discussion.
- Respect our AI policy described in CONTRIBUTING.md.
- Try to adhere to the coding style described in CONTRIBUTING.md.
- Keep this PR as small as reasonably possible; if merged it should leave the project in a working condition.
- Opening a PR does not guarantee it will be merged. It could be delayed or dismissed depending on the current state and direction of the project, and PRs that show no human effort may be ignored and closed.
- If you contributed a reasonably sized PR, you can request the contributor role on our Discord server.
-->

## Summary
* Implement proper index parsing for `parse_path()`
* Make `parse_path()` fallible
* Add tests for `parse_path()`
* Add `path_to_string()` and some usages for it

I tried my best not to succumb to feature creep lol

- [x] This PR respects our AI policy: I completely understand and "own" the coding decisions made, and can discuss them without relying on AI copy-pasted responses.
- [x] This PR's description contains a human-written summary of the content of the code.
- [x] Testing: Dashboard on macOS

